### PR TITLE
[19.07] luci-mod-system: implement system.description, system.notes

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
@@ -119,6 +119,13 @@ return view.extend({
 		o = s.taboption('general', form.Value, 'hostname', _('Hostname'));
 		o.datatype = 'hostname';
 
+		/* could be used also as a default for LLDP, SNMP "system description" in the future */
+		o = s.taboption('general', form.Value, 'description', _('Description'), _('An optional, short description for this device'));
+		o.optional = true;
+
+		o = s.taboption('general', form.TextValue, 'notes', _('Notes'), _('Optional, free-form notes about this device'));
+		o.optional = true;
+
 		o = s.taboption('general', form.ListValue, 'zonename', _('Timezone'));
 		o.value('UTC');
 


### PR DESCRIPTION
Implement two new text "options" for UCI system config, intended to
help humans describe the device.

"system.description" is a short, single-line description suitable for
selector UIs in remote administration applications, or remote UCI (over
ubus RPC), etc.  It would also be suitable as a default for LLDP/SNMP
"system description".

"system.notes" is a multi-line, free-form text field that can be used in
any way the user wishes, e.g. to hold installation notes, or unit serial
number and inventory number, location, etc.

Signed-off-by: Henrique de Moraes Holschuh <henrique@nic.br>