### PR TITLE
 luci-app-https-dns-proxy: add mozilla trr cloudflare provider

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-mozilla.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-mozilla.lua
@@ -1,6 +1,6 @@
 return {
-	name = "Cloudflare-Firefox",
-	label = _("Cloudflare (Firefox)"),
+	name = "Cloudflare-Mozilla-TRR",
+	label = _("Cloudflare (Mozilla’s Trusted Recursive Resolver (TRR) program)"),
 	resolver_url = "https://mozilla.cloudflare-dns.com/dns-query",
 	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001",
 	help_link = "https://developers.cloudflare.com/1.1.1.1/privacy/firefox",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-mozilla.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-mozilla.lua
@@ -1,6 +1,6 @@
 return {
 	name = "Cloudflare-Mozilla-TRR",
-	label = _("Cloudflare (Mozilla’s Trusted Recursive Resolver (TRR) program)"),
+	label = _("Cloudflare (Mozilla’s TRR program)"),
 	resolver_url = "https://mozilla.cloudflare-dns.com/dns-query",
 	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001",
 	help_link = "https://developers.cloudflare.com/1.1.1.1/privacy/firefox",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-mozilla.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns-mozilla.lua
@@ -1,0 +1,8 @@
+return {
+	name = "Cloudflare-Firefox",
+	label = _("Cloudflare (Firefox)"),
+	resolver_url = "https://mozilla.cloudflare-dns.com/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001",
+	help_link = "https://developers.cloudflare.com/1.1.1.1/privacy/firefox",
+	help_link_text = "Cloudflare Resolver for Firefox"
+}


### PR DESCRIPTION
Add the Cloudflare Resolver for Firefox (https://developers.cloudflare.com/1.1.1.1/privacy/firefox) as a new DoH provider.  
