### PR TITLE
luci-mod-system: zram fixes

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
@@ -194,7 +194,7 @@ return view.extend({
 			o.default     = 'lzo';
 			o.value('lzo', 'lzo');
 			o.value('lz4', 'lz4');
-			o.value('deflate', 'deflate');
+			o.value('zstd', 'zstd');
 
 			o = s.taboption('zram', form.Value, 'zram_comp_streams', _('ZRam Compression Streams'), _('Number of parallel threads used for compression'));
 			o.optional    = true;

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
@@ -195,11 +195,6 @@ return view.extend({
 			o.value('lzo', 'lzo');
 			o.value('lz4', 'lz4');
 			o.value('zstd', 'zstd');
-
-			o = s.taboption('zram', form.Value, 'zram_comp_streams', _('ZRam Compression Streams'), _('Number of parallel threads used for compression'));
-			o.optional    = true;
-			o.placeholder = 1;
-			o.datatype    = 'uinteger';
 		}
 
 		/*


### PR DESCRIPTION
Update luci-mod-system/zram to reflect the lastest zram-swap changes.

**NOTE**: This is **completely untested**. My motivation to test LuCI is zero, as I personally don't use it at all.