### PR TITLE
luci-app-ddns: Fix time error

### DIFF
--- a/applications/luci-app-ddns/root/usr/libexec/rpcd/luci.ddns
+++ b/applications/luci-app-ddns/root/usr/libexec/rpcd/luci.ddns
@@ -109,15 +109,15 @@ local methods = {
 					tonumber(s["force_interval"]) or 72,
 					s["force_unit"] or "hours" )
 
-				-- process running but update needs to happen
-				-- problems if force_seconds > uptime
-				force_seconds = (force_seconds > uptime) and uptime or force_seconds
+				local check_seconds = calc_seconds(
+					tonumber(s["check_interval"]) or 10,
+					s["check_unit"] or "minutes" )
 
 				if last_update > 0 then
-					local epoch = os.time() - uptime + last_update + force_seconds
+					local epoch = os.time() - uptime + last_update
 					-- use linux date to convert epoch
 					converted_last_update = epoch2date(epoch,date_format)
-					next_update = epoch2date(epoch + force_seconds)
+					next_update = epoch2date(epoch + force_seconds + check_seconds)
 				end
 
 				if pid > 0 and ( last_update + force_seconds - uptime ) <= 0 then


### PR DESCRIPTION
Fix https://github.com/openwrt/luci/issues/4506
The removal of "+ force_seconds" is to compare the 18.06 version of ddns.lua (https://github.com/openwrt/luci/blob/openwrt-18.06/applications/luci-app-ddns/luasrc/tools/ddns.lua), this can be fixed The bug of the last time overflow. 
The 114 line is removed because this will cause the bug that the next update time is wrong when the router is just started. 
In addition,I checked dynamic_dns_updater.sh and found that next_update should be "epoch + force_seconds + check_seconds", so I added the variable definition of check_seconds. Through the test, the time displayed by luci matches the time of the log file.
