### PR TITLE
 luci-proto-gre: backport to 19.07

### DIFF
--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -2759,6 +2759,20 @@ msgstr ""
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr ""

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -2822,6 +2822,20 @@ msgstr "Clau"
 msgid "Key #%d"
 msgstr "Clau #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Mata"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -2874,6 +2874,20 @@ msgstr "Klíč"
 msgid "Key #%d"
 msgstr "Klíč #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Zabít"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -2907,6 +2907,20 @@ msgstr "Schlüssel"
 msgid "Key #%d"
 msgstr "Schlüssel Nr. %d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr "Schlüssel für eingehende Pakete (optional)."
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr "Schlüssel für ausgehende Pakete (optional)."
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Töten"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -2839,6 +2839,20 @@ msgstr "Κλειδί"
 msgid "Key #%d"
 msgstr "Κλειδί #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Σκότωμα"

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -2810,6 +2810,20 @@ msgstr "Key"
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Kill"

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -2902,6 +2902,20 @@ msgstr "Clave"
 msgid "Key #%d"
 msgstr "Clave #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr "Clave para paquetes entrantes (opcional)."
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr "Clave para paquetes salientes (opcional)."
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Matar"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -2919,6 +2919,20 @@ msgstr "Clé"
 msgid "Key #%d"
 msgstr "Clé n° %d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr "Clé pour les paquets entrants (optionnel)."
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr "Clé pour les paquets sortants (optionnel)."
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Forcer l'arrêt"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -2784,6 +2784,20 @@ msgstr ""
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr ""

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -2761,6 +2761,20 @@ msgstr ""
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr ""

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -2905,6 +2905,20 @@ msgstr "Kulcs"
 msgid "Key #%d"
 msgstr "%d. kulcs"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Kilövés"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -2842,6 +2842,20 @@ msgstr "Chiave"
 msgid "Key #%d"
 msgstr "Chiave #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Uccidi"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -2871,7 +2871,21 @@ msgstr "キー"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1385
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1397
 msgid "Key #%d"
-msgstr "キー#%d"
+msgstr "キー #%d"
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -2815,6 +2815,20 @@ msgstr ""
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "강제 종료"

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -2759,6 +2759,20 @@ msgstr ""
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr ""

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -2780,6 +2780,20 @@ msgstr "Kunci"
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Tamatkan"

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -2818,6 +2818,20 @@ msgstr "Nøkkel"
 msgid "Key #%d"
 msgstr "Nøkkel #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Drep"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -2890,6 +2890,20 @@ msgstr "Klucz"
 msgid "Key #%d"
 msgstr "Klucz #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr "Klucz do pakietów przychodzących (opcjonalnie)."
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr "Klucz do pakietów wychodzących (opcjonalnie)."
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Zabij"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -2908,6 +2908,20 @@ msgstr "Chave"
 msgid "Key #%d"
 msgstr "Chave #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr "Chave para os pacotes da entrada (opcional)."
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr "Chave para os pacotes da saída (optional)."
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Matar"

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -2945,6 +2945,20 @@ msgstr "Chave"
 msgid "Key #%d"
 msgstr "Chave #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr "Chave para os pacotes da entrada (opcional)."
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr "Chave para os pacotes da saída (optional)."
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Matar"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -2793,6 +2793,20 @@ msgstr ""
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Opreste"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -2901,6 +2901,20 @@ msgstr "Пароль (ключ)"
 msgid "Key #%d"
 msgstr "Ключ №%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr "Ключ для входящих пакетов (опционально)."
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr "Ключ для исходящих пакетов (опционально)."
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Принудительно завершить"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -2803,6 +2803,20 @@ msgstr "Kľúč"
 msgid "Key #%d"
 msgstr "Kľúč #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Ukončiť"

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -2781,6 +2781,20 @@ msgstr "Nyckel"
 msgid "Key #%d"
 msgstr "Nyckel #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Döda"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -2750,6 +2750,20 @@ msgstr ""
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr ""

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -2802,6 +2802,20 @@ msgstr ""
 msgid "Key #%d"
 msgstr ""
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr ""

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -2920,6 +2920,20 @@ msgstr "Ключ"
 msgid "Key #%d"
 msgstr "Ключ #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Знищити"

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -2859,6 +2859,20 @@ msgstr "Phím "
 msgid "Key #%d"
 msgstr "Phím %d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "Hủy"

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -2811,6 +2811,20 @@ msgstr "密钥"
 msgid "Key #%d"
 msgstr "密码 #%d"
 
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
+
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
 msgstr "强制关闭"

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -2814,7 +2814,21 @@ msgstr "金鑰"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1385
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1397
 msgid "Key #%d"
