### PR TITLE
luci-app-unbound: fix interface selections to match UCI

### DIFF
--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
@@ -8,7 +8,8 @@ local ena, mcf, lci, lsv
 local rlh, rpv, vld, nvd, eds, prt, tlm
 local ctl, dlk, dom, dty, lfq, wfq, exa
 local dp6, d64, pfx, qry, qrs
-local pro, tgr, rsc, rsn, ag2, stt
+local pro, rsc, rsn, ag2, stt
+local tgr, ifc, wfc
 local rpn, din, ath
 
 local ut = require "luci.util"
@@ -125,7 +126,25 @@ if (valman == "0") then
     ag2:value("24", "24")
     ag2:value("99", "99 ("..translate("never")..")")
 
-    tgr = s1:taboption("advanced", Value, "trigger_interface",
+    ifc = s1:taboption("advanced", Value, "iface_lan",
+        translate("LAN Networks"),
+        translate("Networks to consider LAN (served) beyond those served by DHCP"))
+    ifc.template = "cbi/network_netlist"
+    ifc.widget = "checkbox"
+    ifc.rmempty = true
+    ifc.cast = "string"
+    ifc.nocreate = true
+
+    wfc = s1:taboption("advanced", Value, "iface_wan",
+        translate("WAN Networks"),
+        translate("Networks to consider WAN (unserved)"))
+    wfc.template = "cbi/network_netlist"
+    wfc.widget = "checkbox"
+    wfc.rmempty = true
+    wfc.cast = "string"
+    wfc.nocreate = true
+
+    tgr = s1:taboption("advanced", Value, "iface_trig",
         translate("Trigger Networks"),
         translate("Networks that may trigger Unbound to reload (avoid wan6)"))
     tgr.template = "cbi/network_netlist"


### PR DESCRIPTION
maintainer: me
tested: Linksys WRT3200ACM
description: iface_lan, iface_wan, and iface_trig were not supported in LuCI since they were added to UCI.