### PR TITLE
[18.06] luci-mod-admin-full: implement system.description, system.notes

### DIFF
--- a/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/system.lua
+++ b/modules/luci-mod-admin-full/luasrc/model/cbi/admin_system/system.lua
@@ -40,6 +40,14 @@ function o.write(self, section, value)
 end
 
 
+-- could be used also as a default for LLDP, SNMP "system description" in the future
+o = s:taboption("general", Value, "description", translate("Description"), translate("An optional, short description for this device"))
+o.optional = true
+
+o = s:taboption("general", TextValue, "notes", translate("Notes"), translate("Optional, free-form notes about this device"))
+o.optional = true
+
+
 o = s:taboption("general", ListValue, "zonename", translate("Timezone"))
 o:value("UTC")
 


### PR DESCRIPTION
Implement two new text "options" for UCI system config, intended to
help humans describe the device.

"system.description" is a short, single-line description suitable for
selector UIs in remote administration applications, or remote UCI (over
ubus RPC), etc.  It would also be suitable as a default for LLDP/SNMP
"system description".

"system.notes" is a multi-line, free-form text field that can be used in
any way the user wishes, e.g. to hold installation notes, or unit serial
number and inventory number, location, etc.

Signed-off-by: Henrique de Moraes Holschuh <henrique@nic.br>