-msgstr "金鑰 #%d"
+msgstr "鑰匙 #%d"
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
+msgid "Key for incoming packets (optional)."
+msgstr ""
+
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
+#: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
+msgid "Key for outgoing packets (optional)."
+msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"

--- a/protocols/luci-proto-gre/Makefile
+++ b/protocols/luci-proto-gre/Makefile
@@ -1,0 +1,21 @@
+#
+# Based on luci-proto-ipip.
+# Credited author of luci-proto-ipip is Roger Pueyo Centelles <roger.pueyo@guifi.net>
+# Copyright 2016 Roger Pueyo Centelles <roger.pueyo@guifi.net>
+#
+# Modified by Jan Betik <jan.betik@svine.su>
+# Copyright 2020 Jan Betik <jan.betik@svine.su>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Support for GRE tunnels (RFC2784)
+LUCI_DEPENDS:=+gre
+
+PKG_MAINTAINER:=Jan Betik <jan.betik@svine.su>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js
@@ -93,7 +93,7 @@ return network.registerProtocol('gre', {
 		o.optional = true;
 		o.datatype = 'integer';
 
-		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optional)."));
 		o.optional = true;
 		o.datatype = 'integer';
 

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js
@@ -1,0 +1,96 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^gre4-.+$/);
+
+return network.registerProtocol('gre', {
+	getI18n: function() {
+		return _('GRE tunnel over IPv4');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || 'gre4-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function() {
+		return 'gre';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peeraddr', _("Remote IPv4 address or FQDN"), _("The IPv4 address or the fully-qualified domain name of the remote tunnel end."));
+		o.optional = false;
+		o.datatype = 'or(hostname,ip4addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ipaddr', _("Local IPv4 address"), _("The local IPv4 address over which the tunnel is created (optional)."));
+		o.optional = true;
+		o.datatype = 'ip4addr("nomask")';
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _("Bind interface"), _("Bind the tunnel to this interface (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'mtu', _("Override MTU"), _("Specify an MTU (Maximum Transmission Unit) other than the default (1280 bytes) (optional)."));
+		o.optional = true;
+		o.placeholder = 1280;
+		o.datatype = 'range(68, 9200)';
+
+		o = s.taboption('advanced', form.Value, 'ttl', _("Override TTL"), _("Specify a TTL (Time to Live) for the encapsulating packet other than the default (64) (optional)."));
+		o.optional = true;
+		o.placeholder = 64;
+		o.datatype = 'min(1)';
+
+		o = s.taboption('advanced', form.Value, 'tos', _('Override TOS'), _("Specify a TOS (Type of Service). Can be either <code>inherit</code> (the outer      header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o.optional = true;
+		o.validate = function(section_id, value) {
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
+				return _('Invalid value');
+
+			return true;
+		};
+
+		o = s.taboption('advanced', form.Flag, 'df', _("Don't Fragment"), _("Enable the DF (Don't Fragment) flag of the encapsulating packets."));
+		o.default = o.enabled;
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		s.taboption('advanced', form.Flag, 'icsum', _("Incoming checksum"), _("Require incoming checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'ocsum', _("Outgoing checksum"), _("Compute outgoing checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'iseqno', _("Incoming serialization"), _("Require incoming packets serialization (optional)."));
+		s.taboption('advanced', form.Flag, 'oseqno', _("Outgoing serialization"), _("Perform outgoing packets serialization (optional)."));
+
+	}
+});

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js
@@ -46,6 +46,13 @@ return network.registerProtocol('gre', {
 		o = s.taboption('general', form.Value, 'ipaddr', _("Local IPv4 address"), _("The local IPv4 address over which the tunnel is created (optional)."));
 		o.optional = true;
 		o.datatype = 'ip4addr("nomask")';
+		o.load = function(section_id) {
+			return network.getWANNetworks().then(L.bind(function(nets) {
+				if (nets.length)
+					this.placeholder = nets[0].getIPAddr();
+				return form.Value.prototype.load.apply(this, [section_id]);
+			}, this));
+		};
 
 		// -- advanced ---------------------------------------------------------------------
 
@@ -64,11 +71,11 @@ return network.registerProtocol('gre', {
 		o.placeholder = 64;
 		o.datatype = 'min(1)';
 
-		o = s.taboption('advanced', form.Value, 'tos', _('Override TOS'), _("Specify a TOS (Type of Service). Can be either <code>inherit</code> (the outer      header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o = s.taboption('advanced', form.Value, 'tos', _("Override TOS"), _("Specify a TOS (Type of Service). Can be <code>inherit</code> (the outer header inherits the value of the inner header), or an hexadecimal value <code>00..FF</code> (optional)."));
 		o.optional = true;
 		o.validate = function(section_id, value) {
-			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
-				return _('Invalid value');
+			if (value.length > 0 && !value.match(/^[a-f0-9]{1,2}$/i) && !value.match(/^inherit$/i))
+				return _("Invalid TOS value, expected 00..FF or inherit");
 
 			return true;
 		};
@@ -77,6 +84,9 @@ return network.registerProtocol('gre', {
 		o.default = o.enabled;
 
 		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Flag, 'multicast', _("Multicast"), _("Enable support for multicast traffic (optional)."));
 		o.optional = true;
 
 		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js
@@ -46,6 +46,13 @@ return network.registerProtocol('gretap', {
 		o = s.taboption('general', form.Value, 'ipaddr', _("Local IPv4 address"), _("The local IPv4 address over which the tunnel is created (optional)."));
 		o.optional = true;
 		o.datatype = 'ip4addr("nomask")';
+		o.load = function(section_id) {
+			return network.getWANNetworks().then(L.bind(function(nets) {
+				if (nets.length)
+					this.placeholder = nets[0].getIPAddr();
+				return form.Value.prototype.load.apply(this, [section_id]);
+			}, this));
+		};
 
 		o = s.taboption('general', widgets.NetworkSelect, 'network', _("Network interface"), _("Logical network to which the tunnel will be added (bridged) (optional)."));
 		o.exclude = s.section;
@@ -69,11 +76,11 @@ return network.registerProtocol('gretap', {
 		o.placeholder = 64;
 		o.datatype = 'min(1)';
 
-		o = s.taboption('advanced', form.Value, 'tos', _('Override TOS'), _("Specify a TOS (Type of Service). Can be either <code>inherit</code> (the outer      header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o = s.taboption('advanced', form.Value, 'tos', _("Override TOS"), _("Specify a TOS (Type of Service). Can be <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value <code>00..FF</code> (optional)."));
 		o.optional = true;
 		o.validate = function(section_id, value) {
-			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
-				return _('Invalid value');
+			if (value.length > 0 && !value.match(/^[a-f0-9]{1,2}$/i) && !value.match(/^inherit$/i))
+				return _("Invalid TOS value, expected 00..FF or inherit");
 
 			return true;
 		};
@@ -82,6 +89,9 @@ return network.registerProtocol('gretap', {
 		o.default = o.enabled;
 
 		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Flag, 'multicast', _("Multicast"), _("Enable support for multicast traffic (optional)."));
 		o.optional = true;
 
 		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js
@@ -98,7 +98,7 @@ return network.registerProtocol('gretap', {
 		o.optional = true;
 		o.datatype = 'integer';
 
-		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optional)."));
 		o.optional = true;
 		o.datatype = 'integer';
 

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js
@@ -1,0 +1,101 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^gre4t-.+$/);
+
+return network.registerProtocol('gretap', {
+	getI18n: function() {
+		return _('GRETAP tunnel over IPv4');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || 'gre4t-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function() {
+		return 'gre';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peeraddr', _("Remote IPv4 address or FQDN"), _("The IPv4 address or the fully-qualified domain name of the remote tunnel end."));
+		o.optional = false;
+		o.datatype = 'or(hostname,ip4addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ipaddr', _("Local IPv4 address"), _("The local IPv4 address over which the tunnel is created (optional)."));
+		o.optional = true;
+		o.datatype = 'ip4addr("nomask")';
+
+		o = s.taboption('general', widgets.NetworkSelect, 'network', _("Network interface"), _("Logical network to which the tunnel will be added (bridged) (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _("Bind interface"), _("Bind the tunnel to this interface (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'mtu', _("Override MTU"), _("Specify an MTU (Maximum Transmission Unit) other than the default (1280 bytes) (optional)."));
+		o.optional = true;
+		o.placeholder = 1280;
+		o.datatype = 'range(68, 9200)';
+
+		o = s.taboption('advanced', form.Value, 'ttl', _("Override TTL"), _("Specify a TTL (Time to Live) for the encapsulating packet other than the default (64) (optional)."));
+		o.optional = true;
+		o.placeholder = 64;
+		o.datatype = 'min(1)';
+
+		o = s.taboption('advanced', form.Value, 'tos', _('Override TOS'), _("Specify a TOS (Type of Service). Can be either <code>inherit</code> (the outer      header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o.optional = true;
+		o.validate = function(section_id, value) {
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
+				return _('Invalid value');
+
+			return true;
+		};
+
+		o = s.taboption('advanced', form.Flag, 'df', _("Don't Fragment"), _("Enable the DF (Don't Fragment) flag of the encapsulating packets."));
+		o.default = o.enabled;
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		s.taboption('advanced', form.Flag, 'icsum', _("Incoming checksum"), _("Require incoming checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'ocsum', _("Outgoing checksum"), _("Compute outgoing checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'iseqno', _("Incoming serialization"), _("Require incoming packets serialization (optional)."));
+		s.taboption('advanced', form.Flag, 'oseqno', _("Outgoing serialization"), _("Perform outgoing packets serialization (optional)."));
+
+	}
+});

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
@@ -95,7 +95,7 @@ return network.registerProtocol('grev6', {
 		o.optional = true;
 		o.datatype = 'integer';
 
-		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optional)."));
 		o.optional = true;
 		o.datatype = 'integer';
 

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
@@ -1,0 +1,98 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^gre6-.+$/);
+
+return network.registerProtocol('grev6', {
+	getI18n: function() {
+		return _('GRE tunnel over IPv6');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || 'gre6-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function() {
+		return 'gre';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peer6addr', _("Remote IPv6 address or FQDN"), _("The IPv6 address or the fully-qualified domain name of the remote tunnel end."));
+		o.optional = false;
+		o.datatype = 'or(hostname,ip6addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ip6addr', _("Local IPv6 address"), _("The local IPv6 address over which the tunnel is created (optional)."));
+		o.optional = true;
+		o.datatype = 'ip6addr("nomask")';
+
+		o = s.taboption('general', widgets.NetworkSelect, 'weakif', _("Source interface"), _("Logical network from which to select the local endpoint if local IPv6 address is empty and no WAN IPv6 is available (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _("Bind interface"), _("Bind the tunnel to this interface (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'mtu', _("Override MTU"), _("Specify an MTU (Maximum Transmission Unit) other than the default (1280 bytes) (optional)."));
+		o.optional = true;
+		o.placeholder = 1280;
+		o.datatype = 'range(68, 9200)';
+
+		o = s.taboption('advanced', form.Value, 'ttl', _("Override TTL"), _("Specify a TTL (Time to Live) for the encapsulating packet other than the default (64) (optional)."));
+		o.optional = true;
+		o.placeholder = 64;
+		o.datatype = 'min(1)';
+
+		o = s.taboption('advanced', form.Value, 'tos', _('Traffic Class'), _("Specify a Traffic Class. Can be either <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o.optional = true;
+		o.validate = function(section_id, value) {
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
+				return _('Invalid value');
+
+			return true;
+		};
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		s.taboption('advanced', form.Flag, 'icsum', _("Incoming checksum"), _("Require incoming checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'ocsum', _("Outgoing checksum"), _("Compute outgoing checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'iseqno', _("Incoming serialization"), _("Require incoming packets serialization (optional)."));
+		s.taboption('advanced', form.Flag, 'oseqno', _("Outgoing serialization"), _("Perform outgoing packets serialization (optional)."));
+
+	}
+});

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
@@ -46,6 +46,13 @@ return network.registerProtocol('grev6', {
 		o = s.taboption('general', form.Value, 'ip6addr', _("Local IPv6 address"), _("The local IPv6 address over which the tunnel is created (optional)."));
 		o.optional = true;
 		o.datatype = 'ip6addr("nomask")';
+		o.load = function(section_id) {
+			return network.getWAN6Networks().then(L.bind(function(nets) {
+				if (Array.isArray(nets) && nets.length)
+					this.placeholder = nets[0].getIP6Addr();
+				return form.Value.prototype.load.apply(this, [section_id]);
+			}, this));
+		};
 
 		o = s.taboption('general', widgets.NetworkSelect, 'weakif', _("Source interface"), _("Logical network from which to select the local endpoint if local IPv6 address is empty and no WAN IPv6 is available (optional)."));
 		o.exclude = s.section;
@@ -69,16 +76,19 @@ return network.registerProtocol('grev6', {
 		o.placeholder = 64;
 		o.datatype = 'min(1)';
 
-		o = s.taboption('advanced', form.Value, 'tos', _('Traffic Class'), _("Specify a Traffic Class. Can be either <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o = s.taboption('advanced', form.Value, 'tos', _("Traffic Class"), _("Specify a Traffic Class. Can be <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value <code>00..FF</code> (optional)."));
 		o.optional = true;
 		o.validate = function(section_id, value) {
-			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
-				return _('Invalid value');
+			if (value.length > 0 && !value.match(/^[a-f0-9]{1,2}$/i) && !value.match(/^inherit$/i)))
+				return _("Invalid Traffic Class value, expected 00..FF or inherit");
 
 			return true;
 		};
 
 		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Flag, 'multicast', _("Multicast"), _("Enable support for multicast traffic (optional)."));
 		o.optional = true;
 
 		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js
@@ -79,7 +79,7 @@ return network.registerProtocol('grev6', {
 		o = s.taboption('advanced', form.Value, 'tos', _("Traffic Class"), _("Specify a Traffic Class. Can be <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value <code>00..FF</code> (optional)."));
 		o.optional = true;
 		o.validate = function(section_id, value) {
-			if (value.length > 0 && !value.match(/^[a-f0-9]{1,2}$/i) && !value.match(/^inherit$/i)))
+			if (value.length > 0 && !value.match(/^[a-f0-9]{1,2}$/i) && !value.match(/^inherit$/i))
 				return _("Invalid Traffic Class value, expected 00..FF or inherit");
 
 			return true;

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js
@@ -1,0 +1,103 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^gre6t-.+$/);
+
+return network.registerProtocol('grev6tap', {
+	getI18n: function() {
+		return _('GRETAP tunnel over IPv6');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || 'gre6t-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function() {
+		return 'gre';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		// -- general ---------------------------------------------------------------------
+
+		o = s.taboption('general', form.Value, 'peer6addr', _("Remote IPv6 address or FQDN"), _("The IPv6 address or the fully-qualified domain name of the remote tunnel end."));
+		o.optional = false;
+		o.datatype = 'or(hostname,ip6addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ip6addr', _("Local IPv6 address"), _("The local IPv6 address over which the tunnel is created (optional)."));
+		o.optional = true;
+		o.datatype = 'ip6addr("nomask")';
+
+		o = s.taboption('general', widgets.NetworkSelect, 'weakif', _("Source interface"), _("Logical network from which to select the local endpoint if local IPv6 address is empty and no WAN IPv6 is available (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('general', widgets.NetworkSelect, 'network', _("Network interface"), _("Logical network to which the tunnel will be added (bridged) (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		// -- advanced ---------------------------------------------------------------------
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _("Bind interface"), _("Bind the tunnel to this interface (optional)."));
+		o.exclude = s.section;
+		o.nocreate = true;
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'mtu', _("Override MTU"), _("Specify an MTU (Maximum Transmission Unit) other than the default (1280 bytes) (optional)."));
+		o.optional = true;
+		o.placeholder = 1280;
+		o.datatype = 'range(68, 9200)';
+
+		o = s.taboption('advanced', form.Value, 'ttl', _("Override TTL"), _("Specify a TTL (Time to Live) for the encapsulating packet other than the default (64) (optional)."));
+		o.optional = true;
+		o.placeholder = 64;
+		o.datatype = 'min(1)';
+
+		o = s.taboption('advanced', form.Value, 'tos', _('Traffic Class'), _("Specify a Traffic Class. Can be either <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o.optional = true;
+		o.validate = function(section_id, value) {
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
+				return _('Invalid value');
+
+			return true;
+		};
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o.optional = true;
+		o.datatype = 'integer';
+
+		s.taboption('advanced', form.Flag, 'icsum', _("Incoming checksum"), _("Require incoming checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'ocsum', _("Outgoing checksum"), _("Compute outgoing checksum (optional)."));
+		s.taboption('advanced', form.Flag, 'iseqno', _("Incoming serialization"), _("Require incoming packets serialization (optional)."));
+		s.taboption('advanced', form.Flag, 'oseqno', _("Outgoing serialization"), _("Perform outgoing packets serialization (optional)."));
+
+	}
+});

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js
@@ -42,6 +42,13 @@ return network.registerProtocol('grev6tap', {
 		o = s.taboption('general', form.Value, 'peer6addr', _("Remote IPv6 address or FQDN"), _("The IPv6 address or the fully-qualified domain name of the remote tunnel end."));
 		o.optional = false;
 		o.datatype = 'or(hostname,ip6addr("nomask"))';
+		o.load = function(section_id) {
+			return network.getWAN6Networks().then(L.bind(function(nets) {
+				if (Array.isArray(nets) && nets.length)
+					this.placeholder = nets[0].getIP6Addr();
+				return form.Value.prototype.load.apply(this, [section_id]);
+			}, this));
+		};
 
 		o = s.taboption('general', form.Value, 'ip6addr', _("Local IPv6 address"), _("The local IPv6 address over which the tunnel is created (optional)."));
 		o.optional = true;
@@ -74,16 +81,19 @@ return network.registerProtocol('grev6tap', {
 		o.placeholder = 64;
 		o.datatype = 'min(1)';
 
-		o = s.taboption('advanced', form.Value, 'tos', _('Traffic Class'), _("Specify a Traffic Class. Can be either <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value starting with <code>0x</code> (optional)."));
+		o = s.taboption('advanced', form.Value, 'tos', _("Traffic Class"), _("Specify a Traffic Class. Can be <code>inherit</code> (the outer header inherits the value of the inner header) or an hexadecimal value <code>00..FF</code> (optional)."));
 		o.optional = true;
 		o.validate = function(section_id, value) {
-			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,2}$/) && !value.match(/^inherit$/i))
-				return _('Invalid value');
+			if (value.length > 0 && !value.match(/^[a-f0-9]{1,2}$/i) && !value.match(/^inherit$/i))
+				return _("Invalid Traffic Class value, expected 00..FF or inherit");
 
 			return true;
 		};
 
 		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
+
+		o = s.taboption('advanced', form.Flag, 'multicast', _("Multicast"), _("Enable support for multicast traffic (optional)."));
 		o.optional = true;
 
 		o = s.taboption('advanced', form.Value, 'ikey', _("Incoming key"), _("Key for incoming packets (optional)."));

--- a/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js
+++ b/protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js
@@ -100,7 +100,7 @@ return network.registerProtocol('grev6tap', {
 		o.optional = true;
 		o.datatype = 'integer';
 
-		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optinal)."));
+		o = s.taboption('advanced', form.Value, 'okey', _("Outgoing key"), _("Key for outgoing packets (optional)."));
 		o.optional = true;
 		o.datatype = 'integer';
 


### PR DESCRIPTION
This PR addresses #4510, backporting `luci-proto-gre` to the 19.07 branch. Thanks @feckert for identifying the relevant commits.
cc @mbargo23 