### PR TITLE
[21.02] luci-app-adblock: sync with adblock 4.1.0

### DIFF
--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017-2020 Dirk Brenken (dev@brenken.org)
+# Copyright 2017-2021 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the Apache License, Version 2.0
 
 include $(TOPDIR)/rules.mk

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/blacklist.js
@@ -8,7 +8,7 @@ return view.extend({
 		return L.resolveDefault(fs.read_direct('/etc/adblock/adblock.blacklist'), '');
 	},
 	handleSave: function(ev) {
-		var value = ((document.querySelector('textarea').value || '').trim().toLowerCase().replace(/\r\n/g, '\n').replace(/[^a-z0-9\.\-\#\n]/g, '')) + '\n';
+		var value = ((document.querySelector('textarea').value || '').trim().toLowerCase().replace(/\r\n/g, '\n')) + '\n';
 		return fs.write('/etc/adblock/adblock.blacklist', value)
 			.then(function(rc) {
 				document.querySelector('textarea').value = value;

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
@@ -17,7 +17,7 @@ function handleAction(ev) {
 			]),
 			E('div', { 'class': 'right' }, [
 				E('button', {
-					'class': 'btn',
+					'class': 'btn cbi-button',
 					'click': L.hideModal
 				}, _('Cancel')),
 				' ',
@@ -52,7 +52,7 @@ function handleAction(ev) {
 			]),
 			E('div', { 'class': 'right' }, [
 				E('button', {
-					'class': 'btn',
+					'class': 'btn cbi-button',
 					'click': L.hideModal
 				}, _('Cancel')),
 				' ',
@@ -104,7 +104,7 @@ function handleAction(ev) {
 			]),
 			E('div', { 'class': 'right' }, [
 				E('button', {
-					'class': 'btn',
+					'class': 'btn cbi-button',
 					'click': L.hideModal
 				}, _('Cancel')),
 				' ',
@@ -158,7 +158,7 @@ function handleAction(ev) {
 			]),
 			E('div', { 'class': 'right' }, [
 				E('button', {
-					'class': 'btn',
+					'class': 'btn cbi-button',
 					'click': L.hideModal
 				}, _('Cancel')),
 				' ',
@@ -195,7 +195,7 @@ return view.extend({
 
 	render: function(dnsreport) {
 		if (!dnsreport) {
-			dnsreport = '{ "data": "" }';
+			dnsreport = '{}';
 		};
 		var content;
 		content = JSON.parse(dnsreport);
@@ -213,32 +213,28 @@ return view.extend({
 		]);
 
 		var max = 0;
-		if (content.data.top_clients && content.data.top_domains && content.data.top_blocked) {
-			max = Math.max(content.data.top_clients.length, content.data.top_domains.length, content.data.top_blocked.length);
+		if (content.top_clients && content.top_domains && content.top_blocked) {
+			max = Math.max(content.top_clients.length, content.top_domains.length, content.top_blocked.length);
 		}
 		for (var i = 0; i < max; i++) {
 			var a_cnt = '\xa0', a_addr = '\xa0', b_cnt = '\xa0', b_addr = '\xa0', c_cnt = '\xa0', c_addr = '\xa0';
-			if (content.data.top_clients[i]) {
-				a_cnt = content.data.top_clients[i].count;
+			if (content.top_clients[i]) {
+				a_cnt = content.top_clients[i].count;
 			}
-			if (content.data.top_clients[i]) {
-				a_addr = content.data.top_clients[i].address;
+			if (content.top_clients[i]) {
+				a_addr = content.top_clients[i].address;
 			}
-			if (content.data.top_domains[i]) {
-				b_cnt = content.data.top_domains[i].count;
+			if (content.top_domains[i]) {
+				b_cnt = content.top_domains[i].count;
 			}
-			if (content.data.top_domains[i]) {
-				//[!CDATA[
-					b_addr = '<a href="https://duckduckgo.com/?q=' + encodeURIComponent(content.data.top_domains[i].address) + '&amp;k1=-1&amp;km=l&amp;kh=1" target="_blank" title="Search this domain">' + content.data.top_domains[i].address + '</a>';
-				//]]>
+			if (content.top_domains[i]) {
+				b_addr = '<a href="https://duckduckgo.com/?q=' + encodeURIComponent(content.top_domains[i].address) + '&amp;k1=-1&amp;km=l&amp;kh=1" target="_blank" rel="noreferrer noopener" title="Domain Lookup">' + content.top_domains[i].address + '</a>';
 			}
-			if (content.data.top_blocked[i]) {
-				c_cnt = content.data.top_blocked[i].count;
+			if (content.top_blocked[i]) {
+				c_cnt = content.top_blocked[i].count;
 			}
-			if (content.data.top_blocked[i]) {
-				//[!CDATA[
-					c_addr = '<a href="https://duckduckgo.com/?q=' + encodeURIComponent(content.data.top_blocked[i].address) + '&amp;k1=-1&amp;km=l&amp;kh=1" target="_blank" title="Search this domain">' + content.data.top_blocked[i].address + '</a>';
-				//]]>
+			if (content.top_blocked[i]) {
+				c_addr = '<a href="https://duckduckgo.com/?q=' + encodeURIComponent(content.top_blocked[i].address) + '&amp;k1=-1&amp;km=l&amp;kh=1" target="_blank" rel="noreferrer noopener" title="Domain Lookup">' + content.top_blocked[i].address + '</a>';
 			}
 			rows_top.push([
 				a_cnt,
@@ -264,35 +260,33 @@ return view.extend({
 		]);
 
 		max = 0;
-		if (content.data.requests) {
+		if (content.requests) {
 			var button;
-			max = content.data.requests.length;
+			max = content.requests.length;
 			for (var i = 0; i < max; i++) {
-				if (content.data.requests[i].rc === 'NX') {
+				if (content.requests[i].rc === 'NX') {
 					button = E('button', {
-						'class': 'cbi-button cbi-button-apply',
+						'class': 'btn cbi-button cbi-button-positive',
 						'style': 'word-break: inherit',
 						'name': 'whitelist',
-						'value': content.data.requests[i].domain,
+						'value': content.requests[i].domain,
 						'click': handleAction
 					}, [ _('Whitelist...') ]);
 				} else {
 					button = E('button', {
-						'class': 'cbi-button cbi-button-apply',
+						'class': 'btn cbi-button cbi-button-negative',
 						'style': 'word-break: inherit',
 						'name': 'blacklist',
-						'value': content.data.requests[i].domain,
+						'value': content.requests[i].domain,
 						'click': handleAction
 					}, [ _('Blacklist...') ]);
 				}
 				rows_requests.push([
-					content.data.requests[i].date,
-					content.data.requests[i].time,
-					content.data.requests[i].client,
-					//[!CDATA[
-						'<a href="https://duckduckgo.com/?q=' + encodeURIComponent(content.data.requests[i].domain) + '&amp;k1=-1&amp;km=l&amp;kh=1" target="_blank" title="Search this domain">' + content.data.requests[i].domain + '</a>',
-					//]]>
-					content.data.requests[i].rc,
+					content.requests[i].date,
+					content.requests[i].time,
+					content.requests[i].client,
+					'<a href="https://duckduckgo.com/?q=' + encodeURIComponent(content.requests[i].domain) + '&amp;k1=-1&amp;km=l&amp;kh=1" target="_blank" rel="noreferrer noopener" title="Domain Lookup">' + content.requests[i].domain + '</a>',
+					content.requests[i].rc,
 					button
 				]);
 			}
@@ -301,30 +295,34 @@ return view.extend({
 
 		return E('div', { 'class': 'cbi-map', 'id': 'map' }, [
 			E('div', { 'class': 'cbi-section' }, [
-				E('p', _('This shows the last generated DNS Report, press the refresh button to get a current one.')),
+				E('p', _('This tab shows the last generated DNS Report, press the \'Refresh\' button to get a current one.')),
 				E('p', '\xa0'),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Start Timestamp')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'start', 'style': 'margin-bottom:5px;margin-left:200px;color:#37c' }, (content.data.start_date || '-') + ', ' + (content.data.start_time || '-'))]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('End Timestamp')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'end', 'style': 'margin-bottom:5px;margin-left:200px;color:#37c' }, (content.data.end_date || '-') + ', ' + (content.data.end_time || '-'))]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Total DNS Requests')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'total', 'style': 'margin-bottom:5px;margin-left:200px;color:#37c' }, content.data.total || '-')]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Blocked DNS Requests')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'blocked', 'style': 'margin-bottom:5px;margin-left:200px;color:#37c' }, (content.data.blocked || '-') + ' (' + (content.data.percent || '-') + ')')]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('div', { 'class': 'cbi-value-title', 'style': 'float:left;width:230px' }, _('Start Timestamp')),
+					E('div', { 'class': 'cbi-value-title', 'id': 'start', 'style': 'float:left;color:#37c' }, (content.start_date || '-') + ', ' + (content.start_time || '-'))
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('div', { 'class': 'cbi-value-title', 'style': 'float:left;width:230px' }, _('End Timestamp')),
+					E('div', { 'class': 'cbi-value-title', 'id': 'end', 'style': 'float:left;color:#37c' }, (content.end_date || '-') + ', ' + (content.end_time || '-'))
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('div', { 'class': 'cbi-value-title', 'style': 'float:left;width:230px' }, _('Total DNS Requests')),
+					E('div', { 'class': 'cbi-value-title', 'id': 'total', 'style': 'float:left;color:#37c' }, content.total || '-')
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('div', { 'class': 'cbi-value-title', 'style': 'float:left;width:230px' }, _('Blocked DNS Requests')),
+					E('div', { 'class': 'cbi-value-title', 'id': 'blocked', 'style': 'float:left;color:#37c' }, (content.blocked || '-') + ' (' + (content.percent || '-') + ')')
+				]),
 				E('div', { 'class': 'right' }, [
 					E('button', {
-						'class': 'cbi-button cbi-button-apply',
+						'class': 'btn cbi-button cbi-button-apply',
 						'click': ui.createHandlerFn(this, function() {
 							return handleAction('query');
 						})
 					}, [ _('Blocklist Query...') ]),
 					'\xa0\xa0\xa0',
 					E('button', {
-						'class': 'cbi-button cbi-button-apply',
+						'class': 'btn cbi-button cbi-button-positive',
 						'click': ui.createHandlerFn(this, function() {
 							return handleAction('refresh');
 						})

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/whitelist.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/whitelist.js
@@ -8,7 +8,7 @@ return view.extend({
 		return L.resolveDefault(fs.read_direct('/etc/adblock/adblock.whitelist'), '');
 	},
 	handleSave: function(ev) {
-		var value = ((document.querySelector('textarea').value || '').trim().toLowerCase().replace(/\r\n/g, '\n').replace(/[^a-z0-9\.\-\#\n]/g, '')) + '\n';
+		var value = ((document.querySelector('textarea').value || '').trim().toLowerCase().replace(/\r\n/g, '\n')) + '\n';
 		return fs.write('/etc/adblock/adblock.whitelist', value)
 			.then(function(rc) {
 				document.querySelector('textarea').value = value;

--- a/applications/luci-app-adblock/po/ar/adblock.po
+++ b/applications/luci-app-adblock/po/ar/adblock.po
@@ -11,16 +11,16 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.3.1\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "إجراء"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "المصادر المفعّلة"
 
@@ -49,43 +49,43 @@ msgstr "أضف هذا النطاق (الفرعي) لقائمتك السوداء 
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "أضف هذا النطاق (الفرعي) لقائمتك المسموحة المحلية."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "قائمة حظر إضافية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "إعدادات إضافية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "وقت انتظار إضافي بالثواني قبل الشروع في تطبيق إعدادات أدبلوك."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "إعدادات DNS متقدمة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "إعدادات متقدمة للبريد الالكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "إعدادات متقدمة للتقارير"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "إجابة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "مجلد النسخ الاحتياطي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "مجلد التخزين المؤقت الأساسي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,11 +102,11 @@ msgstr ""
 "تم حفظ التغييرات في القائمة السوداء. رجاء قم بتحديث قوائم أدبلوك الخاصة بك "
 "لتظهر التغييرات."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "القائمة السوداء..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -114,11 +114,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "نطاق محظور"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "نطاقات محظورة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "نسخة احتياطية لقائمة الحظر"
 
@@ -126,15 +126,15 @@ msgstr "نسخة احتياطية لقائمة الحظر"
 msgid "Blocklist Query"
 msgstr "استعلام لقائمة الحظر"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "استعلام لقائمة الحظر..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "مصادر قائمة الحظر"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -148,23 +148,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"تحتاج التغييرات في علامة التبويب هذه إلى إعادة تشغيل خدمة أدبلوك كاملة حتى "
-"تصبح نافذة المفعول.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "العميل"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -182,95 +179,91 @@ msgstr ""
 msgid "Count"
 msgstr "العدد"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -284,31 +277,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "مفعل"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -318,11 +311,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -332,42 +325,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -375,59 +368,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -436,7 +421,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -457,7 +442,7 @@ msgstr ""
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -469,23 +454,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -493,7 +478,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -505,156 +489,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -688,17 +675,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -708,19 +695,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -729,7 +716,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -740,15 +732,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -756,14 +748,21 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "تحتاج التغييرات في علامة التبويب هذه إلى إعادة تشغيل خدمة أدبلوك كاملة "
+#~ "حتى تصبح نافذة المفعول.<br /><p>&#xa0;</p>"

--- a/applications/luci-app-adblock/po/bg/adblock.po
+++ b/applications/luci-app-adblock/po/bg/adblock.po
@@ -4,16 +4,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -42,43 +42,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -91,11 +91,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -103,11 +103,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -115,15 +115,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,21 +134,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -162,95 +161,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -264,31 +259,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -298,11 +293,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,42 +307,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -355,59 +350,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -416,7 +403,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -437,7 +424,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -449,23 +436,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -473,7 +460,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -485,156 +471,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -668,17 +657,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -688,19 +677,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -709,7 +698,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -720,15 +714,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,14 +730,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/bn_BD/adblock.po
+++ b/applications/luci-app-adblock/po/bn_BD/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0.2\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "সক্রিয় উৎস"
 
@@ -48,43 +48,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -97,11 +97,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -109,11 +109,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,15 +121,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,21 +140,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -168,95 +167,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,31 +265,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -304,11 +299,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -318,42 +313,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -361,59 +356,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -422,7 +409,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -443,7 +430,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -455,23 +442,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -479,7 +466,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -491,156 +477,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -674,17 +663,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -694,19 +683,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -715,7 +704,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -726,15 +720,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -742,14 +736,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ca/adblock.po
+++ b/applications/luci-app-adblock/po/ca/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Acció"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -48,45 +48,45 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Retard addicional en segons de l’activador abans que comenci el processament "
 "del blocador d’anuncis."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Directori de còpies de seguretat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -99,11 +99,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Domini blocat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -123,15 +123,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Fonts de la llista negra"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -142,21 +142,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -170,95 +169,91 @@ msgstr ""
 msgid "Count"
 msgstr "Recompte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Directori del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Reinicialització de fitxers del DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Notificació per correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Adreça de destinatari de correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -272,31 +267,31 @@ msgstr "Edita la llista negra"
 msgid "Edit Whitelist"
 msgstr "Edita la llista blanca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -306,11 +301,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -320,42 +315,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Purga la memòria cau del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Força el DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -363,59 +358,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Darrera execució"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Llista d’utilitats de baixada admeses i plenament preconfigurades."
 
@@ -424,7 +411,7 @@ msgstr "Llista d’utilitats de baixada admeses i plenament preconfigurades."
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Servei de prioritat baixa"
 
@@ -445,7 +432,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -457,23 +444,23 @@ msgstr "Consulta"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -481,7 +468,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Actualitza"
 
@@ -493,156 +479,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Desa"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -676,17 +665,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -696,19 +685,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -717,7 +706,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
@@ -728,15 +722,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -744,14 +738,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Reinicialització de fitxers del DNS"

--- a/applications/luci-app-adblock/po/cs/adblock.po
+++ b/applications/luci-app-adblock/po/cs/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.3.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akce"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Aktivní zdroje"
 
@@ -48,44 +48,44 @@ msgstr "Přidejte tuto (sub)doménu na místní blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Přidat tuto (sub)doménu na místní whitelist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Další nastavení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatečné zpoždění v sekundách před začátkem zpracování blokování reklamy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Pokročilá nastavení DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Pokročilá nastavení e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Pokročilá nastavení hlášení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Odpověd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Záložní adresář"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Základní dočasný adresář"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,11 +102,11 @@ msgstr ""
 "Změny blacklistu byly uloženy. Obnovte své adblockové seznamy, aby se změny "
 "projevily."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Blacklist..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -114,11 +114,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Blokované domény"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Blokované domény"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Záloha blokovacího seznamu"
 
@@ -126,15 +126,15 @@ msgstr "Záloha blokovacího seznamu"
 msgid "Blocklist Query"
 msgstr "Dotaz na blokovací seznam"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Dotaz na blokovací seznam..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Zdroje seznamů blokování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,21 +145,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Storno"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -173,7 +172,7 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -181,89 +180,85 @@ msgstr ""
 "Vytváří komprimované zálohy blokovacího seznamu, budou použity v případě "
 "chyb při stahování nebo po příštím spuštění."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Adresář DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Resetování souboru DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Parametry stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Fronta stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Oznámení e-mailem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Počet e-mailových oznámení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "E-mailový profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Adresa příjemce e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Adresa odesílatele e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Téma e-mailu"
 
@@ -277,31 +272,31 @@ msgstr "Upravit blacklist"
 msgid "Edit Whitelist"
 msgstr "Upravit whitelist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Povolit bezpečné vyhledávání (SafeSearch)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Povolit střední filtry SafeSearch pro youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Povolit službu adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Zapnuto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -311,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Stávající úlohy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -325,42 +320,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Vyprázdnit mezipaměť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Vynutit lokální DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Obecná nastavení"
 
@@ -368,59 +363,51 @@ msgstr "Obecná nastavení"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Informace"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Poslední spuštění"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Seznam podporovaných a plně předkonfigurovaných nástrojů pro stahování."
@@ -430,7 +417,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Služba s nízkou prioritou"
 
@@ -451,7 +438,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -463,23 +450,23 @@ msgstr "Dotaz"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adresa příjemce pro e-maily s upozorněním."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -487,7 +474,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Aktualizovat"
 
@@ -499,156 +485,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Počet bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Velikost bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Adresář sestav"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Rozhraní sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Uložit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Pozastavit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Cílový adresář pro vygenerovaný blokovací seznam 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -682,17 +671,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Čas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -702,19 +691,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
@@ -723,7 +712,12 @@ msgstr "Prodleva spuštění"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
@@ -734,15 +728,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -750,14 +744,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Resetování souboru DNS"

--- a/applications/luci-app-adblock/po/de/adblock.po
+++ b/applications/luci-app-adblock/po/de/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "- unbestimmt -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Aktion"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Aktive Quellen"
 
@@ -48,45 +48,45 @@ msgstr "Füge diese (Sub-)Domain zur lokalen Blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Füge diese (Sub-)Domain zur lokalen Whiteklist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Zusätzliche Jail-Sperrliste"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Zusätzliche Verzögerung (in Sekunden) bis zur Verarbeitung durch den "
 "Werbeblocker."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Fortgeschrittene DNS Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Fortgeschrittene E-Mail Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Fortgeschrittene Berichtseinstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Antwort"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Backupverzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Basis-Temp-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -103,11 +103,11 @@ msgstr ""
 "Änderung der Blackliste gespeichert. Aktualisiere deine Adblock-Liste, um "
 "die Änderungen zu übernehmen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Blacklist..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Geblockte DNS-Anfragen"
 
@@ -115,11 +115,11 @@ msgstr "Geblockte DNS-Anfragen"
 msgid "Blocked Domain"
 msgstr "Blockierte Domain"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Gesperrte Domains"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Sperrliste Backup"
 
@@ -127,15 +127,15 @@ msgstr "Sperrliste Backup"
 msgid "Blocklist Query"
 msgstr "Sperrlistenabfrage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Sperrlisten abfragen..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Blockierlisten-Quellen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,23 +149,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"Änderungen auf diesem Reiter werden erst nach Neustart des adblock Services "
-"sichtbar.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -183,7 +180,7 @@ msgstr ""
 msgid "Count"
 msgstr "Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -191,42 +188,38 @@ msgstr ""
 "Erzeuge komprimierte Backups der Sperrlisten, um die Sperrfunktion schon "
 "sofort ab dem Booten oder im Fall von Downloadfehlern zur Verfügung zu haben."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "DNS-Backend"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS-Datei zurücksetzen"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-Report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "DNS-Restart-Timeout"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Deaktiviere DNS-Zulassen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "DNS-Neustarts deaktivieren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -234,48 +227,48 @@ msgstr ""
 "Deaktiviere das Triggern von Neustarts des DNS-Backends durch Adblock per "
 "Autoload/inotify-Funktionsaufrufe."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domäne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Download Parameter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Download Warteschlange"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "E-Mail Benachrichtigungszähler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "E-Mail-Profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Empfängeradresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Absenderadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "E-Mail-Thema"
 
@@ -289,33 +282,33 @@ msgstr "Blacklist bearbeiten"
 msgid "Edit Whitelist"
 msgstr "Whitelist bearbeiten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Aktiviere SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Aktiviere moderate SafeSearch-Filter für YouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Aktiviere den Adblock-Dienst."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Aktivieren Sie die ausführliche Debug-Protokollierung bei "
 "Verarbeitungsfehlern."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "Ende-Zeitstempel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -325,11 +318,11 @@ msgstr "Erzwinge SafeSearch für Google, Bing, DuckDuckGo, Yandex und Pixabay."
 msgid "Existing job(s)"
 msgstr "Bestehende Job(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Externe DNS Lookup Domain"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -341,35 +334,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filterkriterien wie z.B. Datum, Domain oder Client (optional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "Firewall-Ports, die lokal erzwungen/aufgelöst werden sollen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr "Firewall-Zonen, die lokal erzwungen/aufgelöst werden sollen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "DNS-Cache leeren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Lokale DNS-Auflösung erzwingen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "Erzwungene Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "Erzwungene Zonen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -379,7 +372,7 @@ msgstr ""
 "auf Abruf bereitstellen zu können. Hinweis: Hierzu muss das Paket \"tcpdump-"
 "mini\" installiert und der Adblock-Dienst danach neugestartet worden sein."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
@@ -387,37 +380,41 @@ msgstr "Allgemeine Einstellungen"
 msgid "Grant access to LuCI app adblock"
 msgstr "Zugriff auf adblock LuCI app erlauten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Informationen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Sperrverzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Letzter Durchgang"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Neueste DNS Anfragen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "SafeSearch einschränken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "SafeSearch auf bestimmte Anbieter einschränken."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Liste an verfügbaren Netzwerkschnittstellen die von tcpdump verwendet werden "
 "können."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -426,7 +423,7 @@ msgstr ""
 "triggern. Wähle \"unspecified\", um einen herkömmlichen Start-Timeout-"
 "Mechanismuss anstatt eines Netzwerk-Triggers zu verwenden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -434,28 +431,7 @@ msgstr ""
 "Liste an unterstützten DNS-Backens und deren Standard-Listenverzeichnissen. "
 "Um einen Standardpfad zu überschreiben, nutze die \"DNS-Verzeichnis\"-Option."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Liste von unterstützten und vollständig vorkonfigurierten Adblock-Quellen, "
-"bereits aktivierte Quellen sind vorgewählt.<br /> <b><em> Falls zuviele "
-"Listen aktiv sind, kann es zu Out-Of-Memory-Fehlern kommen!</em></b><br /> "
-"Größenangaben für entsprechende Domain-Reichweiten sind:<br /> &#8226;&#xa0;"
-"<b>S</b> (-10k), <b>M</b> (10k-30k) und <b>L</b> (30k-80k) sollten für 128MB-"
-"Geräte ausreichen,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) sollten für "
-"256-512MB-Geräte ausreichen,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) benötigt "
-"mehr RAM und zusätzlich eine Multicore-CPU, z.B entpsrechende x86- oder "
-"RaspberryPi-Geräte.<br /> <p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste der unterstützten und vollständig vorkonfigurierten Download-"
@@ -466,7 +442,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Protokollansicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Dienst mit niedriger Priorität"
 
@@ -487,7 +463,7 @@ msgstr "Aktuell noch keine Adblock-Logs vorhanden!"
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "\"msmtp\"-Profil, das für Adblock-Benachrichtigunsmails verwendet wird."
@@ -500,7 +476,7 @@ msgstr "Abfrage"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Frage aktive Sperrlisten und Backups über eine spezifische Domain ab."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -508,11 +484,11 @@ msgstr ""
 "Erhöhe den Benachrichtigunszähler um Emails zu erhalten, wenn die Gesamtzahl "
 "der Blocklisten kleiner gleich diesem Schwellwert ist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Empfängeradresse für Adblock-Benachrichtigungs-E-Mails."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -520,7 +496,7 @@ msgstr ""
 "Leitet alle DNS-Anfragen aus den angegebenen Zonen an den lokalen DNS-"
 "Resolver um, gilt für das UDP- und TCP-Protokoll."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -531,7 +507,6 @@ msgstr ""
 "des Adblock-Dienstes um in Kraft zu treten."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Aktualisieren"
 
@@ -543,83 +518,85 @@ msgstr "Aktualisiere DNS-Report"
 msgid "Refresh Timer"
 msgstr "Aktualisiere Timer"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Aktualisiere Timer..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Aktualisiere..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "SafeSearch abschwächen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Berichte Datenblock-Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Berichte Datenblock-Größe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Verzeichnis für Berichte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Berichte-Schnittstelle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Berichte Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "Berichte Datenblock-Nutzung durch tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Berichte von tcpdump verwendete Datenblockgröße in MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"Setze die engültige DNS-Sperrliste \"adb_list.overall\" nach dem DNS-Backend "
-"geladen hat zurück. Hinweis: Diese Option startet einen kleinen ubus/adblock-"
-"Monitor im Hintergrund."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Ergebnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Run-Verzeichnisse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "Flags ausführen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Run-Interfaces"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "Run-Werkzeuge"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Speichern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -627,19 +604,19 @@ msgstr ""
 "Sende relevante Adblock-Benachrichtigungen per Email. Hinweis: Hierzu muss "
 "das \"msmtp\"-Zusatzpaket installiert sein."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Absenderadresse für Adblock-Benachrichtigungsmails."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "(Er)Setze einen neuen Adblock-Job"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -647,66 +624,58 @@ msgstr ""
 "Größe der Download-Warteschlange für laufende Downloads (inkl. Platzbedarf "
 "für Sortieren, Zusammenführen)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "Quellen (Größe, Fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Leerzeichengetrennte Liste an Ports die von tcpdump genutzt werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Spezielle Konfigurationseinstellungen für das gewählte Download-Programm."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "Start-Zeitstempel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "Trigger-Interface fürs Starten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Status / Version"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Anhalten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"Zielverzeichnis für DNS-relevante Berichtsdateien. Standardmäßig auf \"/tmp"
-"\" gesetzt, hier sollte besser ein USB-Stick oder anderer lokaler Speicher "
-"verwendet werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"Zielverzeichnis für Sperrlisten-Backups. Standardmäßig auf \"/tmp\" gesetzt, "
-"hier sollte besser ein USB-Stick oder anderer lokaler Speicher verwendet "
-"werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Zielverzeichnis für die erzeugte Sperrliste 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Zielverzeichnis für die erzeugte Jail-Sperrliste \"adb_list.jail\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "Der Aktualisierungstimer konnte nicht aktualisiert werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "Der Aktualisierungstimer wurde aktualisiert."
 
@@ -748,19 +717,17 @@ msgstr ""
 "Kommentare mit # am Anfang ebenfalls, nicht jedoch IP-Adressen, Wildcards "
 "und Regex-Ausdrücke."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
-"Hier wird der zuletzt erzeugte DNS-Report angezeigt, um einen aktuelleren "
-"anzuzeigen, den Erneuern-Knopf drücken."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Zeit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Timeout für erfolgreichen DNS-Backend-Startvorgang."
 
@@ -772,19 +739,19 @@ msgstr ""
 "Um die Adblock-Liste aktuell zu halten, sollte dafür ein automatischer "
 "Update-Job eingerichtet werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "Top-10 Statistiken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr "Betreff für Adblock-Benachrichtigungsmails."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "Gesamte DNS-Anfragen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Verzögerung der Trigger-Bedingung"
 
@@ -793,7 +760,12 @@ msgstr "Verzögerung der Trigger-Bedingung"
 msgid "Unable to save changes: %s"
 msgstr "Konnte Änderungen nicht speichern: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
@@ -806,15 +778,15 @@ msgstr ""
 "Whitelist-Änderungen wurden gespeichert. Aktualisiere die Adblock-Listen um "
 "die Änderung anzuwenden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "Whiteliste..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -822,14 +794,80 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "Max. Größe des Result-Sets"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Änderungen auf diesem Reiter werden erst nach Neustart des adblock "
+#~ "Services sichtbar.<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS-Datei zurücksetzen"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Liste von unterstützten und vollständig vorkonfigurierten Adblock-"
+#~ "Quellen, bereits aktivierte Quellen sind vorgewählt.<br /> <b><em> Falls "
+#~ "zuviele Listen aktiv sind, kann es zu Out-Of-Memory-Fehlern kommen!</em></"
+#~ "b><br /> Größenangaben für entsprechende Domain-Reichweiten sind:<br /> "
+#~ "&#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) und <b>L</b> (30k-80k) "
+#~ "sollten für 128MB-Geräte ausreichen,<br /> &#8226;&#xa0;<b>XL</b> "
+#~ "(80k-200k) sollten für 256-512MB-Geräte ausreichen,<br /> &#8226;&#xa0;"
+#~ "<b>XXL</b> (200k-) benötigt mehr RAM und zusätzlich eine Multicore-CPU, z."
+#~ "B entpsrechende x86- oder RaspberryPi-Geräte.<br /> <p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "Setze die engültige DNS-Sperrliste \"adb_list.overall\" nach dem DNS-"
+#~ "Backend geladen hat zurück. Hinweis: Diese Option startet einen kleinen "
+#~ "ubus/adblock-Monitor im Hintergrund."
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "(Er)Setze einen neuen Adblock-Job"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Zielverzeichnis für DNS-relevante Berichtsdateien. Standardmäßig auf \"/"
+#~ "tmp\" gesetzt, hier sollte besser ein USB-Stick oder anderer lokaler "
+#~ "Speicher verwendet werden."
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Zielverzeichnis für Sperrlisten-Backups. Standardmäßig auf \"/tmp\" "
+#~ "gesetzt, hier sollte besser ein USB-Stick oder anderer lokaler Speicher "
+#~ "verwendet werden."
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr ""
+#~ "Hier wird der zuletzt erzeugte DNS-Report angezeigt, um einen aktuelleren "
+#~ "anzuzeigen, den Erneuern-Knopf drücken."

--- a/applications/luci-app-adblock/po/el/adblock.po
+++ b/applications/luci-app-adblock/po/el/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Ενεργές πηγές"
 
@@ -48,43 +48,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Επιπρόσθετες ρυθμίσεις"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Σύνθετες ρυθμίσεις DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Προηγμένες ρυθμίσεις ηλεκτρονικού ταχυδρομείου"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Σύνθετες ρυθμίσεις αναφοράς"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Απάντηση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "φάκελος διάσωσης"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -97,11 +97,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Αποκλεισμένα αιτήματα DNS"
 
@@ -109,11 +109,11 @@ msgstr "Αποκλεισμένα αιτήματα DNS"
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,15 +121,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Λίστα Μπλοκαρισμένων πηγών"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,21 +140,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "πελάτης"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -168,95 +167,91 @@ msgstr ""
 msgid "Count"
 msgstr "Μέτρηση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "κατάλογος DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Επαναφορά αρχείου DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,31 +265,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Ενεργοποιήθηκε"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -304,11 +299,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -318,42 +313,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Γενικές ρυθμίσεις"
 
@@ -361,59 +356,51 @@ msgstr "Γενικές ρυθμίσεις"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -422,7 +409,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -443,7 +430,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -455,23 +442,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -479,7 +466,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -491,156 +477,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -674,17 +663,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -694,19 +683,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -715,7 +704,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -726,15 +720,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -742,14 +736,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Επαναφορά αρχείου DNS"

--- a/applications/luci-app-adblock/po/en/adblock.po
+++ b/applications/luci-app-adblock/po/en/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -48,43 +48,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -97,11 +97,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -109,11 +109,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,15 +121,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,21 +140,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -168,95 +167,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,31 +265,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Enabled"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -304,11 +299,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -318,42 +313,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -361,59 +356,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -422,7 +409,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -443,7 +430,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -455,23 +442,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -479,7 +466,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -491,156 +477,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -674,17 +663,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -694,19 +683,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -715,7 +704,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -726,15 +720,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -742,14 +736,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/es/adblock.po
+++ b/applications/luci-app-adblock/po/es/adblock.po
@@ -13,16 +13,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "- sin especificar -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Acción"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Fuentes activas"
 
@@ -51,45 +51,45 @@ msgstr "Agregue este (sub) dominio a su lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Agregue este (sub) dominio a su lista blanca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Lista de bloqueo adicional de la cárcel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Configuración adicional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
 "procesamiento de adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Configuración avanzada de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Configuración avanzada de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Configuración avanzada de informes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Responder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Directorio de respaldo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Directorio temporal base"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,11 +106,11 @@ msgstr ""
 "Se han guardado los cambios en la lista negra. Actualice sus listas de "
 "bloqueos de anuncios para que los cambios surtan efecto."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Solicitudes de DNS bloqueadas"
 
@@ -118,11 +118,11 @@ msgstr "Solicitudes de DNS bloqueadas"
 msgid "Blocked Domain"
 msgstr "Dominio bloqueado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Dominios bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Copia de seguridad de lista de bloqueo"
 
@@ -130,15 +130,15 @@ msgstr "Copia de seguridad de lista de bloqueo"
 msgid "Blocklist Query"
 msgstr "Consulta de lista de bloqueo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Consulta de lista de bloqueo..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Fuentes de lista de bloqueo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -153,23 +153,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"Los cambios en esta pestaña requieren un reninicio completo del servicio "
-"adblock para que los cambios surtan efecto.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -187,7 +184,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -195,42 +192,38 @@ msgstr ""
 "Cree copias de seguridad de listas de bloqueo comprimidas, se utilizarán en "
 "caso de errores de descarga o durante el inicio."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "Backend de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Directorio DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Restablecimiento de archivos DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Informe DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Tiempo de espera de reinicio de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Fecha"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Desactivar Permitir DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Desactivar Reinicios de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -238,48 +231,48 @@ msgstr ""
 "Desactivar los reinicios activados por adblock para back-end dns con "
 "funciones de carga automática/inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Descargar parámetros"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Cola de descarga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Notificación por correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Conteo de notificaciones por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "Perfil de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Tema del correo electrónico"
 
@@ -293,33 +286,33 @@ msgstr "Editar lista negra"
 msgid "Edit Whitelist"
 msgstr "Editar lista blanca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Activar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activar filtros moderados de SafeSearch para YouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Activa el servicio Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activar el registro de depuración detallado en caso de errores de "
 "procesamiento."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Activado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "Finalizar marca de tiempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -331,11 +324,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Trabajo(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Dominio de búsqueda de DNS externo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -348,35 +341,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterios de filtro como fecha, dominio o cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "Puertos del cortafuegos que deben forzarse localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas de origen del cortafuegos que deben forzarse localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Vaciar caché de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Forzar DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "Puertos forzados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "Zonas forzadas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -387,7 +380,7 @@ msgstr ""
 "instalación adicional del paquete 'tcpdump-mini' y un reinicio completo del "
 "servicio adblock para que surta efecto."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Configuración general"
 
@@ -395,35 +388,39 @@ msgstr "Configuración general"
 msgid "Grant access to LuCI app adblock"
 msgstr "Conceder acceso a la aplicación adblock de LuCI"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Información"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Directorio de la cárcel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Último inicio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Últimas solicitudes de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "Limitar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limitar SafeSearch a proveedores specíficos."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de dispositivos de red disponibles utilizados por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -432,7 +429,7 @@ msgstr ""
 "Elija 'No especificado' para usar un tiempo de espera de inicio clásico en "
 "lugar de un disparador de red."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -440,28 +437,7 @@ msgstr ""
 "Lista de backends DNS compatibles con su directorio de lista predeterminado. "
 "Para sobrescribir la ruta predeterminada, use la opción 'Directorio DNS'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Lista de fuentes de adblock compatibles y totalmente preconfiguradas, las "
-"fuentes ya activas están preseleccionadas.<br /><b><em>Para evitar errores "
-"de OOM, ¡no seleccione demasiadas listas!</em></b><br /> Enumere la "
-"información de tamaño con los rangos de dominio respectivos de la siguiente "
-"manera:<br /> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) y <b>L</b> "
-"(30k-80k) debería funcionar para dispositivos de 128 MByte,<br /> &#8226;"
-"&#xa0;<b>XL</b> (80k-200k) debería funcionar para dispositivos de 256-512 "
-"MByte,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) necesita más RAM y soporte "
-"multinúcleo, p. ej. x86 o dispositivos Raspberry.<br /><p></p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de utilidades de descarga totalmente preconfiguradas y compatibles."
@@ -471,7 +447,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Vista de registro"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Servicio con prioridad baja"
 
@@ -492,7 +468,7 @@ msgstr "¡Aún no hay registros relacionados con adblock!"
 msgid "Overview"
 msgstr "Vista general"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil utilizado por 'msmtp' para notificaciones de E-Mails adblock."
 
@@ -506,7 +482,7 @@ msgstr ""
 "Consulta listas de bloqueo activas y copias de seguridad para un dominio "
 "específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -514,11 +490,11 @@ msgstr ""
 "Aumente el recuento de notificaciones para obtener correos electrónicos si "
 "el recuento general de la lista de bloqueo es menor o igual al límite dado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Dirección del receptor para la notificación de bloqueos electrónicos."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -526,7 +502,7 @@ msgstr ""
 "Redirigir todas las consultas de DNS de las zonas especificadas al sistema "
 "de resolución de DNS local, se aplica a los protocolos UDP y TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -537,7 +513,6 @@ msgstr ""
 "reinicio completo del servicio adblock para que surta efecto."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Refrescar"
 
@@ -549,83 +524,85 @@ msgstr "Actualizar informe DNS"
 msgid "Refresh Timer"
 msgstr "Temporizador de actualización"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Actualizar temporizador..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Actualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "Relajar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Informe de recuento de fragmentos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Tamaño del fragmento de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Directorio de informes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Interfaz de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Informar puertos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "Informe el recuento de fragmentos utilizado por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informe el tamaño del fragmento utilizado por tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"Restablece la lista de bloqueo de DNS final 'adb_list.overall' después de la "
-"carga del backend de DNS. Nota: esta opción inicia un pequeño monitor ubus/"
-"adblock en segundo plano."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Resultado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Ejecutar directorios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "Ejecutar banderas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Ejecutar interfaces"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "Ejecutar utilidades"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -633,21 +610,21 @@ msgstr ""
 "Enviar correos electrónicos de notificación relacionados con adblock. Tenga "
 "en cuenta: esto necesita una instalación adicional del paquete 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Dirección del remitente para los correos electrónicos de notificación de "
 "adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "Establecer/Reemplazar un nuevo trabajo de adblock"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -655,70 +632,62 @@ msgstr ""
 "Tamaño de la cola de descarga para el procesamiento de descarga (incluida la "
 "clasificación, fusión, etc.) en paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "Fuentes (tamaño, enfoque)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista de puertos separados por espacios utilizados por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opciones de configuración especiales para la utilidad de descarga "
 "seleccionada."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "Iniciar marca de tiempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "Interfaz de activación de inicio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Estado/Versión"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"Directorio de destino para archivos de informes relacionados con DNS. El "
-"valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB u "
-"otro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"Directorio de destino para copias de seguridad de listas de bloqueo. El "
-"valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB u "
-"otro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo generada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo de cárcel generada 'adb_list."
 "jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "No se pudo actualizar el temporizador de actualización."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "Se ha actualizado el temporizador de actualización."
 
@@ -762,19 +731,17 @@ msgstr ""
 "línea. Los comentarios introducidos con '#' están permitidos; las "
 "direcciones IP, comodines y expresiones regulares no."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
-"Esto muestra el último Informe DNS generado, presione el botón Actualizar "
-"para obtener uno actual."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Hora"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tiempo de espera para esperar un reinicio de backend de DNS exitoso."
 
@@ -786,19 +753,19 @@ msgstr ""
 "Para mantener sus listas de bloqueos de anuncios actualizadas, debe "
 "configurar un trabajo de actualización automática para estas listas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "Top 10 estadísticas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr "Tema para los correos electrónicos de notificación de adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "Solicitudes DNS Totales"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
@@ -807,7 +774,12 @@ msgstr "Retraso de disparo"
 msgid "Unable to save changes: %s"
 msgstr "No se pudo guardar los cambios: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
@@ -820,15 +792,15 @@ msgstr ""
 "Se han guardado los cambios en la lista blanca. Actualice sus listas de "
 "bloqueos de anuncios para que los cambios surtan efecto."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "Lista blanca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -836,14 +808,81 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "máx. tamaño del conjunto de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "llamado (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "crudo (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Los cambios en esta pestaña requieren un reninicio completo del servicio "
+#~ "adblock para que los cambios surtan efecto.<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Restablecimiento de archivos DNS"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Lista de fuentes de adblock compatibles y totalmente preconfiguradas, las "
+#~ "fuentes ya activas están preseleccionadas.<br /><b><em>Para evitar "
+#~ "errores de OOM, ¡no seleccione demasiadas listas!</em></b><br /> Enumere "
+#~ "la información de tamaño con los rangos de dominio respectivos de la "
+#~ "siguiente manera:<br /> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) "
+#~ "y <b>L</b> (30k-80k) debería funcionar para dispositivos de 128 MByte,"
+#~ "<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) debería funcionar para "
+#~ "dispositivos de 256-512 MByte,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) "
+#~ "necesita más RAM y soporte multinúcleo, p. ej. x86 o dispositivos "
+#~ "Raspberry.<br /><p></p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "Restablece la lista de bloqueo de DNS final 'adb_list.overall' después de "
+#~ "la carga del backend de DNS. Nota: esta opción inicia un pequeño monitor "
+#~ "ubus/adblock en segundo plano."
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "Establecer/Reemplazar un nuevo trabajo de adblock"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Directorio de destino para archivos de informes relacionados con DNS. El "
+#~ "valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB "
+#~ "u otro disco local."
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Directorio de destino para copias de seguridad de listas de bloqueo. El "
+#~ "valor predeterminado es '/ tmp', utilice preferiblemente una memoria USB "
+#~ "u otro disco local."
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr ""
+#~ "Esto muestra el último Informe DNS generado, presione el botón Actualizar "
+#~ "para obtener uno actual."

--- a/applications/luci-app-adblock/po/fi/adblock.po
+++ b/applications/luci-app-adblock/po/fi/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Toiminta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Aktiiviset lähteet"
 
@@ -48,44 +48,44 @@ msgstr "Lisää tämä (ali-)verkkonimi kieltolistallesi."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lisää tämä (ali-)verkkonimi sallittujen listallesi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ylimääräinen odotusaika sekunteina ennen adblock-käsittelyn aloittamista."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "DNS-lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Sähköpostin lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Raportoinnin lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Vastaus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Varmuuskopiohakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Oletushakemisto väliaikaistiedostoille"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,11 +102,11 @@ msgstr ""
 "Kieltolistan muutokset on tallennettu. Virkistä adblock-listat ottaaksesi "
 "muutokset käyttöön."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Kieltolista..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -114,11 +114,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Estetty verkkonimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Estetyt verkkonimet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Kieltolistan varmuuskopio"
 
@@ -126,15 +126,15 @@ msgstr "Kieltolistan varmuuskopio"
 msgid "Blocklist Query"
 msgstr "Estolistan kysely"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Estolistojen lähteet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,21 +145,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Asiakas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -173,48 +172,44 @@ msgstr ""
 msgid "Count"
 msgstr "Määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "DNS-sovellus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS-tiedoston resetointi"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Päivä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Estä DNS:n salliminen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Estä DNS:n uudelleenkäynnistykset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -222,48 +217,48 @@ msgstr ""
 "Estä adblockin aiheuttamat DNS-sovelluksen uudelleenkäynnistykset autoload/"
 "inotify-funktioilla."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Verkkonimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Latausparametrit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Latausjono"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Lataustyökalu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Sähköposti-ilmoitus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Sähköposti-ilmoitusten määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "Sähköpostiprofiili"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Sähköposti: vastaanottajan osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Sähköposti: lähettäjän osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Sähköposti: otsikko"
 
@@ -277,31 +272,31 @@ msgstr "Editoi estolistaa"
 msgid "Edit Whitelist"
 msgstr "Editoi sallittujen lista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Ota Adblock-palvelu käyttöön."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Runsas lokisisältö toimintojen virheiden etsimistä varten."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -311,11 +306,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Nykyiset työt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -325,42 +320,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Suodatintekijät kuten päivä, verkkonimi tai asiakas (valinnainen)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Tyhjennä DNS-välimuisti"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Tyhjennä DNS-välimuisti ennen Adblock-sääntöjen käsittelyä."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Pakota paikallinen DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Yleisasetukset"
 
@@ -368,59 +363,51 @@ msgstr "Yleisasetukset"
 msgid "Grant access to LuCI app adblock"
 msgstr "Salli pääsy Adblock-asetuksiin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Tietoja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Viimeksi ajettu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Viimeiset DNS-kyselyt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Tuetut ja valmiiksi asetetut lataustyökalut."
 
@@ -429,7 +416,7 @@ msgstr "Tuetut ja valmiiksi asetetut lataustyökalut."
 msgid "Log View"
 msgstr "Lokinäkymä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Matala sovelluksen prioriteetti"
 
@@ -450,7 +437,7 @@ msgstr "Ei vielä Adblock-lokeja!"
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -462,23 +449,23 @@ msgstr "Kysely"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Vastaanottajan sähköpostiosoite Adblockin ilmoituksille."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -486,7 +473,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Päivitä"
 
@@ -498,156 +484,159 @@ msgstr "Päivitä DNS-raportti"
 msgid "Refresh Timer"
 msgstr "Päivitysajastin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Päivitysajastin..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Päivitä..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Raporttipalojen määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Raporttipalojen koko"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Raporttihakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Raportoitava sovitin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Raportoitavat portit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Tulos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Ajohakemistot"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "Ajo-parametrit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Ajettavat sovittimet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Tallenna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Lähettäjän osoite Adblockin sähköposti-ilmoituksille."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Asetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "Lähteet (koko, fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -681,17 +670,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -701,19 +690,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -722,7 +711,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -733,15 +727,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -749,14 +743,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS-tiedoston resetointi"

--- a/applications/luci-app-adblock/po/fr/adblock.po
+++ b/applications/luci-app-adblock/po/fr/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Action"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Sources actives"
 
@@ -48,45 +48,45 @@ msgstr "Ajout sous-domaine au réseau local blacklisté."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Ajout sous-domaine au réseau local whitelisté."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Additionnel Bannis Blocklisté"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Paramètres additionnels"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Délai de déclenchement supplémentaire en secondes avant que le bloqueur de "
 "publicité démarre."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Paramètres DNS avancés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Paramètres de messagerie électronique avancés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Paramètres de rapport avancés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Répondre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Répertoire de sauvegarde"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Répertoire Temporaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -103,11 +103,11 @@ msgstr ""
 "Changement Blacklist a été Sauvegarder. Rafraichir votre liste Adblock pour "
 "que les chgmt prennent effet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Liste noire ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -115,11 +115,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Domaines bloqués"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Domaines bloqués"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Sauvegarde de la liste de blocage"
 
@@ -127,15 +127,15 @@ msgstr "Sauvegarde de la liste de blocage"
 msgid "Blocklist Query"
 msgstr "Demande Blocklist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Demande Blocklist..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Sources des listes de blocage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -150,23 +150,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Annuler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"Les modifications de cet onglet nécessitent un redémarrage complet du "
-"service adblock pour prendre effet <br /> <p> &#xa0; </p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,7 +182,7 @@ msgstr ""
 msgid "Count"
 msgstr "Compteur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -193,42 +190,38 @@ msgstr ""
 "Créer des sauvegardes de listes de blocage compressées, elles seront "
 "utilisées en cas d'erreurs de téléchargement ou lors du démarrage."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "Backend du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Répertoire du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Réinitialiser le fichier de DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Rapport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Délai de redémarrage DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Date"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Désactiver l'autorisation DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Désactiver les redémarrages DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -236,48 +229,48 @@ msgstr ""
 "Désactiver les redémarrages déclenchés par adblock pour les backends dns "
 "avec des fonctions d'auto-chargement/notification."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domaine"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Paramètres Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Queue de Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Notifications par e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Nombre de notifications par courrier électronique"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "Email du profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Adresse e-mail du destinataire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Adresse électronique de l'expéditeur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Objet du courrier électronique"
 
@@ -291,32 +284,32 @@ msgstr "Modifier la liste noire"
 msgid "Edit Whitelist"
 msgstr "Modifier la liste blanche"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Activer Safesearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activez les filtres SafeSearch modérés pour youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Activer le service adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activez la journalisation verbale de débogage en cas d'erreurs de traitement."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Activé"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -328,11 +321,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Travaux en cours"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Domaine de recherche DNS externe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -345,35 +338,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Critère filtre comme la date, domaine, client (option)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Vider le cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Videz également le cache DNS avant le traitement des adblocs."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Forcer le DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -384,7 +377,7 @@ msgstr ""
 "d'un paquet \"tcpdump-mini\" supplémentaire et le redémarrage complet du "
 "service adblock pour prendre effet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
@@ -392,35 +385,39 @@ msgstr "Paramètres généraux"
 msgid "Grant access to LuCI app adblock"
 msgstr "Donner tout accès à l'application LuCI adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Répertoire des bannis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Dernière exécution"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Dernière Requêtes DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "Limiter SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limitez SafeSearch à certains fournisseurs."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste des périphériques réseau disponibles utilisés par tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -429,7 +426,7 @@ msgstr ""
 "l'adblock. Choisissez \"non spécifié\" pour utiliser un délai de démarrage "
 "classique au lieu d'un déclencheur réseau."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -438,29 +435,7 @@ msgstr ""
 "Pour écraser le chemin d'accès par défaut, utilisez l'option \"Répertoire DNS"
 "\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Liste des sources adblock supportées et entièrement pré-configurées, les "
-"sources déjà actives sont présélectionnées.<br /> <b><em>Pour éviter les "
-"erreurs d'OOM, veuillez ne pas sélectionner trop de listes !</em></b><br /> "
-"Indiquez les informations sur la taille avec les plages de domaines "
-"respectives comme suit :<br /> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> "
-"(10k-30k) et <b>L</b> (30k-80k) devrait fonctionner pour des appareils de "
-"128 MByte,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) devrait fonctionner pour "
-"les appareils de 256 à 512 Mo,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) a "
-"besoin de plus de RAM et de support Multicore, par exemple des appareils x86 "
-"ou Raspberry.<br /> <p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste des utilitaires de téléchargement pris en charge et entièrement pré-"
@@ -471,7 +446,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Vue du journal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Service en priorité basse"
 
@@ -492,7 +467,7 @@ msgstr "Pas encore de journaux liés à l'adblock !"
 msgid "Overview"
 msgstr "Vue d’ensemble"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilisé par \"msmtp\" pour les e-mails de notification adblock."
 
@@ -506,7 +481,7 @@ msgstr ""
 "Recherchez des listes de blocage actives et des sauvegardes pour un domaine "
 "spécifique."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -515,19 +490,19 @@ msgstr ""
 "électroniques si le nombre total de blocages est inférieur ou égal à la "
 "limite donnée."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Adresse du destinataire pour les e-mails de notification du bloqueur de "
 "publicité."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -539,7 +514,6 @@ msgstr ""
 "effet."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Actualiser"
 
@@ -551,83 +525,85 @@ msgstr "Rafraîchir le rapport DNS"
 msgid "Refresh Timer"
 msgstr "Rafraichir Horloge"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Rafraîchir l'horloge..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Rafraichi..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "Relax SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Rapporter le nombre de morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Rapporter la taille des morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Rapporter le Répertoire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Rapporter l'Interface"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Rapport des Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "Signalez le nombre de morceaux utilisés par tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Indiquez la taille des morceaux utilisés par tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"Réinitialise la liste de blocage DNS finale \"adb_list.overall\" après le "
-"chargement du backend DNS. Veuillez noter : Cette option démarre un petit "
-"moniteur ubus/adblock en arrière-plan."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Resultat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Répertoire de travail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "Drapeaux de travail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Interfaces de travail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "Outils de travail"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Enregistrer"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -635,21 +611,21 @@ msgstr ""
 "Envoyer des e-mails de notification relatifs à l'adblock. Veuillez noter que "
 "l'installation du paquet \"msmtp\" supplémentaire est nécessaire."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Adresse de l'expéditeur des courriers électroniques de notification de "
 "l'adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "Définir/remplacer un nouveau travail d'adblock"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Paramètres"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -657,67 +633,60 @@ msgstr ""
 "Taille de la file d'attente pour le traitement des téléchargements (y "
 "compris le tri, la fusion, etc.) en parallèle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "Sources (Taille, Focus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Liste des ports utilisés par tcpdump, séparés par des espaces."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Options de configuration spéciales pour l'utilitaire de téléchargement "
 "sélectionné."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "Interface de déclenchmnt de démarrage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Statut / Version"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Mettre en pause"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"Répertoire cible pour les fichiers de rapports liés au DNS. La valeur par "
-"défaut est '/tmp', veuillez utiliser plutot une clé usb ou un disque local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"Répertoire cible pour les sauvegardes des listes de blocage. La valeur par "
-"défaut est '/tmp', veuillez utiliser de préférence une clé usb ou un autre "
-"disque local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Répertoire cible pour la liste de blocage générée \"adb_list.overall\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Répertoire cible pour la liste de blocage générée \"adb_list.jail\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "L'horloge de rafraîchissement n'a pas pu être mise à jour."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "Horloge mis à jour."
 
@@ -763,19 +732,17 @@ msgstr ""
 "autorisés - les adresses IP, les caractères génériques et les expressions "
 "rationnelles ne le sont pas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
-"Ceci montre le dernier rapport DNS généré, appuyez sur le bouton de "
-"rafraîchissement pour en obtenir un actuel."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Heure"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Délai d'attente pour un redémarrage réussi du backend du DNS."
 
@@ -787,19 +754,19 @@ msgstr ""
 "Pour maintenir vos listes adblock à jour, vous devez configurer un travail "
 "de mise à jour automatique de ces listes."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "Top 10 Statistiques"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr "Objet pour les notifications par e-mails d'adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
@@ -808,7 +775,12 @@ msgstr "Délai de déclenchement"
 msgid "Unable to save changes: %s"
 msgstr "Sauvegarde Impossible : %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
@@ -821,15 +793,15 @@ msgstr ""
 "Les modifications apportées à la liste blanche sauvegardées. Rafraîchissez "
 "adblock pour prise d'effet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "Liste Blanche..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -837,14 +809,81 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "taille max. des résultats"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Les modifications de cet onglet nécessitent un redémarrage complet du "
+#~ "service adblock pour prendre effet <br /> <p> &#xa0; </p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Réinitialiser le fichier de DNS"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Liste des sources adblock supportées et entièrement pré-configurées, les "
+#~ "sources déjà actives sont présélectionnées.<br /> <b><em>Pour éviter les "
+#~ "erreurs d'OOM, veuillez ne pas sélectionner trop de listes !</em></b><br /"
+#~ "> Indiquez les informations sur la taille avec les plages de domaines "
+#~ "respectives comme suit :<br /> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> "
+#~ "(10k-30k) et <b>L</b> (30k-80k) devrait fonctionner pour des appareils de "
+#~ "128 MByte,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) devrait fonctionner "
+#~ "pour les appareils de 256 à 512 Mo,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) "
+#~ "a besoin de plus de RAM et de support Multicore, par exemple des "
+#~ "appareils x86 ou Raspberry.<br /> <p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "Réinitialise la liste de blocage DNS finale \"adb_list.overall\" après le "
+#~ "chargement du backend DNS. Veuillez noter : Cette option démarre un petit "
+#~ "moniteur ubus/adblock en arrière-plan."
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "Définir/remplacer un nouveau travail d'adblock"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Répertoire cible pour les fichiers de rapports liés au DNS. La valeur par "
+#~ "défaut est '/tmp', veuillez utiliser plutot une clé usb ou un disque "
+#~ "local."
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Répertoire cible pour les sauvegardes des listes de blocage. La valeur "
+#~ "par défaut est '/tmp', veuillez utiliser de préférence une clé usb ou un "
+#~ "autre disque local."
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr ""
+#~ "Ceci montre le dernier rapport DNS généré, appuyez sur le bouton de "
+#~ "rafraîchissement pour en obtenir un actuel."

--- a/applications/luci-app-adblock/po/he/adblock.po
+++ b/applications/luci-app-adblock/po/he/adblock.po
@@ -11,16 +11,16 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -49,43 +49,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,11 +98,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -110,11 +110,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,15 +122,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -141,21 +141,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "ביטול"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -169,95 +168,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -271,31 +266,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -305,11 +300,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -319,42 +314,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -362,59 +357,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -423,7 +410,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -444,7 +431,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -456,23 +443,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -480,7 +467,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -492,156 +478,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "הגדרות"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -675,17 +664,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -695,19 +684,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -716,7 +705,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -727,15 +721,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -743,14 +737,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hi/adblock.po
+++ b/applications/luci-app-adblock/po/hi/adblock.po
@@ -4,16 +4,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -42,43 +42,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -91,11 +91,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -103,11 +103,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -115,15 +115,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,21 +134,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -162,95 +161,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -264,31 +259,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -298,11 +293,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -312,42 +307,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -355,59 +350,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -416,7 +403,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -437,7 +424,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -449,23 +436,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -473,7 +460,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -485,156 +471,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -668,17 +657,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -688,19 +677,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -709,7 +698,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -720,15 +714,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,14 +730,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hu/adblock.po
+++ b/applications/luci-app-adblock/po/hu/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Művelet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -48,45 +48,45 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "További aktiválókésleltetés másodpercben, mielőtt a reklámblokkolás "
 "feldolgozása elkezdődik."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Válasz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Biztonsági mentés könyvtára"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -99,11 +99,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -111,11 +111,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Blokkolt tartomány"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -123,15 +123,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Blokkolási lista forrásai"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -142,21 +142,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Mégse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Ügyfél"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -170,95 +169,91 @@ msgstr ""
 msgid "Count"
 msgstr "Darabszám"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS könyvtár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS fájlvisszaállítás"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Tartomány"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "E-mail értesítés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "E-mail fogadócím"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -272,31 +267,31 @@ msgstr "Feketelista szerkesztése"
 msgid "Edit Whitelist"
 msgstr "Fehérlista szerkesztése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -306,11 +301,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -320,42 +315,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "DNS gyorsítótár kiürítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Helyi DNS kényszerítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Általános Beállítások"
 
@@ -363,59 +358,51 @@ msgstr "Általános Beállítások"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Utolsó futás"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "A támogatott és teljesen előre beállított letöltési segédprogramok listája."
@@ -425,7 +412,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Alacsony prioritású szolgáltatás"
 
@@ -446,7 +433,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -458,23 +445,23 @@ msgstr "Lekérdezés"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Fogadó címe a reklámblokkoló értesítési e-mailekhez."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -482,7 +469,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Frissítés"
 
@@ -494,156 +480,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Darabok számának jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Darabok méretének jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Könyvtár jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Csatoló jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Mentés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Felfüggesztés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Célkönyvtár az előállított „adb_list.overall” blokkolási listához."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -679,17 +668,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Idő"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -699,19 +688,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
@@ -720,7 +709,12 @@ msgstr "Aktiváló késleltetése"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
@@ -731,15 +725,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -747,14 +741,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS fájlvisszaállítás"

--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -13,16 +13,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Action"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Sorgenti attive"
 
@@ -51,43 +51,43 @@ msgstr "Aggiungi questo (sotto)dominio alla tua lista nera locale."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Aggiungi questo (sotto)dominio alla tua lista bianca locale."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Impostazioni aggiuntive"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Tempo addizionale in secondi di attesa prima che adblock si avvii."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Impostazioni DNS avanzate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Impostazioni E-Mail avanzate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Impostazioni avanzate dei report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Risposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Directory del Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -100,11 +100,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -112,11 +112,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Domini bloccati"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -124,15 +124,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Fonti lista di Blocco"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -143,23 +143,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Annulla"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"I cambiamenti effetuati in questa pagina richiedono un riavvio completo del "
-"servizio adblock per essere applicati.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -177,7 +174,7 @@ msgstr ""
 msgid "Count"
 msgstr "Numero"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -185,89 +182,85 @@ msgstr ""
 "Crea dei backup delle liste di blocco comrpessi, saranno usati "
 "nell'evenienza di errori nello scaricamento o all'avvio."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "Backend DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Directory DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Reset File DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Report del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Tempo di riavvio del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Utilità di Scaricamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Notifica E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail destinatario"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -281,31 +274,31 @@ msgstr "Modifica Lista Nera"
 msgid "Edit Whitelist"
 msgstr "Modifica Lista Bianca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Inglese (sviluppatore)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -315,11 +308,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -329,42 +322,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Pulisci Cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Forza DNS Locale"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Impostazioni generali"
 
@@ -372,59 +365,51 @@ msgstr "Impostazioni generali"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Ultimo Avvio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Elenco delle utility di download supportate e completamente preconfigurate."
@@ -434,7 +419,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Serviio a bassa priorità"
 
@@ -455,7 +440,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Riassunto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -467,24 +452,24 @@ msgstr "Interrogazione"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Indirizzo del destinatario per e-mail di notifica di blocco degli annunci."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -492,7 +477,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Ricaricare"
 
@@ -504,156 +488,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Directory dei report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Salva"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Sospendi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Directory per la lista di blocco generata 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -688,17 +675,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -708,19 +695,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Ritardo Innesco"
 
@@ -729,7 +716,12 @@ msgstr "Ritardo Innesco"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Registro di Debug Dettagliato"
 
@@ -740,15 +732,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -756,14 +748,24 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "I cambiamenti effetuati in questa pagina richiedono un riavvio completo "
+#~ "del servizio adblock per essere applicati.<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Reset File DNS"

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -13,16 +13,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "詳細不明"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "アクション"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "アクティブなソース"
 
@@ -51,43 +51,43 @@ msgstr "この(サブ)ドメインをローカルのブラックリストに追�
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "この(サブ)ドメインをローカルのホワイトリストに追加します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "追加のJailブロックリスト"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "追加設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Adblock の処理が開始されるまでの、追加の遅延時間（秒）です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "DNS の詳細設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Eメールの詳細設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "リポートの詳細設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "バックアップ先 ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "ベースとなるテンポラリディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -103,11 +103,11 @@ msgid ""
 msgstr ""
 "ブラックリストへの変更が保存されました。adblockを更新して変更を適用します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "ブラックリスト..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "ブロックされたDNSリクエスト"
 
@@ -115,11 +115,11 @@ msgstr "ブロックされたDNSリクエスト"
 msgid "Blocked Domain"
 msgstr "ブロックされたドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "ブロックされたドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "ブロックリストのバックアップ"
 
@@ -127,15 +127,15 @@ msgstr "ブロックリストのバックアップ"
 msgid "Blocklist Query"
 msgstr "ブロックリストのクエリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "ブロックリストのクエリ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "ブロックリスト提供元"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,23 +149,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"このタブでの変更を適用するにはadblockサービスを完全に再起動する必要がありま"
-"す。<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "クライアント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -183,7 +180,7 @@ msgstr ""
 msgid "Count"
 msgstr "カウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -191,42 +188,38 @@ msgstr ""
 "圧縮されたブロックリストのバックアップを作成します。ダウンロードエラーや起動"
 "時に使用されます。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "DNSバックエンド"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS ファイル リセット"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNSレポート"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "DNS再起動タイムアウト"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "日付"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "DNS許可を無効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "DNS再起動を無効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -234,48 +227,48 @@ msgstr ""
 "autoload/inotify機能を使用してDNSバックエンドのadblockの再起動トリガーを無効"
 "にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "セレクティブDNSホワイトリスティングを無効化(RPZパススルー)。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "ドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "ダウンロードのパラメータ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "ダウンロードキュー"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "ダウンロードユーティリティ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Eメール通知数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "Eメールプロファイル"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Eメール送信者アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Eメールトピック"
 
@@ -289,31 +282,31 @@ msgstr "ブラックリストの編集"
 msgid "Edit Whitelist"
 msgstr "ホワイトリストの編集"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "セーフサーチを有効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "youtube用の適度なセーフサーチフィルタを有効にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "adblockサービスを有効にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "エラーが発生した際に詳細なデバッグロギングを有効にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "有効"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "終了タイムスタンプ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -325,11 +318,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "既存のジョブ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "外部DNSルックアップドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -341,35 +334,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "日付、ドメイン、クライアントなどのフィルター基準(オプション)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "DNS キャッシュのクリア"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "adblockが正常に動くようにするため、事前にDNSキャッシュをクリアします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "ローカル DNS の強制"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -379,7 +372,7 @@ msgstr ""
 "ポートを提供します。 注意: これを有効にするには、追加の「tcpdump-mini」パッ"
 "ケージのインストールと完全なadblockサービスの再起動が必要です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -387,35 +380,39 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app adblock"
 msgstr "LuCIアプリのadblockへのアクセスを許可"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "情報"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Jailディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "最終実行"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "最新のDNSリクエスト"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "セーフサーチを制限"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "セーフサーチを特定のプロバイダに制限します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdumpが使用する利用可能なネットワークデバイス一覧です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -423,7 +420,7 @@ msgstr ""
 "adblockの開始をトリガーできるネットワークインターフェース一覧です。未指定を選"
 "択するとトリガーの代わりに従来のスタートアップタイムアウトを使用します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -431,19 +428,7 @@ msgstr ""
 "デフォルトのリストディレクトリを使用するDNSバックエンド一覧です。デフォルトの"
 "パスを上書きするには'DNSディレクトリ'オプションを使用してください。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "サポートされ、かつ設定済のダウンロード ユーティリティの一覧です。"
 
@@ -452,7 +437,7 @@ msgstr "サポートされ、かつ設定済のダウンロード ユーティ�
 msgid "Log View"
 msgstr "ログビュー"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "優先度が低いサービス"
 
@@ -473,7 +458,7 @@ msgstr "まだadblolck関連のログがありません！"
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp'をadblock通知Eメールに使用するプロファイル。"
 
@@ -485,7 +470,7 @@ msgstr "検索"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "特定のドメインのアクティブなブロックリストとバックアップを検索します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -493,17 +478,17 @@ msgstr ""
 "通知数を上げて、ブロックリスト全体の数が指定された制限以下の場合に電子メール"
 "を取得します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知メールの受信アドレスです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -514,7 +499,6 @@ msgstr ""
 "す。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "リフレッシュ"
 
@@ -526,83 +510,85 @@ msgstr "DNSリポートをリフレッシュ"
 msgid "Refresh Timer"
 msgstr "リフレッシュタイマー"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "タイマーをリフレッシュ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "リフレッシュ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "リラックスセーフサーチ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "レポート チャンクカウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "レポート チャンクサイズ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "レポート インターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "レポートポート"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "tcpdumpによって使用されるレポートチャンク数。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "tcpdumpがメガバイト単位で使用するレポートチャンクサイズ。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"DNSバックエンドの読み込み後に、最後のDNSブロックリスト'adb_list.overlall'をリ"
-"セットします。注意: このオプションはバックグラウンドで小さなubus/adblockモニ"
-"ターを起動します。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "結果"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "実行ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "実行フラグ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "実行インターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "実行ユーティリティー"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -610,19 +596,19 @@ msgstr ""
 "adblock関連の通知Eメールを送信します。注意: これは追加の'msmtp'パッケージのイ"
 "ンストールが必要です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr "adblockの通知Eメール送信者アドレス。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "新しいadblockジョブの設定/置き換え"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -630,65 +616,58 @@ msgstr ""
 "ダウンロード処理(並べ替え、統合など)のダウンロードキューのサイズを並列で指定"
 "します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "ソース(サイズ、フォーカス)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdumpが使用するポートの、スペースで区切られたリスト。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr "選択したダウンロードユーティリティーの特別な設定オプション。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "開始タイムスタンプ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "起動時トリガーインターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "ステータス / バージョン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "一時停止"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"DNS関連のレポートファイルのターゲットディレクトリです。デフォルトは'/tmp'で"
-"す。可能ならばUSBメモリまたは別のローカルディスクを使用してください。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"ブロックリストのバックアップに使用されるターゲットディレクトリです。デフォル"
-"トは'/tmp'です。可能ならばUSBメモリまたは別のローカルディスクを使用してくださ"
-"い。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成されたブロックリスト 'adb_list.overall' の保存先ディレクトリです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "生成されたjailブロックリスト'adb_list.jail'のターゲットディレクトリです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "リフレッシュタイマーを更新できませんでした。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "リフレッシュタイマーが更新されました。"
 
@@ -728,19 +707,17 @@ msgstr ""
 "す。<br /> 注意: 1行につきドメインを1つだけ追加してください。'#'で始まるコメ"
 "ントを追加できます - IPアドレス、ワイルドカード、正規表現は使用できません。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
-"最後に生成されたDNSレポートを表示しています。更新ボタンを押して現在の状況を表"
-"示します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "時刻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "DNSバックエンドの再起動が成功するまでのタイムアウト。"
 
@@ -752,19 +729,19 @@ msgstr ""
 "adblockリストを常に最新にするには、自動更新をこれらのリストに設定する必要があ"
 "ります。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "上位10項目"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr "adblockの通知Eメールのトピック。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "DNSリクエスト合計"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
@@ -773,7 +750,12 @@ msgstr "トリガ遅延"
 msgid "Unable to save changes: %s"
 msgstr "変更を保存できませんでした: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
@@ -786,15 +768,15 @@ msgstr ""
 "ホワイトリストへの変更が保存されました。adblockのリストを更新して変更を適用し"
 "ます。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "ホワイトリスト..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -802,14 +784,59 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "最大の結果セットサイズ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "このタブでの変更を適用するにはadblockサービスを完全に再起動する必要があり"
+#~ "ます。<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS ファイル リセット"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "DNSバックエンドの読み込み後に、最後のDNSブロックリスト'adb_list."
+#~ "overlall'をリセットします。注意: このオプションはバックグラウンドで小さな"
+#~ "ubus/adblockモニターを起動します。"
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "新しいadblockジョブの設定/置き換え"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "DNS関連のレポートファイルのターゲットディレクトリです。デフォルトは'/"
+#~ "tmp'です。可能ならばUSBメモリまたは別のローカルディスクを使用してくださ"
+#~ "い。"
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "ブロックリストのバックアップに使用されるターゲットディレクトリです。デフォ"
+#~ "ルトは'/tmp'です。可能ならばUSBメモリまたは別のローカルディスクを使用して"
+#~ "ください。"
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr ""
+#~ "最後に生成されたDNSレポートを表示しています。更新ボタンを押して現在の状況"
+#~ "を表示します。"

--- a/applications/luci-app-adblock/po/ko/adblock.po
+++ b/applications/luci-app-adblock/po/ko/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "- 명시되지 않음 -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "액션"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "활성화된 소스"
 
@@ -48,45 +48,45 @@ msgstr "이 (서브)도메인을 로컬 블랙리스트에 추가."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "이 (서브)도메인을 로컬 화이트리스트에 추가."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "추가적인 Jail 블록리스트"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "추가 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "고급 DNS 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "고급 이메일 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "고급 리포트 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 #, fuzzy
 msgid "Answer"
 msgstr "답변"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 #, fuzzy
 msgid "Backup Directory"
 msgstr "백업 경로"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -101,11 +101,11 @@ msgstr ""
 "블랙리스트 변경사항이 저장되었습니다. Adblock 리스트를 새로고침하여 변경사항"
 "을 적용하세요."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "블랙리스트..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "차단된 DNS 요청"
 
@@ -113,11 +113,11 @@ msgstr "차단된 DNS 요청"
 msgid "Blocked Domain"
 msgstr "차단된 도메인"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "차단된 도메인들"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "차단목록 백업"
 
@@ -125,15 +125,15 @@ msgstr "차단목록 백업"
 msgid "Blocklist Query"
 msgstr "블록리스트 쿼리"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "블록리스트 등록..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -144,21 +144,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "취소"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -172,95 +171,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -274,31 +269,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -308,11 +303,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -322,42 +317,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "기본 설정"
 
@@ -365,59 +360,51 @@ msgstr "기본 설정"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -426,7 +413,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -447,7 +434,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -459,23 +446,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -483,7 +470,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -495,156 +481,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -678,17 +667,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -698,19 +687,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -719,7 +708,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -730,15 +724,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -746,14 +740,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/mr/adblock.po
+++ b/applications/luci-app-adblock/po/mr/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -48,43 +48,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -97,11 +97,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -109,11 +109,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,15 +121,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,21 +140,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -168,95 +167,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,31 +265,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "सक्षम केले"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -304,11 +299,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -318,42 +313,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -361,59 +356,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -422,7 +409,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -443,7 +430,7 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -455,23 +442,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -479,7 +466,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -491,156 +477,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -674,17 +663,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -694,19 +683,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -715,7 +704,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -726,15 +720,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -742,14 +736,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ms/adblock.po
+++ b/applications/luci-app-adblock/po/ms/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Tindakan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -48,43 +48,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Terdapat kelewatan picu dalam saat sebelum proses adblock bermula."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Jawapan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Direktori Sandaran"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -97,11 +97,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -109,11 +109,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Kawasan Liputan Yang telah disekat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -121,15 +121,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Punca Senarai Sekatan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,21 +140,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Pelanggan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -168,95 +167,91 @@ msgstr ""
 msgid "Count"
 msgstr "Kiraan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Direktori DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Reset fail DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Tarikh"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,31 +265,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -304,11 +299,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -318,42 +313,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -361,59 +356,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -422,7 +409,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -443,7 +430,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -455,23 +442,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -479,7 +466,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -491,156 +477,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -674,17 +663,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -694,19 +683,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -715,7 +704,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -726,15 +720,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -742,14 +736,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Reset fail DNS"

--- a/applications/luci-app-adblock/po/nb_NO/adblock.po
+++ b/applications/luci-app-adblock/po/nb_NO/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "- ubestemt -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Handling"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Aktive kilder"
 
@@ -48,45 +48,45 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Ytterligere innstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligere utløserforsinkelse i sekunder før behandling av "
 "reklameblokkering starter."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Avanserte DNS-innstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Avanserte e-postinnstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Avanserte rapporteringsinnstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Sikkerhetskopimappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -99,11 +99,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Blokkerte DNS-forespørsler"
 
@@ -111,11 +111,11 @@ msgstr "Blokkerte DNS-forespørsler"
 msgid "Blocked Domain"
 msgstr "Blokkert domene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Blokkerte domener"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Blokkeringslistesikkerhetskopi"
 
@@ -123,15 +123,15 @@ msgstr "Blokkeringslistesikkerhetskopi"
 msgid "Blocklist Query"
 msgstr "Blokkeringslistespørring"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Blokkeringslistespørring …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Blokklistekilder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -142,21 +142,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -170,95 +169,91 @@ msgstr ""
 msgid "Count"
 msgstr "Antall"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS-mappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS-filtilbakestilling"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-rapport"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "DNS-omstartstidsavbrudd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Dato"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Skru av DNS-tillatelse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Skru av DNS-omstarter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Nedlastingsparametre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Nedlastingskø"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "E-postmerknad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "E-postmerknadsantall"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagersadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "E-postsenderadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "E-postemne"
 
@@ -272,32 +267,32 @@ msgstr "Rediger svarteliste"
 msgid "Edit Whitelist"
 msgstr "Rediger hvitliste"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Skru på SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 #, fuzzy
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Skru på moderate SafeSearch-filtre for YouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Aktivert"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -307,11 +302,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -321,42 +316,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Tøm DNS-hurtiglageret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Tving lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -364,59 +359,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr "Innvilg tilgang til LuCI-programreklameblokkering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Info"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Fengselsmappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Sist kjørt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Siste DNS-forespørsler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "Begrens SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "Begrens SafeSearch til gitte tilbydere."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste over tilgjengelige nettverksenheter brukt av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -425,7 +412,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Loggvisning"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Lavprioritetstjeneste"
 
@@ -446,7 +433,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -458,23 +445,23 @@ msgstr "Spørring"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -482,7 +469,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Gjenoppfrisk"
 
@@ -494,156 +480,159 @@ msgstr "Gjenoppfrisk DNS-rapport"
 msgid "Refresh Timer"
 msgstr "Gjenoppfrisk tidsur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Gjenoppfrisk tidsur …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Gjenoppfrisk …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Rapportmappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Rapportgrensesnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Rapportporter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Resultat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Lagre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Status/versjon"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -677,17 +666,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Tid"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -697,19 +686,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "Topp 10-statistikk"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Utløserforsinkelse"
 
@@ -718,7 +707,12 @@ msgstr "Utløserforsinkelse"
 msgid "Unable to save changes: %s"
 msgstr "Kunne ikke lagre endringer: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -729,15 +723,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "Hvitliste …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -745,14 +739,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS-filtilbakestilling"

--- a/applications/luci-app-adblock/po/pl/adblock.po
+++ b/applications/luci-app-adblock/po/pl/adblock.po
@@ -11,16 +11,16 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "- nieokreślony -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akcja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Aktywne źródła"
 
@@ -49,45 +49,45 @@ msgstr "Dodaj tę (sub-)domenę do Twojej lokalnej czarnej listy."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Dodaj tę (pod-)domenę do Twojej lokalnej białej listy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Dodatkowa lista blokująca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Dodatkowe ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalacza w sekundach przed rozpoczęciem przetwarzania "
 "adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Ustawienia DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Zaawansowane ustawienia e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Ustawienia raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Odpowiedź"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Katalog kopii zapasowej"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Podstawowy katalog tymczasowy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,11 +104,11 @@ msgstr ""
 "Zmiany czarnej listy zostały zapisane. Odśwież listę adblocków, aby zmiany "
 "zostały wprowadzone."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Czarna lista..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Zablokowane żądania DNS"
 
@@ -116,11 +116,11 @@ msgstr "Zablokowane żądania DNS"
 msgid "Blocked Domain"
 msgstr "Zablokowana domena"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Zablokowane domeny"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Kopia zapasowa list blokujących"
 
@@ -128,15 +128,15 @@ msgstr "Kopia zapasowa list blokujących"
 msgid "Blocklist Query"
 msgstr "Zapytanie do list blokujących"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Zapytanie..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Źródła czarnej listy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -151,23 +151,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"Zmiany na tej karcie wymagają ponownego uruchomienia usługi Adblock, aby "
-"zostały wprowadzone. <br /> <p> &#xa0; </p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,7 +182,7 @@ msgstr ""
 msgid "Count"
 msgstr "Licznik"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -193,42 +190,38 @@ msgstr ""
 "Tworzenie skompresowanej kopii zapasowej list, będzie używana w przypadku "
 "błędów pobierania lub podczas startu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "Zaplecze DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Katalog DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Resetuj plik DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Raport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Limit czasu restartu DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Wyłącz pozwolenie na DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Wyłącz restart DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -236,48 +229,48 @@ msgstr ""
 "Wyłącz wyzwalane restarty adblocka dla zaplecza DNS z funkcjami Autoload/"
 "Inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domena"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Parametry pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Kolejka pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Powiadomienie e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Licznik powiadomień e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "Profil e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Adres e-mail odbiorcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Adres e-mail nadawcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Temat e-mail"
 
@@ -291,32 +284,32 @@ msgstr "Czarna lista"
 msgid "Edit Whitelist"
 msgstr "Biała lista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Włącz SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Włącz umiarkowane filtry SafeSearch dla youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Włącz usługę adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Włącz pełne rejestrowanie debugowania w przypadku błędów przetwarzania."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Włączone"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "Sygnatura czasowa zakończenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -328,11 +321,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Istniejące zadania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Zewnętrzna domena wyszukiwania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -345,35 +338,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Kryteria filtrowania takie jak data, domena lub klient (opcjonalnie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "Porty zapory, które powinny być wymuszane lokalnie."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr "Strefy źródłowe zapory, które powinny być wymuszane lokalnie."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Opróżnij pamięć podręczną DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Wymuś lokalny DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "Wymuszone porty"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "Strefy wymuszone"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -383,7 +376,7 @@ msgstr ""
 "dostarczaj raport DNS. Uwaga: wymaga to dodatkowej instalacji pakietu "
 "'tcpdump-mini' i pełnego ponownego uruchomienia usługi adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
@@ -391,35 +384,39 @@ msgstr "Ustawienia główne"
 msgid "Grant access to LuCI app adblock"
 msgstr "Udziel dostępu LuCI do aplikacji adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Informacje"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Katalog więzienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Ostatnie uruchomienie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Ostatnie zapytania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "Limit SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limit SafeSearch dla certyfikowanych dostawców."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dostępnych urządzeń sieciowych używanych przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -428,7 +425,7 @@ msgstr ""
 "'nieokreślone', aby użyć klasycznego limitu czasu uruchamiania zamiast "
 "wyzwalacza sieciowego."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -436,29 +433,7 @@ msgstr ""
 "Lista obsługiwanych zapleczy DNS z domyślnym katalogiem list. Aby zastąpić "
 "domyślną ścieżkę, użyj opcji 'Katalog DNS'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Lista obsługiwanych i w pełni skonfigurowanych źródeł adblock, niektóre "
-"aktywne źródła są wstępnie wybrane. <br /> <b> <em> Aby uniknąć błędów OOM, "
-"nie wybieraj zbyt wielu list! </em> </b> <br /> Informacje o rozmiarze dla "
-"odpowiednich zakresów domen wyglądają w następujący sposób:<br /> &#8226;"
-"&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) i <b>L</b> (30k-80k) powinny "
-"działać na urządzeniach z 128 MB pamięci RAM<br /> &#8226;&#xa0;<b>XL</b> "
-"(80k-200k) powinny działać na urządzeniach z 256-512 MB pamięci RAM,<br /> "
-"&#8226;&#xa0;<b>XXL</b> (200k-) wymagają więcej pamięci RAM i obsługi "
-"wielordzeniowej, np. urządzenia x86 lub urządzenia typu raspberry.<br /> "
-"<p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista obsługiwanych i wstępnie skonfigurowanych narzędzi do pobierania."
@@ -468,7 +443,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Widok dziennika"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Usługa niskopriorytetowa"
 
@@ -489,7 +464,7 @@ msgstr "Brak dzienników związanych z adblockiem!"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil używany przez 'msmtp' do powiadamiania o blokadzie e-mail."
 
@@ -503,7 +478,7 @@ msgstr ""
 "Wysyłaj zapytania do aktywnych list blokowania i kopii zapasowych dla "
 "określonej domeny."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -511,11 +486,11 @@ msgstr ""
 "Zwiększ liczbę powiadomień, aby otrzymywać wiadomości e-mail jeśli ogólna "
 "liczba blokowanych list jest mniejsza lub równa podanemu limitowi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adres odbiorcy dla powiadomień e-mail adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -523,7 +498,7 @@ msgstr ""
 "Przekieruj wszystkie zapytania DNS z określonych stref do lokalnego "
 "resolwera DNS, dotyczy protokołów UDP i TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -533,7 +508,6 @@ msgstr ""
 "Uwaga: wymagany restart usługi adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Odśwież"
 
@@ -545,82 +519,85 @@ msgstr "Odśwież raport DNS"
 msgid "Refresh Timer"
 msgstr "Odśwież zegar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Odśwież zegar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Odświeżanie..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "Odpoczynek SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Zgłoś liczbę fragmentów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Zgłoś wielkość porcji"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Katalog raportów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Interfejs raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Porty raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "Raportuj liczbę fragmentów używaną przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Raportuj wielkość fragmentów używaną przez tcpdump w MB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"Resetuje ostateczną listę bloków DNS 'adb_list.overall' po załadowaniu "
-"zaplecza DNS. Uwaga: Ta opcja uruchamia w tle mały monitor ubus/adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Wynik"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Uruchomione katalogi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "Uruchomione flagi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Uruchomione interfejsy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "Uruchomione narzędzia"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Zapisz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -628,19 +605,19 @@ msgstr ""
 "Wysyłaj powiadomienia e-mail związane z adblock. Uwaga: wymaga to dodatkowej "
 "instalacji pakietu 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adres nadawcy dla powiadomień e-mailowych adblocka."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "Ustaw/Zmień nowe zadanie Adblock"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -648,65 +625,59 @@ msgstr ""
 "Rozmiar kolejki pobierania do przetwarzania plików (w tym sortowanie, "
 "łączenie itp.) równolegle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "Źródła (wielkość, skupienie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Rozdzielona spacjami lista portów używanych przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr "Specjalne opcje konfiguracji dla wybranego narzędzia do pobierania."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "Sygnatura czasowa uruchamiania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "Interfejs wyzwalacza uruchamiania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Status/Wersja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Zawieś"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"Katalog docelowy dla plików raportowania. Domyślnie jest to '/ tmp', "
-"najlepiej użyj pamięci USB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"Katalog docelowy dla kopii zapasowej list. Domyślnie jest to '/tmp', użyj "
-"najlepiej pamięci USB lub innego dysku."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy blokowania 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy zablokowanych 'adb_list.jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "Nie można zaktualizować odświeżania zegara."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "Odświeżanie zegara zostało zaktualizowane."
 
@@ -749,19 +720,17 @@ msgstr ""
 "<br /> Uwaga: dodaj tylko jedną domenę na linię. Komentarze wprowadzone z "
 "'#' są dozwolone - adresy ip, wildcards i regex nie są dozwolone."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
-"Pokazuje ostatni wygenerowany raport DNS, naciśnij przycisk odświeżania, aby "
-"uzyskać bieżący."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Czas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Limit czasu oczekiwania na pomyślne ponowne uruchomienie zaplecza DNS."
 
@@ -773,19 +742,19 @@ msgstr ""
 "Aby twoje listy były aktualne, powinieneś ustawić automatyczne zadanie "
 "aktualizacji dla tych list."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "Top 10"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr "Temat dla powiadomień e-mail adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "Łączna liczba żądań DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
@@ -794,7 +763,12 @@ msgstr "Opóźnienie wyzwalacza"
 msgid "Unable to save changes: %s"
 msgstr "Nie można zapisać zmian: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
@@ -807,15 +781,15 @@ msgstr ""
 "Zmiany na białej liście zostały zapisane. Odśwież listę, aby zmiany zostały "
 "wprowadzone."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "Biała lista ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -823,14 +797,78 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "maks. rozmiar zestawu wyników"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Zmiany na tej karcie wymagają ponownego uruchomienia usługi Adblock, aby "
+#~ "zostały wprowadzone. <br /> <p> &#xa0; </p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Resetuj plik DNS"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Lista obsługiwanych i w pełni skonfigurowanych źródeł adblock, niektóre "
+#~ "aktywne źródła są wstępnie wybrane. <br /> <b> <em> Aby uniknąć błędów "
+#~ "OOM, nie wybieraj zbyt wielu list! </em> </b> <br /> Informacje o "
+#~ "rozmiarze dla odpowiednich zakresów domen wyglądają w następujący sposób:"
+#~ "<br /> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) i <b>L</b> "
+#~ "(30k-80k) powinny działać na urządzeniach z 128 MB pamięci RAM<br /> "
+#~ "&#8226;&#xa0;<b>XL</b> (80k-200k) powinny działać na urządzeniach z "
+#~ "256-512 MB pamięci RAM,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) wymagają "
+#~ "więcej pamięci RAM i obsługi wielordzeniowej, np. urządzenia x86 lub "
+#~ "urządzenia typu raspberry.<br /> <p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "Resetuje ostateczną listę bloków DNS 'adb_list.overall' po załadowaniu "
+#~ "zaplecza DNS. Uwaga: Ta opcja uruchamia w tle mały monitor ubus/adblock."
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "Ustaw/Zmień nowe zadanie Adblock"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Katalog docelowy dla plików raportowania. Domyślnie jest to '/ tmp', "
+#~ "najlepiej użyj pamięci USB."
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Katalog docelowy dla kopii zapasowej list. Domyślnie jest to '/tmp', użyj "
+#~ "najlepiej pamięci USB lub innego dysku."
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr ""
+#~ "Pokazuje ostatni wygenerowany raport DNS, naciśnij przycisk odświeżania, "
+#~ "aby uzyskać bieżący."

--- a/applications/luci-app-adblock/po/pt/adblock.po
+++ b/applications/luci-app-adblock/po/pt/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.4.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "- não especificado -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Fontes Ativas"
 
@@ -48,45 +48,45 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Priosional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso adicional do gatilho em segundos antes do processamento do adblock "
 "começar."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Configurações Avançadas do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Configurações Avançadas do E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Configurações Avançadas do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Diretório do Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,11 +104,11 @@ msgstr ""
 "As alterações na lista negra foram gravadas. Atualize as suas listas de "
 "adblock para que as alterações entrem em vigor."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Solicitações de DNS bloqueadas"
 
@@ -116,11 +116,11 @@ msgstr "Solicitações de DNS bloqueadas"
 msgid "Blocked Domain"
 msgstr "Domínio Bloqueado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -128,15 +128,15 @@ msgstr "Cópia de Segurança da Lista de Bloqueio"
 msgid "Blocklist Query"
 msgstr "Consulta na Lista de Bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Pesquisando a Lista de Bloqueio..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Origem da Blocklist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -151,23 +151,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"As alterações nesta guia precisam de uma reinicialização completa do serviço "
-"adblock para entrar em vigor.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,7 +182,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -193,42 +190,38 @@ msgstr ""
 "Crie cópias de segurança compactados da lista de bloqueio, estes serão "
 "usados em caso de erros de descarregamento ou durante a inicialização."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Repor o ficheiro DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -236,48 +229,48 @@ msgstr ""
 "Desativar o adblock que causar a reinicialização das funções autoload/"
 "inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desativa a lista branca seletiva do DNS (passagem pelo RPZ)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Parâmetros de Descarregamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Fila de Descarregamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Ferramenta para Descarregar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Notificação por e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "Perfil de e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de e-mail do destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Endereço de e-mail do remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Assunto do e-mail"
 
@@ -291,33 +284,33 @@ msgstr "Editar Lista Negra"
 msgid "Edit Whitelist"
 msgstr "Editar lista de permissões"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Ativar o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Ativar os filtros SafeSearch de forma moderada para o Youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Ativar o serviço adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registo de depuração detalhado para casos de todos os erros de "
 "processamento."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "Carimbo de tempo final"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -329,11 +322,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -346,35 +339,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "Portas da firewall que devem ser localmente forçadas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas fonte da firewall que devem ser localmente forçadas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Limpar o cache de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também limpar o Cache do DNS antes do adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Forçar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "Portas forçadas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "Zonas forçadas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -385,7 +378,7 @@ msgstr ""
 "pacote 'tcpdump-mini' e a reinicialização completa do serviço do adblock "
 "para que as modificações entrem em vigor."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Configurações gerais"
 
@@ -393,35 +386,39 @@ msgstr "Configurações gerais"
 msgid "Grant access to LuCI app adblock"
 msgstr "Conceder acesso à app LuCI adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Informação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "Limite do SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limite o SafeSearch a determinados provedores."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de aparelhos da rede disponíveis que foram usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -430,7 +427,7 @@ msgstr ""
 "'não especificado' para usar um tempo de inicialização clássico em vez de um "
 "gatilho de rede."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -439,28 +436,7 @@ msgstr ""
 "de diretório. Para substituir o caminho predefinido, use a opção 'Diretório "
 "DNS'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Listagem das fontes de adblock compatíveis e totalmente pré-configuradas, as "
-"fontes já ativas estão pré-selecionadas.<br /> <b><em>Para evitar erros do "
-"tipo OOM, não selecione muitas listas!</em></b><br /> Lista o tamanho da "
-"informação com as suas respetivas faixas de domínio da seguinte maneira:<br /"
-"> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) e <b>L</b> (30k-80k) deve "
-"funcionar para aparelhos com 128 MByte de memória,<br /> &#8226;&#xa0;<b>XL</"
-"b> (80k-200k) deve funcionar com aparelhos com 256-512 MByte de memória,<br /"
-"> &#8226;&#xa0;<b>XXL</b> (200k-) precisa de mais suporte a RAM e Multicore, "
-"por exemplo. x86 ou aparelhos raspberry.<br /> <p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de ferramentas de descarregamento suportadas e completamente pré-"
@@ -471,7 +447,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Vista do registo log"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
@@ -492,7 +468,7 @@ msgstr "Ainda não há registos relacionados ao adblock!"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil dos e-mails de notificação do adblock utilizado por 'msmtp'."
 
@@ -506,7 +482,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -514,11 +490,11 @@ msgstr ""
 "Aumente a contagem de notificações para receber e-mails caso a contagem "
 "geral das listas de bloqueio seja menor ou igual ao limite informado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Endereço do destinatário para e-mails de notificação do adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -526,7 +502,7 @@ msgstr ""
 "Redirecionar todas as consultas DNS de zonas especificadas para o resolvedor "
 "DNS local, aplica-se ao protocolo UDP e TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -537,7 +513,6 @@ msgstr ""
 "reinicialização completa do serviço adblock para que faça efeito."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -549,83 +524,85 @@ msgstr "Atualizar o Relatório do DNS"
 msgid "Refresh Timer"
 msgstr "Atualizar Temporizador"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Atualizando o Temporizador..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Atualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "Alivie o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Relatar Contagem de Porções"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Tamanho de Porções de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Diretório de Relatórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Interface de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"Reinicialisa a lista final de bloqueio do DNS 'adb_list.overall' após o "
-"carregamento da infraestrutura do DNS. Nota: Esta opção inicia um pequeno "
-"monitor ubus/adblock em segundo plano."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Resultado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Executar Diretórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "Flags de Execução"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Executar Interfaces"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "Executar Utilitários"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -633,19 +610,19 @@ msgstr ""
 "Envie e-mails de notificação relacionados ao adblock. Note que: a instalação "
 "adicional do pacote 'msmtp' é necessária."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Endereço E-Mail do remetente para as notificações do adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "Definir/Substituir um novo trabalho de adblock"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -653,70 +630,62 @@ msgstr ""
 "Tamanho da fila de descarregamento para o processamento de descarregamento "
 "(incl. classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de descarregamento "
 "selecionado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "Carimbo de tempo incial"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "Interface do Gatilho de Inicialização"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Condição geral / versão"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"Diretório de destino para os ficheiros de relatório relacionados ao DNS. O "
-"diretório predefinido é '/tmp', use preferencialmente um pendrive ou um "
-"outro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"Diretório de destino para a cópia de segurança das listas de bloqueio. O "
-"diretório predefinido é '/tmp', use preferencialmente um pendrive ou outro "
-"disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Diretório de destino para a lista de blocos 'adb_list.overall' gerada ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
 "prisional 'adb_list.jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "Não foi possível atualizar o tempo de atualização do temporizador."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "O tempo de atualização foi atualizado."
 
@@ -758,19 +727,17 @@ msgstr ""
 "permitidos.<br /> Nota: adicione apenas um domínio por linha. Comentários "
 "introduzidos com '#' são permitidos - endereços ip, curingas e regex não são."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
-"Exibe o último Relatório DNS gerado, pressione o botão de atualização para "
-"obter um atual."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -782,20 +749,20 @@ msgstr ""
 "Para manter as suas listas de adblock atualizadas, deve configurar uma "
 "tarefa de atualização automática para essas listas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos e-mails que serão usados nas notificações do adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "Total de solicitações de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
@@ -804,7 +771,12 @@ msgstr "Atraso do Gatilho"
 msgid "Unable to save changes: %s"
 msgstr "Impossível gravar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Registos detalhados de depuração"
 
@@ -817,15 +789,15 @@ msgstr ""
 "As modificações feitas na lista branca foram salvas. Atualize a sua lista de "
 "adblock para que as modificações feitas tenham efeito."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -833,14 +805,81 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "As alterações nesta guia precisam de uma reinicialização completa do "
+#~ "serviço adblock para entrar em vigor.<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Repor o ficheiro DNS"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Listagem das fontes de adblock compatíveis e totalmente pré-configuradas, "
+#~ "as fontes já ativas estão pré-selecionadas.<br /> <b><em>Para evitar "
+#~ "erros do tipo OOM, não selecione muitas listas!</em></b><br /> Lista o "
+#~ "tamanho da informação com as suas respetivas faixas de domínio da "
+#~ "seguinte maneira:<br /> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) "
+#~ "e <b>L</b> (30k-80k) deve funcionar para aparelhos com 128 MByte de "
+#~ "memória,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) deve funcionar com "
+#~ "aparelhos com 256-512 MByte de memória,<br /> &#8226;&#xa0;<b>XXL</b> "
+#~ "(200k-) precisa de mais suporte a RAM e Multicore, por exemplo. x86 ou "
+#~ "aparelhos raspberry.<br /> <p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "Reinicialisa a lista final de bloqueio do DNS 'adb_list.overall' após o "
+#~ "carregamento da infraestrutura do DNS. Nota: Esta opção inicia um pequeno "
+#~ "monitor ubus/adblock em segundo plano."
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "Definir/Substituir um novo trabalho de adblock"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Diretório de destino para os ficheiros de relatório relacionados ao DNS. "
+#~ "O diretório predefinido é '/tmp', use preferencialmente um pendrive ou um "
+#~ "outro disco local."
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Diretório de destino para a cópia de segurança das listas de bloqueio. O "
+#~ "diretório predefinido é '/tmp', use preferencialmente um pendrive ou "
+#~ "outro disco local."
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr ""
+#~ "Exibe o último Relatório DNS gerado, pressione o botão de atualização "
+#~ "para obter um atual."

--- a/applications/luci-app-adblock/po/pt_BR/adblock.po
+++ b/applications/luci-app-adblock/po/pt_BR/adblock.po
@@ -13,16 +13,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "- não especificado -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Fontes Ativas"
 
@@ -51,45 +51,45 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Adicional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Configurações Adicionais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso de gatilho adicional em segundos antes do processamento do adblock "
 "começar."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Configurações Avançadas do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Configurações Avançadas do E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Configurações Avançadas do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -107,11 +107,11 @@ msgstr ""
 "As alterações na lista negra foram salvas. Atualize as suas listas de "
 "bloqueio de anúncios para que as alterações entrem em vigor."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Requisições bloqueadas do DNS"
 
@@ -119,11 +119,11 @@ msgstr "Requisições bloqueadas do DNS"
 msgid "Blocked Domain"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -131,15 +131,15 @@ msgstr "Cópia de Segurança da Lista de Bloqueio"
 msgid "Blocklist Query"
 msgstr "Consulta na Lista de Bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Pesquisando a Lista de Bloqueio..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Fontes das listas de bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -154,23 +154,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"As alterações nesta guia precisam de uma reinicialização completa do serviço "
-"adblock para entrar em vigor.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -188,7 +185,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -196,42 +193,38 @@ msgstr ""
 "Crie cópias de segurança compactados da lista de bloqueio, estes serão "
 "usados em caso de erros de download ou durante a inicialização."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Zerar Arquivo de DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Dia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -239,48 +232,48 @@ msgstr ""
 "Desative o bloqueador de anúncios que causar a reinicialização das funções "
 "autoload/inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Fila de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -294,33 +287,33 @@ msgstr "Editar a Lista Negra"
 msgid "Edit Whitelist"
 msgstr "Editar a Lista Branca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Ativar o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Ativar os filtros SafeSearch de forma moderada para o youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Ativar o serviço de bloqueio de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registro de depuração detalhada nos casos de qualquer erro de "
 "processamento."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "Fim da marca temporal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -332,11 +325,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -349,35 +342,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "As portas do firewall que devem ser impostas localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas de origem do firewall que devem ser imposta localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Limpar a Cache do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Usar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "Portas Impostas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "Zonas Impostas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -388,7 +381,7 @@ msgstr ""
 "pacote 'tcpdump-mini' e da reinicialização completa do serviço do bloqueio "
 "de anúncios para que as modificações entrem em vigor."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Configurações Gerais"
 
@@ -396,36 +389,40 @@ msgstr "Configurações Gerais"
 msgid "Grant access to LuCI app adblock"
 msgstr "Conceda acesso ao aplicativo LuCI adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "Limite do SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limite o SafeSearch a determinados fornecedores."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Lista de dispositivos da rede disponíveis que foram usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -434,7 +431,7 @@ msgstr ""
 "Escolha 'não especificado' para usar um tempo de inicialização clássico em "
 "vez de um gatilho de rede."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -443,29 +440,7 @@ msgstr ""
 "de diretório. Para substituir o caminho predefinido, use a opção 'Diretório "
 "DNS'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Listagem das fontes de bloqueio de anúncios compatíveis e totalmente pré-"
-"configuradas, as fontes já ativas estão pré-selecionadas.<br /> <b><em>Para "
-"evitar erros do tipo OOM, não selecione muitas listas!</em></b><br /> Lista "
-"o tamanho da informação com as suas respectivas faixas de domínio da "
-"seguinte maneira:<br /> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) e "
-"<b>L</b> (30k-80k) deve funcionar para dispositivos com 128 MByte de memória,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) deve funcionar com dispositivos com "
-"256-512 MByte de memória,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) precisa de "
-"mais suporte a RAM e Multicore, por exemplo. x86 ou dispositivos raspberry."
-"<br /> <p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
 
@@ -474,7 +449,7 @@ msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download.
 msgid "Log View"
 msgstr "Exibir o Registro Log"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
@@ -495,7 +470,7 @@ msgstr "Ainda não há registros relacionados ao bloqueio de anúncio!"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Perfil dos E-Mails de notificação do bloqueio de anúncio utilizado por "
@@ -511,7 +486,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -519,13 +494,13 @@ msgstr ""
 "Aumente a contagem de notificações para receber E-Mails caso a contagem "
 "geral das listas de bloqueio seja menor ou igual ao limite informado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Endereço do E-Mail do destinatário para o recebimento das notificações do "
 "adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -533,7 +508,7 @@ msgstr ""
 "Redirecione todas as consultas DNS das zonas especificadas para o resolvedor "
 "do DNS local, aplica-se ao protocolo UDP e TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -545,7 +520,6 @@ msgstr ""
 "surta efeito."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -557,83 +531,85 @@ msgstr "Atualizar o Relatório do DNS"
 msgid "Refresh Timer"
 msgstr "Atualize o Temporizador"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Atualizando o Temporizador..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Atualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "Alivie o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Contagem de Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Tamanho dos Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Interface do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"Zera a lista final de bloqueio do DNS 'adb_list.overall' após o carregamento "
-"da infraestrutura do DNS. Nota: Esta opção inicia um pequeno monitor ubus/"
-"adblock em segundo plano."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Resultado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Executar Diretórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "Executar Flags"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Executar Interfaces"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "Executar Utilitários"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Salvar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -641,20 +617,20 @@ msgstr ""
 "Envie E-Mails de notificação relacionados ao bloqueio de anúncios. Note que: "
 "é necessário a instalação adicional do pacote 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Endereço E-Mail do remetente para as notificações do bloqueador de anúncios."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "Definir/Substituir um novo trabalho de bloqueio de anúncios"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -662,68 +638,60 @@ msgstr ""
 "Tamanho da fila de download para o processamento de download (incl. "
 "classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de download selecionado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "Início da marca temporal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "Interface do Gatilho de Inicialização"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Condição Geral / Versão"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"Diretório de destino para os arquivos de relatório relacionados ao DNS. O "
-"diretório predefinido é '/tmp', use preferencialmente um pendrive ou um "
-"outro disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"Diretório de destino para a cópia de segurança das listas de bloqueio. O "
-"diretório predefinido é '/tmp', use preferencialmente um pendrive ou outro "
-"disco local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Caminho do diretório para a lista nega gerada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
 "prisional 'adb_list.jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "Não foi possível atualizar o tempo de atualização do temporizador."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "O tempo de atualização foi atualizado."
 
@@ -766,19 +734,17 @@ msgstr ""
 "Comentários introduzidos com '#' são permitidos - endereços ip, curingas e "
 "regex não são."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
-"Exibe o último Relatório DNS gerado, pressione o botão de atualização para "
-"obter um atual."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -790,21 +756,21 @@ msgstr ""
 "Para manter as suas listas de bloqueio de anúncios atualizadas, você deve "
 "configurar uma tarefa de atualização automática para essas listas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos E-Mais que serão usados nas notificações do bloqueador "
 "de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "Total das solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
@@ -813,7 +779,12 @@ msgstr "Gatilho de Atraso"
 msgid "Unable to save changes: %s"
 msgstr "Impossível salvar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
@@ -826,15 +797,15 @@ msgstr ""
 "As modificações feitas na lista branca foram salvas. Atualize a sua lista de "
 "bloqueio de anúncios para que as modificações feitas surtam efeito."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -842,14 +813,81 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "As alterações nesta guia precisam de uma reinicialização completa do "
+#~ "serviço adblock para entrar em vigor.<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Zerar Arquivo de DNS"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Listagem das fontes de bloqueio de anúncios compatíveis e totalmente pré-"
+#~ "configuradas, as fontes já ativas estão pré-selecionadas.<br /> "
+#~ "<b><em>Para evitar erros do tipo OOM, não selecione muitas listas!</em></"
+#~ "b><br /> Lista o tamanho da informação com as suas respectivas faixas de "
+#~ "domínio da seguinte maneira:<br /> &#8226;&#xa0;<b>S</b> (-10k), <b>M</b> "
+#~ "(10k-30k) e <b>L</b> (30k-80k) deve funcionar para dispositivos com 128 "
+#~ "MByte de memória,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) deve funcionar "
+#~ "com dispositivos com 256-512 MByte de memória,<br /> &#8226;&#xa0;<b>XXL</"
+#~ "b> (200k-) precisa de mais suporte a RAM e Multicore, por exemplo. x86 ou "
+#~ "dispositivos raspberry.<br /> <p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "Zera a lista final de bloqueio do DNS 'adb_list.overall' após o "
+#~ "carregamento da infraestrutura do DNS. Nota: Esta opção inicia um pequeno "
+#~ "monitor ubus/adblock em segundo plano."
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "Definir/Substituir um novo trabalho de bloqueio de anúncios"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Diretório de destino para os arquivos de relatório relacionados ao DNS. O "
+#~ "diretório predefinido é '/tmp', use preferencialmente um pendrive ou um "
+#~ "outro disco local."
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Diretório de destino para a cópia de segurança das listas de bloqueio. O "
+#~ "diretório predefinido é '/tmp', use preferencialmente um pendrive ou "
+#~ "outro disco local."
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr ""
+#~ "Exibe o último Relatório DNS gerado, pressione o botão de atualização "
+#~ "para obter um atual."

--- a/applications/luci-app-adblock/po/ro/adblock.po
+++ b/applications/luci-app-adblock/po/ro/adblock.po
@@ -11,16 +11,16 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Actiune"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Surse Active"
 
@@ -49,45 +49,45 @@ msgstr "Adăugați acest (sub) domeniu în lista locală de interzise."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adăugați acest (sub) domeniu la lista locală de admise."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Setări Suplimentare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Întârziere adițională înainte ca procesarea adblock-ului să înceapă (în "
 "secunde)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Setări Avansate DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Setări Avansate E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Setări Avansate Raport"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Răspuns"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Director copie de siguranţă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Director Temporar de Bază"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,11 +104,11 @@ msgstr ""
 "Schimbările la Lista de Interzise au fost salvate. Reîmprospătați lista "
 "adblock pentru ca schimbările să aibă efect."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Lista de Interzise..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -116,11 +116,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Domeniu blocat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Domenii Blocate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Copie de Rezervă Pentru Lista de Blocate"
 
@@ -128,15 +128,15 @@ msgstr "Copie de Rezervă Pentru Lista de Blocate"
 msgid "Blocklist Query"
 msgstr "Interogare Lista de Blocare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Interogare Lista de Blocare..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Surse de blocare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -151,21 +151,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Renunțare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -183,7 +182,7 @@ msgstr ""
 msgid "Count"
 msgstr "Număr"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -191,42 +190,38 @@ msgstr ""
 "Creare copii de rezervă comprimate a listei de blocate, acestea vor fi "
 "utilizate în cazul erorilor de descărcare sau în timpul pornirii."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Director DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Raport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Timp Repornire DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Dezactivare Permite DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Dezactivare Repornire DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -234,48 +229,48 @@ msgstr ""
 "Dezactivează repornirile declanșate de adblock pentru backend-urile dns cu "
 "funcții de autoîncărcare /notificare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domeniu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Descărcare Parametri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Coadă de Descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Notificare e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Număr de Notificări pe E-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "Profil E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Adresa E-Mail Expeditor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Subiect E-Mail"
 
@@ -289,32 +284,32 @@ msgstr "Editare listă neagră"
 msgid "Edit Whitelist"
 msgstr "Editare listă albă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Activare Căutare Sigură"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activare filtre moderate SafeSearch pentru YouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Activare serviciu adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activare înregistrare detaliată de depanare în cazul unor erori de procesare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -326,11 +321,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Activitate(ăți) existentă(e)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Domeniul de căutare DNS extern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -343,35 +338,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterii de filtrare precum dată, domeniu sau client (opțional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Eliberează cache-ul DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Forţează DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -382,7 +377,7 @@ msgstr ""
 "pachetului „tcpdump-mini” și o repornire completă a serviciului de blocare, "
 "pentru a avea efect."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Setări generale"
 
@@ -390,35 +385,39 @@ msgstr "Setări generale"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Informare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Director Închisoare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Ultima rulare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Ultimele Cereri DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dispozitivelor de rețea utilizate de tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -427,7 +426,7 @@ msgstr ""
 "Alegeți „nespecificat” pentru a utiliza un interval de timp de pornire "
 "clasic în loc de declanșarea rețelei."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -435,28 +434,7 @@ msgstr ""
 "Lista DNS-urilor acceptate cu directorul lor al listelor implicite. Pentru a "
 "rescrie calea implicită, utilizați opțiunea „Director DNS”."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Lista surselor acceptate și complet pre-configurate ale abdlock, surse deja "
-"active sunt preselectate.<br /> <b><em>Pentru a evita erorile OOM, nu "
-"selectați prea multe liste!</em></b><br /> Mărimea listei cu informații "
-"despre domeniul respectiv variază astfel:<br /> &#8226;&#xa0;<b>S</b> "
-"(-10k), <b>M</b> (10k-30k) și <b>L</b> (30k-80k) ar trebui să funcționeze "
-"pentru dispozitive de 128 MByte,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) ar "
-"trebui să funcționeze pentru dispozitivele de 256-512 MByte,<br /> &#8226;"
-"&#xa0;<b>XXL</b> (200k-) au nevoie de dispozitive cu mai mult RAM și suport "
-"Multicore, ex. x86 sau raspberry.<br /> <p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -465,7 +443,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Vizualizare Jurnal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -486,7 +464,7 @@ msgstr "Nu există încă jurnale adblock!"
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilizat de „msmtp” pentru e-mailurile de notificare adblock."
 
@@ -500,7 +478,7 @@ msgstr ""
 "Interogare listă de blocări active și copii de rezervă pentru un anumit "
 "domeniu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -508,17 +486,17 @@ msgstr ""
 "Creșteți numărul de notificări pentru a primi e-mailuri dacă numărul total "
 "de blocări este mai mic sau egal cu limita dată."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -529,7 +507,6 @@ msgstr ""
 "o repornire completă a serviciului de blocare pentru a avea efect."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Reîmprospătare"
 
@@ -541,156 +518,159 @@ msgstr "Actualizare Raport DNS"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Salvează"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Suspendă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -724,17 +704,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -744,19 +724,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
@@ -765,7 +745,12 @@ msgstr "Intârzierea declanșării"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -776,15 +761,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -792,14 +777,35 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Lista surselor acceptate și complet pre-configurate ale abdlock, surse "
+#~ "deja active sunt preselectate.<br /> <b><em>Pentru a evita erorile OOM, "
+#~ "nu selectați prea multe liste!</em></b><br /> Mărimea listei cu "
+#~ "informații despre domeniul respectiv variază astfel:<br /> &#8226;&#xa0;"
+#~ "<b>S</b> (-10k), <b>M</b> (10k-30k) și <b>L</b> (30k-80k) ar trebui să "
+#~ "funcționeze pentru dispozitive de 128 MByte,<br /> &#8226;&#xa0;<b>XL</b> "
+#~ "(80k-200k) ar trebui să funcționeze pentru dispozitivele de 256-512 MByte,"
+#~ "<br /> &#8226;&#xa0;<b>XXL</b> (200k-) au nevoie de dispozitive cu mai "
+#~ "mult RAM și suport Multicore, ex. x86 sau raspberry.<br /> <p>&#xa0;</p>"

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -16,17 +16,17 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 #, fuzzy
 msgid "- unspecified -"
 msgstr "- не указано -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Действие"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Активные источники"
 
@@ -55,44 +55,44 @@ msgstr "Добавить этот (под-)домен в локальный чё
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Добавить этот (под-)домен в локальный белый список."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Дополнительный «тюремный» список блокировок"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Дополнительная задержка в секундах до начала работы Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Расширенные настройки DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Расширенные настройки электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Расширенные настройки отчётов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Ответ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Папка для резервных копий"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 #, fuzzy
 msgid "Base Temp Directory"
 msgstr "Расположение временных файлов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -109,11 +109,11 @@ msgstr ""
 "Изменения чёрного списка сохранены. Для того, чтобы они вступили в силу, "
 "обновите списки блокировок."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Чёрный список..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Заблокированные DNS-запросы"
 
@@ -121,11 +121,11 @@ msgstr "Заблокированные DNS-запросы"
 msgid "Blocked Domain"
 msgstr "Заблокированный домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Блокируемые домены"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Резервная копия чёрного списка"
 
@@ -133,15 +133,15 @@ msgstr "Резервная копия чёрного списка"
 msgid "Blocklist Query"
 msgstr "Поиск по чёрному списку"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Поиск по чёрному списку..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Источники чёрных списков"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -156,23 +156,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Отмена"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"Для вступления в силу изменений на этой вкладке требуется полный перезапуск "
-"службы Adblock.<br /> <p> &#xa0; </p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Клиент"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -190,7 +187,7 @@ msgstr ""
 msgid "Count"
 msgstr "Количество"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -198,42 +195,38 @@ msgstr ""
 "Создание сжатых резервных копий списков блокировок для использования при "
 "различных проблемах с загрузкой или во время запуска."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "Служба DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "Папка DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Сброс файла DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Отчёт DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Тайм-аут перезапуска DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Отключить пропуск DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Отключить перезагрузки DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -241,49 +234,49 @@ msgstr ""
 "Отключить перезапуски служб DNS с функциями автозагрузки/inotify, вызываемые "
 "Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 #, fuzzy
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Запретить избирательное применение белого списка DNS (сквозное RPZ)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Параметры загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Очередь загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Утилита для загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Уведомление по электронной почте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Счётчик e-mail уведомлений"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Адрес получателя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Адрес отправителя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "Тема"
 
@@ -297,31 +290,31 @@ msgstr "Редактировать чёрный список"
 msgid "Edit Whitelist"
 msgstr "Редактировать белый список"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Включить Безопасный поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Включить более умеренные фильтры Безопасного поиска для УouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Включить службу Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Включить подробное формирование отчёта на случай возникновения ошибок."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Включено"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "Время окончания"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -333,11 +326,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Существующие задания"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Внешний домен DNS Lookup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -350,39 +343,39 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Критерии фильтрации, такие как дата, домен или клиент (необязательно)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "Порты файерволла, перенаправляемые локально."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 #, fuzzy
 msgid "Firewall source zones that should be forced locally."
 msgstr "Зоны файерволла, перенаправляемые локально."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Очистка кэша DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Дополнительная очистка кэша DNS до его обработки Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 #, fuzzy
 msgid "Force Local DNS"
 msgstr "Принудительный локальный DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 #, fuzzy
 msgid "Forced Ports"
 msgstr "Перенаправляемые порты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 #, fuzzy
 msgid "Forced Zones"
 msgstr "Перенаправляемые зоны"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -392,7 +385,7 @@ msgstr ""
 "<i>Обратите внимание: для работы этой функции необходим пакет 'tcpdump-mini' "
 "и полная перезагрузка службы Adblock.</i>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Основные настройки"
 
@@ -400,37 +393,41 @@ msgstr "Основные настройки"
 msgid "Grant access to LuCI app adblock"
 msgstr "Предоставить доступ к приложению Adblock для LuCI"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Информация"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Папка для «тюрьмы»"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Последний запуск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Последние DNS-запросы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "Ограничить Безопасный поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 "Ограничить использование Безопасного поиска определёнными поисковыми "
 "службами."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "Список доступных сетевых устройств, используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -438,7 +435,7 @@ msgstr ""
 "Список сетевых интерфейсов для запуска Adblock в случае их доступности. "
 "Выберите «не определено» для стандартного запуска по тайм-ауту."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -446,28 +443,7 @@ msgstr ""
 "Список поддерживаемых служб DNS с их каталогом по умолчанию. Чтобы "
 "перезаписать путь по умолчанию, используйте опцию «Каталог DNS»."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Список поддерживаемых предварительно настроенных источников списков "
-"блокировок, уже активные источники отмечены.<br /> <b><em>Во избежание "
-"ошибок нехватки памяти не выбирайте слишком много списков!</em></b><br /"
-">Информация о размере списков:<br /> &#8226;&#xa0;<b>S</b> (<10k), <b>M</b> "
-"(10k-30k) и <b>L</b> (30k-80k) должны работать на устройствах с 128 МБайт "
-"ОЗУ,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) должны работать на устройствах "
-"с 256–512 МБайт ОЗУ,<br /> &#8226;&#xa0;<b>XXL</b> (200k<) требуют больше "
-"ОЗУ и многоядерный процессор, (например, на основе raspberry или x86).<br /> "
-"<p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Список поддерживаемых предварительно настроенных утилит для загрузки списков."
@@ -477,7 +453,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Просмотр журнала"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Низкий приоритет службы"
 
@@ -498,7 +474,7 @@ msgstr "Ещё нет журналов, связанных с Adblock!"
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Профиль, используемый 'msmtp' для отправки почтовых уведомлений."
 
@@ -511,7 +487,7 @@ msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 "Поиск определенного домена в активных списках блокировок и резервных копиях."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 #, fuzzy
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
@@ -520,11 +496,11 @@ msgstr ""
 "Увеличение количества уведомлений для отправки письма в случае, если "
 "количество блокировок не превышает указанного числа."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Адрес получателя для уведомлений по электронной почте."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -532,7 +508,7 @@ msgstr ""
 "Перенаправление всех DNS-запросов из указанных зон к локальной службе DNS "
 "Lookup. Применяется к протоколам TCP и UDP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -543,7 +519,6 @@ msgstr ""
 "полная перезагрузка службы Adblock.</i>"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Обновить"
 
@@ -555,84 +530,86 @@ msgstr "Обновить отчёт DNS"
 msgid "Refresh Timer"
 msgstr "Обновить таймер"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Обновить таймер..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Обновить..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "Ослабить Безопасный поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Количество фрагментов отчёта"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Размер фрагментов отчёта"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Папка для отчётов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Интерфейсы в отчёте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Порты в отчёте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "Количество фрагментов отчёта, используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Размер фрагментов отчёта, используемых tcpdump, в мегабайтах."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"Сброс последнего списка блокировок DNS 'adb_list.overall' после загрузки "
-"службы DNS. <br /> <i>Обратите внимание: эта опция запускает в фоне "
-"небольшой монитор ubus/adblock.</i>"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Результат"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Рабочие папки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 #, fuzzy
 msgid "Run Flags"
 msgstr "Рабочие флаги"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Рабочие интерфейсы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "Рабочие утилиты"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Сохранить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -640,19 +617,19 @@ msgstr ""
 "Отправлять на e-mail уведомления, касающиеся Adblock. <br /> <i>Обратите "
 "внимание: требуется установка дополнительного пакета \"msmtp\".</i>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr "E-Mail адрес отправителя уведомлений Adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "Создать новое/заменить задание Adblock"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -660,64 +637,58 @@ msgstr ""
 "Размер очереди загрузки для параллельной обработки (сортировки, объединения "
 "и т.п.)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 #, fuzzy
 msgid "Sources (Size, Focus)"
 msgstr "Источники (Размер, Фокусировка)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Разделенный пробелами список портов, используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr "Специальные опции конфигурации для выбранной утилиты загрузки."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "Время начала"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "Интерфейс для запуска"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Статус / Версия"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Приостановить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"Каталог для отчетов, связанных с DNS. По умолчанию — '/tmp', предпочтительно "
-"использовать USB-накопитель или другой локальный диск."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"Каталог для резервных копий списков блокировок. По умолчанию — '/tmp', "
-"предпочтительно использовать USB-накопитель или другой локальный диск."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Папка для созданного списка блокировки 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Папка для «тюремного» списка блокировки 'adb_list.jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "Не удалось обновить таймер обновления."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "Таймер обновления обновлён."
 
@@ -761,19 +732,17 @@ msgstr ""
 "домену на строку. Разрешается использование комментариев, начинающихся на "
 "'#' — IP-адреса и регулярные выражения не поддерживаются.</i>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
-"Отображение последнего отчёта DNS, нажмите кнопку «Обновить» для создания "
-"нового."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Время"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Тайм-аут ожидания успешного перезапуска службы DNS."
 
@@ -783,19 +752,19 @@ msgid ""
 "job for these lists."
 msgstr "Чтобы списки были актуальны, настройте их автоматическое обновление."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "Топ-10 статистики"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr "Тема, используемая для отправки электронных писем."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "Всего DNS-запросов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
@@ -804,7 +773,12 @@ msgstr "Задержка запуска"
 msgid "Unable to save changes: %s"
 msgstr "Невозможно сохранить изменения: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
@@ -817,15 +791,15 @@ msgstr ""
 "Изменения в белом списке были сохранены. Обновите свои списки блокировок, "
 "чтобы изменения вступили в силу."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "Белый список..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -833,14 +807,78 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "макс. размер списка результатов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "named (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Для вступления в силу изменений на этой вкладке требуется полный "
+#~ "перезапуск службы Adblock.<br /> <p> &#xa0; </p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Сброс файла DNS"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Список поддерживаемых предварительно настроенных источников списков "
+#~ "блокировок, уже активные источники отмечены.<br /> <b><em>Во избежание "
+#~ "ошибок нехватки памяти не выбирайте слишком много списков!</em></b><br /"
+#~ ">Информация о размере списков:<br /> &#8226;&#xa0;<b>S</b> (<10k), <b>M</"
+#~ "b> (10k-30k) и <b>L</b> (30k-80k) должны работать на устройствах с 128 "
+#~ "МБайт ОЗУ,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) должны работать на "
+#~ "устройствах с 256–512 МБайт ОЗУ,<br /> &#8226;&#xa0;<b>XXL</b> (200k<) "
+#~ "требуют больше ОЗУ и многоядерный процессор, (например, на основе "
+#~ "raspberry или x86).<br /> <p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "Сброс последнего списка блокировок DNS 'adb_list.overall' после загрузки "
+#~ "службы DNS. <br /> <i>Обратите внимание: эта опция запускает в фоне "
+#~ "небольшой монитор ubus/adblock.</i>"
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "Создать новое/заменить задание Adblock"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Каталог для отчетов, связанных с DNS. По умолчанию — '/tmp', "
+#~ "предпочтительно использовать USB-накопитель или другой локальный диск."
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "Каталог для резервных копий списков блокировок. По умолчанию — '/tmp', "
+#~ "предпочтительно использовать USB-накопитель или другой локальный диск."
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr ""
+#~ "Отображение последнего отчёта DNS, нажмите кнопку «Обновить» для создания "
+#~ "нового."

--- a/applications/luci-app-adblock/po/sk/adblock.po
+++ b/applications/luci-app-adblock/po/sk/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akcia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -48,46 +48,46 @@ msgstr "Pridať túto (sub-) doménu medzi lokálne zakázané domény."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Pridať túto (sub-) doménu medzi lokálne povolené domény."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Ďalšie nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatočné oneskorenie v sekundách pred začiatkom spracovania blokovania "
 "reklamy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Pokročilé DNS nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Pokročilé nastavenia e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 #, fuzzy
 msgid "Advanced Report Settings"
 msgstr "Pokročilé nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Odpoveď"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Záložný priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Základný Temp priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,11 +102,11 @@ msgstr ""
 "Zmeny v zozname zakázaných domén boli uložené. Obnovte zoznamy Adblocku aby "
 "sa prejavili."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Zoznam zakázaných domén..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -114,11 +114,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Blokovaná doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Blokované domény"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Záloha zoznamu blokovaných domén"
 
@@ -126,15 +126,15 @@ msgstr "Záloha zoznamu blokovaných domén"
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Zdroje zoznamov blokovaní"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,21 +145,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -173,95 +172,91 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS adresár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Inicializácia DNS súboru"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "Upozornenie e-mailom"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "Adresa príjemcu e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -275,31 +270,31 @@ msgstr "Upraviť čiernu listinu"
 msgid "Edit Whitelist"
 msgstr "Upraviť bielu listinu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Povolené"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -309,11 +304,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -323,42 +318,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Vyprázdniť medzipamäť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Všeobecné nastavenia"
 
@@ -366,59 +361,51 @@ msgstr "Všeobecné nastavenia"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Informácie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -427,7 +414,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -448,7 +435,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -460,23 +447,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -484,7 +471,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -496,156 +482,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Uložiť"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -679,17 +668,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -699,19 +688,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -720,7 +709,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -731,15 +725,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -747,14 +741,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Inicializácia DNS súboru"

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "- ospecificerad -"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Åtgärd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Aktiva källor"
 
@@ -48,45 +48,45 @@ msgstr "Lägg till denna (under-)domän till din lokala svartlista."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lägg till denna (under-)domän i din lokala vitlista."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Ytterligare arrest-blocklista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Fler inställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligare trigger fördröjning i sekunder innan Adblock-bearbetningen "
 "påbörjas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Avancerade DNS-inställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Avancerade e-post-inställingar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Avancerade rapportinställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Tempkatalogbas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -103,11 +103,11 @@ msgstr ""
 "Ändringar av startlistan har sparats. Uppdatera dina annonsblockeringslistor "
 "för att ändringarna ska få verkan."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Svartlista..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Blockerade DNS-uppslag"
 
@@ -115,11 +115,11 @@ msgstr "Blockerade DNS-uppslag"
 msgid "Blocked Domain"
 msgstr "Blockerad domän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Blockerade domäner"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Blockeringslistssäkerhetskopia"
 
@@ -127,15 +127,15 @@ msgstr "Blockeringslistssäkerhetskopia"
 msgid "Blocklist Query"
 msgstr "Blockeringslistsfråga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Blockeringslistsfråga..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Källor för blockeringslistor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,23 +149,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"Ändringar i denna flik kräver en fullständig omstart av "
-"annonsblockerinstjänsten för att få verkan.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -183,7 +180,7 @@ msgstr ""
 msgid "Count"
 msgstr "Räkna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -191,42 +188,38 @@ msgstr ""
 "Skapa komprimerade säkerhetskopior av spärrlistor för att användas vid "
 "uppstart i händelse av nedladdningsfel."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "DNS-bakände"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS-mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS-filåterställning"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-rapport"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "Tidsgräns för DNS-omstart"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "Inaktivera DNS-tillåtelse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "Inaktivera DNS-omstarter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -234,48 +227,48 @@ msgstr ""
 "Inaktivera annonsblockeringsstyrda omstarter av DNS-bakändar med autoload/"
 "inotify funktionalitet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Inaktivera selektiv DNS-vitlistning (RPZ-genomflöde)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "Ladda ner parametrar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "Nedladdningskö"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "E-postavisering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "Antal E-postaviseringar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagaradress"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "Avsändaradress för e-post"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "E-postämne"
 
@@ -289,31 +282,31 @@ msgstr "Redigera svartlista"
 msgid "Edit Whitelist"
 msgstr "Redigera vitlista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "Aktivera SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Aktivera måttliga SafeSearch-filter för Youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Aktivera annonsblockerinstjänsten."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Aktivera utförlig avlusningsloggning i händelse av behandlingsfel."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "Sluttidstämpel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -323,11 +316,11 @@ msgstr "Påtvingar SafeSearch på Google, Bing, DuckDuckGo, Yandex och Pixbay."
 msgid "Existing job(s)"
 msgstr "Befintliga jobb"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Extern DNS-uppslagsdomän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -339,35 +332,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtreringsvillkor som datum, domän eller klient (valfritt)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "Brandväggsportar som ska forceras lokalt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr "Brandväggskällzoner som ska forceras lokalt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "Töm DNS-cache"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spola också DNS-cachen innan annonsblockeringshantering."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Tvinga lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "Forcerade portar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "Forcerade zoner"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -378,7 +371,7 @@ msgstr ""
 "'tcpdump-mini'-paketet och en fullständig omstart av "
 "annonsblockeringstjänsten för att få verkan."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Generella inställningar"
 
@@ -386,35 +379,39 @@ msgstr "Generella inställningar"
 msgid "Grant access to LuCI app adblock"
 msgstr "Ge tillgång till LuCi-programmet annonsblockering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Arrestkatalog"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Kördes senast"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Senaste DNS-begäranden"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "Begränsa SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "Begränsa SafeSearch till vissa leverantörer."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista med tillgängliga nätverksenheter använda av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -423,7 +420,7 @@ msgstr ""
 "annonsblockeringen. Välj 'unspecified' för att använda en klassisk "
 "upstartstidsgräns istället för en nätverksaktivering."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -431,27 +428,7 @@ msgstr ""
 "Lista med tillgängliga DNS-bakändar med deras standardlistskatalog. För att "
 "åsidosätta standardsökvägen; använd alternativet 'DNS-katalog'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Lista med stödja och fullt förkonfigurerade annonsblockeringskällor. Redan "
-"aktiva källor är förvalda.<br /> <b><em>För att undvika slut-på-minnesfel, "
-"välj inte för många listor!</em></b><br /> Liststorleksinformation med "
-"respektive domänomfång är som följer:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) och <b>L</b> (30k-80k) bör fungera på 128 MByte enheter,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) bör fungera på 256-512 MByte "
-"enheter,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) berhöver mer RAM och "
-"flerkärnsstöd, t.ex. x86- eller raspberry-enheter.<br /> <p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista över stödda och helt förkonfigurerade nedladdningsverktyg."
 
@@ -460,7 +437,7 @@ msgstr "Lista över stödda och helt förkonfigurerade nedladdningsverktyg."
 msgid "Log View"
 msgstr "Logutsikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Lågprioriterad tjänst"
 
@@ -481,7 +458,7 @@ msgstr "Inga annonsblockerinsrelaterade loggar ännu!"
 msgid "Overview"
 msgstr "Översikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Profil som används av 'msmtp' för annonsblockeringsaviserinse-"
@@ -495,7 +472,7 @@ msgstr "Fråga"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Fråga aktiva svartlistor och säkerhetskopior efter en given domän."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -503,11 +480,11 @@ msgstr ""
 "Öka aviseringsantalet för att få e-post om den sammantagna spärrlistans "
 "antal är mindre än eller lika med den givna gränsen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Mottagande adress för annonsblockeringsaviserings-e-postmeddelanden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -515,7 +492,7 @@ msgstr ""
 "Omdirigera alla DNS-frågor från specifika zoner till den lokala DNS-"
 "utredaren, gäller för UDP- och TCP-protokoll."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -526,7 +503,6 @@ msgstr ""
 "omstart av annonsblockeringstjänsten för att ha verkan."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Uppdatera"
 
@@ -538,159 +514,159 @@ msgstr "Förnya DNS-rapporten"
 msgid "Refresh Timer"
 msgstr "Förnya stoppuret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "Förnya stoppuret..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "Fräscha upp..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "Slappna av SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "Rapportera klimpantal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "Rapportera klimpstorlek"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "Rapportkatalog"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "Rapportgränssnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "Rapporthamnar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "Rapportera klimpantal använt av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Rapportera klimpstorlek som används av tcpdump i MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"Nollställer den slutgiltiga DNS-spärrlistan 'adb_list.overall' after DNS-"
-"bakändesladdning. Notera: detta alternativ startar en liten ubus/adblock "
-"övervakare i bakgrunden."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "Resultat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "Körkataloger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "Förflaggor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "Körgränssnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "Kör verktyg"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Spara"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Inställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "Status / Version"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "Stäng av"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -724,17 +700,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -744,19 +720,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -765,7 +741,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -776,15 +757,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -792,14 +773,54 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Ändringar i denna flik kräver en fullständig omstart av "
+#~ "annonsblockerinstjänsten för att få verkan.<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS-filåterställning"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Lista med stödja och fullt förkonfigurerade annonsblockeringskällor. "
+#~ "Redan aktiva källor är förvalda.<br /> <b><em>För att undvika slut-på-"
+#~ "minnesfel, välj inte för många listor!</em></b><br /> "
+#~ "Liststorleksinformation med respektive domänomfång är som följer:<br /> "
+#~ "&#8226;&#xa0;<b>S</b> (-10k), <b>M</b> (10k-30k) och <b>L</b> (30k-80k) "
+#~ "bör fungera på 128 MByte enheter,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) "
+#~ "bör fungera på 256-512 MByte enheter,<br /> &#8226;&#xa0;<b>XXL</b> "
+#~ "(200k-) berhöver mer RAM och flerkärnsstöd, t.ex. x86- eller raspberry-"
+#~ "enheter.<br /> <p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "Nollställer den slutgiltiga DNS-spärrlistan 'adb_list.overall' after DNS-"
+#~ "bakändesladdning. Notera: detta alternativ startar en liten ubus/adblock "
+#~ "övervakare i bakgrunden."

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -1,16 +1,16 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -39,43 +39,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -88,11 +88,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -100,11 +100,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -112,15 +112,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -131,21 +131,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -159,95 +158,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -261,31 +256,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -295,11 +290,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -309,42 +304,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -352,59 +347,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -413,7 +400,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -434,7 +421,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -446,23 +433,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -470,7 +457,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -482,156 +468,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -665,17 +654,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -685,19 +674,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -706,7 +695,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -717,15 +711,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -733,14 +727,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/tr/adblock.po
+++ b/applications/luci-app-adblock/po/tr/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Eylem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Aktif Kaynaklar"
 
@@ -48,44 +48,44 @@ msgstr "Bu (alt-)alan adını yerel kara listenize ekleyin."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Bu (alt)alan adını yerel izin verilen listenize ekleyin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "Ek \"Hapis\" Engelleme listesi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "Ek Ayarlar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Reklam engelleme işlemi başlamadan önce saniye cinsinden gecikme süresi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "Gelişmiş DNS Ayarları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "Gelişmiş E-Posta Ayarları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "Gelişmiş Rapor Ayarları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Cevap"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Yedekleme Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "Geçici dosyalar icin temel Dizin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,11 +102,11 @@ msgstr ""
 "Kara liste değişiklikleri kaydedildi. Değişikliklerin etkili olması için "
 "reklam engelleme listelerinizi yenileyin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "Kara liste..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Engellenen DNS İstekleri"
 
@@ -114,11 +114,11 @@ msgstr "Engellenen DNS İstekleri"
 msgid "Blocked Domain"
 msgstr "Engellenmiş Alan Adı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "Engellenen Alan Adları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "Engelleme Listesi Yedekleme"
 
@@ -126,15 +126,15 @@ msgstr "Engelleme Listesi Yedekleme"
 msgid "Blocklist Query"
 msgstr "Engelleme Listesi Sorgusu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "Engelleme Listesi Sorgusu..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Engelleme Listesi Kaynakları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,23 +149,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "İptal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"Bu sekmedeki değişikliklerin yürürlüğe girmesi için reklam engelleme "
-"hizmetinin yeniden başlatılması gerekir.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "İstemci"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -184,7 +181,7 @@ msgstr ""
 msgid "Count"
 msgstr "Adet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -192,42 +189,38 @@ msgstr ""
 "Sıkıştırılmış kara liste yedekleri oluşturun, bunlar indirme hataları ve "
 "başlatma sırasında kullanılacaktır."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "DNS Arka Uç"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS Dosya Sıfırlama"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS Raporu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "DNS Yeniden Başlatma Zaman Aşımı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Tarih"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "DNS İzin Vermeyi Devre Dışı bırakın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "DNS Yeniden Başlatmalarını Devre Dışı bırakın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -235,48 +228,48 @@ msgstr ""
 "Adblock tarafından tetiklenen autoload/inotify fonksiyonları ile dns arka uç "
 "yeniden başlatmasını devre dışı bırakın."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "Seçilebilir DNS beyaz listesini (RPZ geçişi) devre dışı bırakın."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Alan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "İndirme Parametreleri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "İndirme Kuyruğu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "İndirme Aracı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "E-Mail Bildirimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "E-Mail Bildirim Sayısı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "E-Mail Profili"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Alıcı Adresi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Gönderen Adresi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "E-Mail Konusu"
 
@@ -290,33 +283,33 @@ msgstr "Karalisteyi Düzenle"
 msgid "Edit Whitelist"
 msgstr "Beyazlisteyi Düzenle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "GüvenliArama'yı Etkinleştir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Youtube için hafif GüvenliArama'yı etkinleştir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "Adblock servisini etkinleştir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Herhangi bir işleme hatası durumunda ayrıntılı hata ayıklama günlüğünü "
 "etkinleştir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Etkin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "Zaman damgasını bitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -328,11 +321,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Mevcut iş(ler)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "Harici DNS Arama Alanı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -345,35 +338,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Tarih, alan, client gibi filtre özellikleri (opsiyonel)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "DNS Önbelleğini Temizle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Adblock işleminden önce de DNS Önbelleğini temizle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "Yerel DNS zorla"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "Zorlanan Erişim Noktaları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "Zorlanan Bölgeler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -384,7 +377,7 @@ msgstr ""
 "'tcpdump-mini' paket kurulumuna ve adblock hizmetinin tamamen yeniden "
 "başlatılması gerekir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Genel Ayarlar"
 
@@ -392,59 +385,51 @@ msgstr "Genel Ayarlar"
 msgid "Grant access to LuCI app adblock"
 msgstr "LuCI uygulaması adblock'a izin verin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Bilgi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Kafes Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "Son çalışma zamanı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "Yeni DNS Sorguları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "GüvenliArama'yı limitle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "Belirli sağlayıcılar için GüvenliArama'yı limitle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -453,7 +438,7 @@ msgstr ""
 msgid "Log View"
 msgstr "Kayıtları göster"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "Düşük Öncelikli Servis"
 
@@ -474,7 +459,7 @@ msgstr "Henüz adblock ile ilgili kayıt yok!"
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -486,23 +471,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -510,7 +495,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Yenile"
 
@@ -522,156 +506,159 @@ msgstr "DNS Raporunu Yenile"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Kaydet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -705,17 +692,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -725,19 +712,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -746,7 +733,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -757,15 +749,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -773,14 +765,24 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Bu sekmedeki değişikliklerin yürürlüğe girmesi için reklam engelleme "
+#~ "hizmetinin yeniden başlatılması gerekir.<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS Dosya Sıfırlama"

--- a/applications/luci-app-adblock/po/uk/adblock.po
+++ b/applications/luci-app-adblock/po/uk/adblock.po
@@ -11,16 +11,16 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.3.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Дія"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "Активні джерела"
 
@@ -49,43 +49,43 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,11 +98,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -110,11 +110,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,15 +122,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -141,21 +141,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Клієнт"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -169,95 +168,91 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -271,31 +266,31 @@ msgstr "Редагувати чорний список"
 msgid "Edit Whitelist"
 msgstr "Редагувати білий список"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -305,11 +300,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -319,42 +314,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "Головні налаштування"
 
@@ -362,59 +357,51 @@ msgstr "Головні налаштування"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "Інформація"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -423,7 +410,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -444,7 +431,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -456,23 +443,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -480,7 +467,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "Оновити"
 
@@ -492,156 +478,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "Зберегти"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -675,17 +664,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -695,19 +684,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr ""
 
@@ -716,7 +705,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -727,15 +721,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -743,14 +737,14 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/vi/adblock.po
+++ b/applications/luci-app-adblock/po/vi/adblock.po
@@ -10,16 +10,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Hành động"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr ""
 
@@ -48,44 +48,44 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Kích hoạt độ trễ trong vài giây trước khi bắt đầu tiến trình chặn quảng cáo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Phản hồi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "Thư mục sao lưu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -98,11 +98,11 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
@@ -110,11 +110,11 @@ msgstr ""
 msgid "Blocked Domain"
 msgstr "Tên miền bị chặn"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -122,15 +122,15 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "Bộ lọc"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -141,21 +141,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "Khách hàng"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -169,96 +168,92 @@ msgstr ""
 msgid "Count"
 msgstr "Bộ đếm"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 #, fuzzy
 msgid "DNS Directory"
 msgstr "Thư mục DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "Đặt lại tệp DNS"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "Ngày"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -272,31 +267,31 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "Bật"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -306,11 +301,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -320,42 +315,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr ""
 
@@ -363,59 +358,51 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -424,7 +411,7 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr ""
 
@@ -445,7 +432,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -457,23 +444,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -481,7 +468,6 @@ msgid ""
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr ""
 
@@ -493,156 +479,159 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
+msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
@@ -676,17 +665,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "Thời gian"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -696,19 +685,19 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
@@ -717,7 +706,12 @@ msgstr "Kích hoạt độ trễ"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 #, fuzzy
 msgid "Verbose Debug Logging"
 msgstr "Nhật ký gỡ lỗi khởi động"
@@ -729,15 +723,15 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -745,14 +739,17 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "DNS File Reset"
+#~ msgstr "Đặt lại tệp DNS"

--- a/applications/luci-app-adblock/po/zh_Hans/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hans/adblock.po
@@ -17,16 +17,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "未指定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "开始"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "活动源"
 
@@ -55,43 +55,43 @@ msgstr "添加此域名到本地黑名单。"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "添加此域名到本地白名单。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "其它被屏蔽列表"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "其他设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "事件触发启动前的延时（秒）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "高级DNS设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "高级设置-邮箱"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "高级报告设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "备份文件夹"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "基本缓存文件夹"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,11 +104,11 @@ msgid ""
 "take effect."
 msgstr "黑名单更改已保存。刷新您的广告阻止列表，以使更改生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "黑名单..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "阻止的DNS请求"
 
@@ -116,11 +116,11 @@ msgstr "阻止的DNS请求"
 msgid "Blocked Domain"
 msgstr "已拦截的域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "已拦截域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "黑名单列表的备份"
 
@@ -128,15 +128,15 @@ msgstr "黑名单列表的备份"
 msgid "Blocklist Query"
 msgstr "拦截列表查询"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "黑名单查询..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "阻止列表内容"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,21 +149,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "关闭"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
-msgstr "改变此项后需要完全重启 adblock 以生效<br /><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "客户端 Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -180,95 +179,91 @@ msgstr ""
 msgid "Count"
 msgstr "计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr "创建压缩的阻止列表备份，将在下载错误或启动期间使用它们。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "DNS后端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS 目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS 文件重置"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS报告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "DNS重新启动超时"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "禁用DNS允许"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "禁用DNS重新启动"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "禁用具有自动加载/ inotify功能的dns后端的adblock触发的重启。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "禁止选择性DNS白名单(RPZ通过)."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "下载参数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "下载队列"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "电子邮件通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "电子邮件通知计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "电子邮件概要"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "电子邮件收件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -282,31 +277,31 @@ msgstr "编辑黑名单"
 msgid "Edit Whitelist"
 msgstr "编辑白名单"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "启用安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "为YouTube启用适度的安全搜索过滤器."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "启用广告屏蔽服务."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在任何处理错误的情况下启用详细调试日志记录."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "启用"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "结束时间戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -316,11 +311,11 @@ msgstr "强制执行Google，Bing，Duckduckgo，Yandex，youtube和Google的Saf
 msgid "Existing job(s)"
 msgstr "现有工作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "外部DNS查找域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -332,35 +327,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "过滤条件，例如日期，域或客户（可选）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "本地应强制使用的防火墙端口。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr "本地应强制使用的防火墙源域。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 缓存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "还要在处理adblock之前刷新DNS缓存。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "强制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "强制端口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "强制域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -369,7 +364,7 @@ msgstr ""
 "通过tcpdump收集与DNS相关的网络流量，并按需提供DNS报告。请注意：这需要额外的“ "
 "tcpdump-mini”软件包安装，并重新启动完整的adblock服务才能生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "常规设置"
 
@@ -377,35 +372,39 @@ msgstr "常规设置"
 msgid "Grant access to LuCI app adblock"
 msgstr "授予对LuCI应用程序adblock的访问权限"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "黑名单目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "最后运行"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "最新的DNS请求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "限定安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "限定特定搜索引擎使用安全搜索。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump使用的可用网络设备列表."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -413,33 +412,14 @@ msgstr ""
 "触发adblock启动的可用网络接口列表.选择“未指定”以使用传统的启动超时而不是网络"
 "触发器."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 "支持的DNS后端列表及其默认列表目录.要覆盖默认路径，请使用“ DNS目录”选项."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"受支持且已完全预先配置的adblock源列表，已预先选择了已激活的源。<br /> <b> "
-"<em>为避免OOM错误，请不要选择太多列表！</em> </b> <br />列出各个域范围的大小"
-"信息，如下所示：<br />＆＃8226;＆＃xa0; <b> S </b>（-10k），<b> M </b>（10k "
-"-30k）和<b> L </b>（30k-80k）适用于128 MByte设备，<br />＆＃8226;＆＃xa0; "
-"<b> XL </b>（80k-200k）应适用适用于256-512 MB设备，<br />＆＃8226;＆＃xa0; "
-"<b> XXL </b>（200k-）需要更多的RAM和多核支持，例如x86或树莓派设备。<br /> <p>"
-"＆＃xa0; </p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支持的和完全预先配置的下载实用程序列表."
 
@@ -448,7 +428,7 @@ msgstr "支持的和完全预先配置的下载实用程序列表."
 msgid "Log View"
 msgstr "日志视图"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "低优先级服务"
 
@@ -469,7 +449,7 @@ msgstr "尚无与adblock相关的日志！"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp' 用于adblock通知电子邮件的配置文件。"
 
@@ -481,24 +461,24 @@ msgstr "查询"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查询特定域的活动阻止列表和备份."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 "如果总体阻止列表总数小于或等于给定的限制，请提高通知数量，以获取电子邮件."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知 E-Mail 的收件人地址。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr "将所有DNS查询从指定区域重定向到本地DNS解析器，适用于UDP和TCP协议。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -508,7 +488,6 @@ msgstr ""
 "adblock服务才能生效."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "刷新"
 
@@ -520,161 +499,159 @@ msgstr "刷新DNS报告"
 msgid "Refresh Timer"
 msgstr "定时恢复"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "定时恢复中..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "刷新..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "放宽安全搜寻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "报告区块计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "报告区块大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "报告目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "报告接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "报告端口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "报告 tcpdump 所使用的区块数量。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "报告 tcpdump 所使用的区块大小 (以 MByte 显示)。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"在 DNS 后端载入后重置黑名单 \"adb_list.overall\"。请留意：此选项将在后台启动 "
-"ubus/adblock 微监控。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "结果"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "运行目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "运行标记"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "运行接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "运行工具"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr "发送 AdBlock 相关的通知邮件。请留意：此功能需要安装 \"msmtp\"。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr "AdBlock 通知邮件的发送地址。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "设置/替换新 AdBlock 任务"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr "并行下载处理 (分类、合并等) 的下载队列大小。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "来源（大小，焦点）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump使用的端口列表，用空格分隔端口。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr "所选下载实用程序的特殊配置选项."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "开始时间戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "启动触发接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "状态 / 版本"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "暂停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"DNS相关报告文件的目标目录。默认值为“/tmp”，请最好使用USB记忆棒或其他本地磁"
-"盘。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"阻止列表备份的目标目录。默认值为“/tmp”，请最好使用U 盘或本地磁盘进行备份。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "无法更新刷新计时器."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "刷新计时器已更新."
 
@@ -712,17 +689,17 @@ msgstr ""
 "这是本地adblock白名单，始终允许某些（子）域。<br />请注意：每行仅添加一个域。"
 "允许以“＃”开头的注释-不允许使用IP地址，通配符和正则表达式。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
-msgstr "这显示了上次生成的 DNS 报告，按刷新按钮获取当前报告。"
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "时间"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "等待成功的DNS后端重新启动的超时。"
 
@@ -732,19 +709,19 @@ msgid ""
 "job for these lists."
 msgstr "为了使您的广告过滤列表保持最新，你应该为这些列表设置一个自动更新作业。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "前 10 统计数据"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr "广告拦截通知邮件的主题。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "DNS 请求总数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "触发延迟"
 
@@ -753,7 +730,12 @@ msgstr "触发延迟"
 msgid "Unable to save changes: %s"
 msgstr "无法保存更改: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
@@ -764,15 +746,15 @@ msgid ""
 "take effect."
 msgstr "白名单更改已保存。刷新您的广告阻止列表，以使更改生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "白名单..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "抑制 (/etc/kresd)"
 
@@ -780,14 +762,70 @@ msgstr "抑制 (/etc/kresd)"
 msgid "max. result set size"
 msgstr "最大结果集大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "BIND(/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "原始（/ tmp）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "未绑定 (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr "改变此项后需要完全重启 adblock 以生效<br /><p>&#xa0;</p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS 文件重置"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "受支持且已完全预先配置的adblock源列表，已预先选择了已激活的源。<br /> <b> "
+#~ "<em>为避免OOM错误，请不要选择太多列表！</em> </b> <br />列出各个域范围的大"
+#~ "小信息，如下所示：<br />＆＃8226;＆＃xa0; <b> S </b>（-10k），<b> M </"
+#~ "b>（10k -30k）和<b> L </b>（30k-80k）适用于128 MByte设备，<br />＆＃8226;"
+#~ "＆＃xa0; <b> XL </b>（80k-200k）应适用适用于256-512 MB设备，<br />＆＃"
+#~ "8226;＆＃xa0; <b> XXL </b>（200k-）需要更多的RAM和多核支持，例如x86或树莓"
+#~ "派设备。<br /> <p>＆＃xa0; </p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "在 DNS 后端载入后重置黑名单 \"adb_list.overall\"。请留意：此选项将在后台启"
+#~ "动 ubus/adblock 微监控。"
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "设置/替换新 AdBlock 任务"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "DNS相关报告文件的目标目录。默认值为“/tmp”，请最好使用USB记忆棒或其他本地磁"
+#~ "盘。"
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "阻止列表备份的目标目录。默认值为“/tmp”，请最好使用U 盘或本地磁盘进行备份。"
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr "这显示了上次生成的 DNS 报告，按刷新按钮获取当前报告。"

--- a/applications/luci-app-adblock/po/zh_Hant/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hant/adblock.po
@@ -16,16 +16,16 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
 msgid "- unspecified -"
 msgstr "未指定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "開始"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:216
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Active Sources"
 msgstr "活躍的來源"
 
@@ -54,43 +54,43 @@ msgstr "加入該（子）域名到您的本地黑名單。"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "加入該（子）域名到您的本地白名單。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid "Additional Jail Blocklist"
 msgstr "附加 Jail 封鎖清單"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:269
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
 msgid "Additional Settings"
 msgstr "附加設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "附加觸發 Adblock 行程延遲開始的秒數。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Advanced DNS Settings"
 msgstr "進階 DNS 設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:272
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "Advanced E-Mail Settings"
 msgstr "進階電郵設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
 msgid "Advanced Report Settings"
 msgstr "進階報告設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:261
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Backup Directory"
 msgstr "備份目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid "Base Temp Directory"
 msgstr "基本臨時目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:368
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,11 +104,11 @@ msgid ""
 "take effect."
 msgstr "黑名單變更已儲存；請重新整理您的 Adblock 清單來使變更生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:286
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
 msgid "Blacklist..."
 msgstr "黑名單…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:316
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "封鎖的 DNS 請求"
 
@@ -116,11 +116,11 @@ msgstr "封鎖的 DNS 請求"
 msgid "Blocked Domain"
 msgstr "封鎖的域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:213
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Blocked Domains"
 msgstr "封鎖的域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Blocklist Backup"
 msgstr "黑名單備份"
 
@@ -128,15 +128,15 @@ msgstr "黑名單備份"
 msgid "Blocklist Query"
 msgstr "封鎖清單查詢"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
 msgid "Blocklist Query..."
 msgstr "黑名單查詢…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Blocklist Sources"
 msgstr "封鎖清單來源"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,22 +149,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:59
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:271
-msgid ""
-"Changes on this tab needs a full adblock service restart to take effect.<br /"
-"><p>&#xa0;</p>"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+msgid "Categories"
 msgstr ""
-"此分頁上的變更需要您完全重新啟動 Adblock 服務後才能生效。<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:259
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
 msgid "Client"
 msgstr "客户端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:128
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -182,95 +180,91 @@ msgstr ""
 msgid "Count"
 msgstr "計數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:373
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr "建立壓縮的封鎖清單備份；它們將在下載錯誤時或啟動期間被使用。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid "DNS Backend"
 msgstr "DNS 後端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Directory"
 msgstr "DNS 目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid "DNS File Reset"
-msgstr "DNS 檔案重設"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS 報告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Restart Timeout"
 msgstr "DNS 重新啟動逾時值"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable DNS Allow"
 msgstr "停用 DNS 解析修改"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "Disable DNS Restarts"
 msgstr "停用 DNS 重新啟動"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "停用 Adblock 觸發具有「自動載入／inotify 」功能的 DNS 後端重新啟動。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Disable selective DNS whitelisting (RPZ pass through)."
 msgstr "停用 DNS 選擇性白名單解析（忽略 RPZ，一律放行）。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:260
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "網域名稱"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Download Parameters"
 msgstr "下載參數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid "Download Queue"
 msgstr "下載佇列"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Download Utility"
 msgstr "下載工具"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid "E-Mail Notification"
 msgstr "電子郵件通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid "E-Mail Notification Count"
 msgstr "電郵通知數量"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "E-Mail Profile"
 msgstr "電郵設定檔"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Receiver Address"
 msgstr "電郵收件人位址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "E-Mail Sender Address"
 msgstr "電郵寄件人位址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "E-Mail Topic"
 msgstr "電郵主旨"
 
@@ -284,31 +278,31 @@ msgstr "編輯黑名單"
 msgid "Edit Whitelist"
 msgstr "編輯白名單"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid "Enable SafeSearch"
 msgstr "啟用安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "啟用為 YouTube 設定的中度安全搜尋篩選器。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enable the adblock service."
 msgstr "啟用 Adblock 服務。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在出現任何處理錯誤的情況下，請啟用詳細除錯日誌記錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
 msgid "Enabled"
 msgstr "啟用"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:310
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
 msgid "End Timestamp"
 msgstr "結束時間戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -320,11 +314,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "現存工作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid "External DNS Lookup Domain"
 msgstr "供 DNS 查詢的外部域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -336,35 +330,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "篩選器準則（例如：日期、域名或客戶端，可選）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Firewall ports that should be forced locally."
 msgstr "本地應被強制重新導向的防火牆通訊埠號。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Firewall source zones that should be forced locally."
 msgstr "本地應被強制重新導向的防火牆來源區域。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush DNS Cache"
 msgstr "清除 DNS 快取"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "在 Adblock 行程啟動前也要清除 DNS 快取。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid "Force Local DNS"
 msgstr "強制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
 msgid "Forced Ports"
 msgstr "強制埠號"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
 msgid "Forced Zones"
 msgstr "強制區域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:330
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -373,7 +367,7 @@ msgstr ""
 "透過 tcpdump 收集與 DNS 相關的網路流量，並隨需提供 DNS 報告；請注意：這需要安"
 "裝 \"tcpdump-mini\" 附加套件，且在完全重新啟動 Adblock 服務後才能生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:268
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -381,35 +375,39 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app adblock"
 msgstr "授予 luci-app-adblock 擁有 UCI 存取的權限"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:208
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
 msgid "Information"
 msgstr "資訊"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Jail Directory"
 msgstr "Jail 檔案目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:234
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Last Run"
 msgstr "最後執行"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
 msgid "Latest DNS Requests"
 msgstr "最新 DNS 請求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch"
 msgstr "限制性安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
 msgid "Limit SafeSearch to certain providers."
 msgstr "啟用限制性安全搜尋，以限制給定搜尋引擎的搜尋範圍。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+msgid "Line number to remove"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "List of available network devices used by tcpdump."
 msgstr "用於 tcpdump 的可用網路裝置清單。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -417,33 +415,14 @@ msgstr ""
 "用來觸發 Adblock 啟動的可用網路介面清單；選擇「未指定」則使用傳統的啟動逾時，"
 "而不透過網路觸發。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:397
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 "支援的 DNS 後端清單及其預設清單目錄；要重寫預設路徑，請使用「DNS 目錄」選項。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:273
-msgid ""
-"List of supported and fully pre-configured adblock sources, already active "
-"sources are pre-selected.<br /> <b><em>To avoid OOM errors, please do not "
-"select too many lists!</em></b><br /> List size information with the "
-"respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> (-10k), "
-"<b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 MByte devices,"
-"<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for 256-512 MByte "
-"devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more RAM and Multicore "
-"support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;</p>"
-msgstr ""
-"Adblock 支援的來源清單（完全預先配置），預先選擇的來源已啟動。<br /><b><em>為"
-"避免出現 OOM 錯誤，請不要選擇太多的清單！</em></b><br />與清單包含域名數和各"
-"自使用範圍相關的資訊，如下所述：<br />&#8226;&#xa0;<b>S</b> (&lt;10k), <b>M</"
-"b> (10k-30k) 和 <b>L</b> (30k-80k) 適用於 128MB 裝置，<br />&#8226;&#xa0;"
-"<b>XL</b> (80k-200k) 適用於 256-512MB 裝置，<br />&#8226;&#xa0;<b>XXL</b> "
-"(&gt;200k) 則需要更多的 RAM 和多核心處理器支援（例如：x86 抑或樹莓派裝置）。"
-"<br /><p>&#xa0;</p>"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:383
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支援的下載工具清單（完全預先配置）。"
 
@@ -452,7 +431,7 @@ msgstr "支援的下載工具清單（完全預先配置）。"
 msgid "Log View"
 msgstr "日誌檢視"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid "Low Priority Service"
 msgstr "低優先權服務"
 
@@ -473,7 +452,7 @@ msgstr "尚無與 Adblock 相關的日誌！"
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:482
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "\"msmtp\" 使用的設定檔，用於 Adblock 寄送通知電子郵件。"
 
@@ -485,7 +464,7 @@ msgstr "查詢"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查詢「特定網域」的活躍封鎖清單和備份。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -493,11 +472,11 @@ msgstr ""
 "提高通知數量；除非整體「封鎖清單數」小於或等於給定的限制，否則將不再取得電子"
 "郵件。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adblock 通知電子郵件的收件人位址。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -505,7 +484,7 @@ msgstr ""
 "重新導向指定區域的所有「DNS 查詢」到本地 DNS 解析器（適用於 UDP 與 TCP 協"
 "定）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:349
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -515,7 +494,6 @@ msgstr ""
 "新啟動 Adblock 服務後才能生效。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Refresh"
 msgstr "重新整理"
 
@@ -527,163 +505,160 @@ msgstr "重新整理 DNS 報告"
 msgid "Refresh Timer"
 msgstr "重新整理計時器"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:242
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
 msgid "Refresh Timer..."
 msgstr "重新整理計時器…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:331
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
 msgid "Refresh..."
 msgstr "重新整理…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:326
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
 msgid "Relax SafeSearch"
 msgstr "放寬安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+msgid "Reload"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+msgid "Remove an existing job"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report Chunk Count"
 msgstr "報告區塊數量"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report Chunk Size"
 msgstr "報告區塊大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Report Directory"
 msgstr "報告目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Report Interface"
 msgstr "報告介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Report Ports"
 msgstr "報告埠號"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
 msgid "Report chunk count used by tcpdump."
 msgstr "報告 tcpdump 使用的區塊數量。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:462
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "報告 tcpdump 使用的區塊大小（單位：MB）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-msgid ""
-"Resets the final DNS blocklist 'adb_list.overall' after DNS backend loading. "
-"Please note: This option starts a small ubus/adblock monitor in the "
-"background."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+msgid "Restart"
 msgstr ""
-"在 DNS 後端載入後，重設最終的 DNS 封鎖清單 \"adb_list.overall\"；請注意：啟用"
-"此選項會在後台啟動用於 Adblock 的 ubus 小型監視器。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:96
 msgid "Result"
 msgstr "結果"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:228
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Directories"
 msgstr "執行目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:231
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Flags"
 msgstr "執行旗標"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Interfaces"
 msgstr "執行介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 msgid "Run Utils"
 msgstr "執行工具"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:83
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
 msgid "Save"
 msgstr "儲存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:334
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 "寄送與 Adblock 相關的通知電子郵件；請注意：這需要安裝 \"msmtp\" 附加套件。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adblock 通知電子郵件的寄件人位址。"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:29
-msgid "Set/Replace a new adblock job"
-msgstr "設定／取代 Adblock 新工作"
+msgid "Set a new adblock job"
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr "平行下載處理（包含排序、合併等）的下載佇列大小。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:494
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
 msgid "Sources (Size, Focus)"
 msgstr "來源（大小、聚焦的類別）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump 使用的通訊埠號（以空格分隔）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:391
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
 msgid "Special config options for the selected download utility."
 msgstr "已選擇下載工具的特殊組態選項。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:307
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
 msgid "Start Timestamp"
 msgstr "啟動時間戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:287
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
 msgid "Startup Trigger Interface"
 msgstr "啟動觸發介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
 msgid "Status / Version"
 msgstr "狀態／版本"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:250
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
 msgid "Suspend"
 msgstr "掛起"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-msgid ""
-"Target directory for DNS related report files. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+msgid "Target directory for DNS related report files."
 msgstr ""
-"DNS 相關報告檔的目標目錄（預設值：\"/tmp\"）；請最好使用 USB 隨身碟或其他本地"
-"磁碟來儲存。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:377
-msgid ""
-"Target directory for blocklist backups. Default is '/tmp', please use "
-"preferably an usb stick or another local disk."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+msgid "Target directory for blocklist backups."
 msgstr ""
-"封鎖清單備份的目標目錄（預設值：\"/tmp\"）；請最好使用 USB 隨身碟或其他本地磁"
-"碟來儲存。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "產生封鎖清單 \"adb_list.overall\" 的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "產生 Jail 封鎖清單 \"adb_list.jail\" 的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
 msgid "The Refresh Timer could not been updated."
 msgstr "重新整理計時器無法更新。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:74
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
 msgid "The Refresh Timer has been updated."
 msgstr "重新整理計時器已更新。"
 
@@ -723,17 +698,17 @@ msgstr ""
 "入一個域名，允許使用 \"#\" 來引入註解，但不允許使用 IP 位址、萬用字元和正規表"
 "示式。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:304
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
 msgid ""
-"This shows the last generated DNS Report, press the refresh button to get a "
-"current one."
-msgstr "此處顯示最後產生的 DNS 報告，請按下「重新整理」按鈕以更新報告。"
+"This tab shows the last generated DNS Report, press the 'Refresh' button to "
+"get a current one."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
 msgid "Time"
 msgstr "時間"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "等待 DNS 後端成功重新啟動的逾時值。"
 
@@ -743,19 +718,19 @@ msgid ""
 "job for these lists."
 msgstr "要保持最新的 Adblock 清單，您應該設定這些清單的自動更新工作。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
 msgid "Top 10 Statistics"
 msgstr "前 10 統計"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:478
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Topic for adblock notification E-Mails."
 msgstr "Adblock 通知電子郵件的主旨。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
 msgid "Total DNS Requests"
 msgstr "DNS 請求總數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:354
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
@@ -764,7 +739,12 @@ msgstr "觸發延遲"
 msgid "Unable to save changes: %s"
 msgstr "無法儲存變更（訊息：%s）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:346
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+msgid "Variants"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
 msgid "Verbose Debug Logging"
 msgstr "詳細除錯日誌"
 
@@ -775,15 +755,15 @@ msgid ""
 "take effect."
 msgstr "白名單變更已儲存；請重新整理您的 Adblock 清單來使變更生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:278
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
 msgid "Whitelist..."
 msgstr "白名單…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:400
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "Dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -791,14 +771,73 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "最大結果集大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
 msgid "named (/var/lib/bind)"
 msgstr "BIND (/var/lib/bind)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
 msgstr "原始 (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:401
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "Unbound (/var/lib/unbound)"
+
+#~ msgid ""
+#~ "Changes on this tab needs a full adblock service restart to take effect."
+#~ "<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "此分頁上的變更需要您完全重新啟動 Adblock 服務後才能生效。<br /><p>&#xa0;</"
+#~ "p>"
+
+#~ msgid "DNS File Reset"
+#~ msgstr "DNS 檔案重設"
+
+#~ msgid ""
+#~ "List of supported and fully pre-configured adblock sources, already "
+#~ "active sources are pre-selected.<br /> <b><em>To avoid OOM errors, please "
+#~ "do not select too many lists!</em></b><br /> List size information with "
+#~ "the respective domain ranges as follows:<br /> &#8226;&#xa0;<b>S</b> "
+#~ "(-10k), <b>M</b> (10k-30k) and <b>L</b> (30k-80k) should work for 128 "
+#~ "MByte devices,<br /> &#8226;&#xa0;<b>XL</b> (80k-200k) should work for "
+#~ "256-512 MByte devices,<br /> &#8226;&#xa0;<b>XXL</b> (200k-) needs more "
+#~ "RAM and Multicore support, e.g. x86 or raspberry devices.<br /> <p>&#xa0;"
+#~ "</p>"
+#~ msgstr ""
+#~ "Adblock 支援的來源清單（完全預先配置），預先選擇的來源已啟動。<br /"
+#~ "><b><em>為避免出現 OOM 錯誤，請不要選擇太多的清單！</em></b><br />與清單包"
+#~ "含域名數和各自使用範圍相關的資訊，如下所述：<br />&#8226;&#xa0;<b>S</b> "
+#~ "(&lt;10k), <b>M</b> (10k-30k) 和 <b>L</b> (30k-80k) 適用於 128MB 裝置，"
+#~ "<br />&#8226;&#xa0;<b>XL</b> (80k-200k) 適用於 256-512MB 裝置，<br /"
+#~ ">&#8226;&#xa0;<b>XXL</b> (&gt;200k) 則需要更多的 RAM 和多核心處理器支援"
+#~ "（例如：x86 抑或樹莓派裝置）。<br /><p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Resets the final DNS blocklist 'adb_list.overall' after DNS backend "
+#~ "loading. Please note: This option starts a small ubus/adblock monitor in "
+#~ "the background."
+#~ msgstr ""
+#~ "在 DNS 後端載入後，重設最終的 DNS 封鎖清單 \"adb_list.overall\"；請注意："
+#~ "啟用此選項會在後台啟動用於 Adblock 的 ubus 小型監視器。"
+
+#~ msgid "Set/Replace a new adblock job"
+#~ msgstr "設定／取代 Adblock 新工作"
+
+#~ msgid ""
+#~ "Target directory for DNS related report files. Default is '/tmp', please "
+#~ "use preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "DNS 相關報告檔的目標目錄（預設值：\"/tmp\"）；請最好使用 USB 隨身碟或其他"
+#~ "本地磁碟來儲存。"
+
+#~ msgid ""
+#~ "Target directory for blocklist backups. Default is '/tmp', please use "
+#~ "preferably an usb stick or another local disk."
+#~ msgstr ""
+#~ "封鎖清單備份的目標目錄（預設值：\"/tmp\"）；請最好使用 USB 隨身碟或其他本"
+#~ "地磁碟來儲存。"
+
+#~ msgid ""
+#~ "This shows the last generated DNS Report, press the refresh button to get "
+#~ "a current one."
+#~ msgstr "此處顯示最後產生的 DNS 報告，請按下「重新整理」按鈕以更新報告。"

--- a/applications/luci-app-adblock/root/usr/share/rpcd/acl.d/luci-app-adblock.json
+++ b/applications/luci-app-adblock/root/usr/share/rpcd/acl.d/luci-app-adblock.json
@@ -19,10 +19,13 @@
 				"/usr/sbin/logread -e adblock-": [ "exec" ],
 				"/etc/init.d/adblock list" : [ "exec" ],
 				"/etc/init.d/adblock reload" : [ "exec" ],
+				"/etc/init.d/adblock restart" : [ "exec" ],
 				"/etc/init.d/adblock suspend" : [ "exec" ],
 				"/etc/init.d/adblock resume" : [ "exec" ],
 				"/etc/init.d/adblock report * [0-9]* [a-z]* json" : [ "exec" ],
-				"/etc/init.d/adblock timer * [0-9]* [0-9*]* [1-7,-*]*" : [ "exec" ],
+				"/etc/init.d/adblock timer list" : [ "exec" ],
+				"/etc/init.d/adblock timer remove [0-9]*" : [ "exec" ],
+				"/etc/init.d/adblock timer add * [0-9]* [0-9*]* [1-7,-*]*" : [ "exec" ],
 				"/etc/init.d/adblock query *" : [ "exec" ]
 			},
 			"uci": ["adblock"]


### PR DESCRIPTION
* made the blocklist selection/categories much more flexible
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>