### PR TITLE
themes: warn if booted from initramfs

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -59,6 +59,16 @@
 				</div>
 			<%- end -%>
 
+			<%- if boardinfo.rootfs_type == "initramfs" then -%>
+				<div class="alert-message warning">
+					<h4><%:System running in recovery (initramfs) mode.%></h4>
+					<p><%:No changes to settings will be stored and are lost after rebooting. This mode should only be used to install a firmware upgrade%></p>
+					<% if disp.lookup("admin/system/flash") then %>
+					  <div class="right"><a class="btn" href="<%=url("admin/system/flash")%>"><%:Go to firmware upgrade...%></a></div>
+					<% end %>
+				</div>
+			<%- end -%>
+
 			<noscript>
 				<div class="alert-message warning">
 					<h4><%:JavaScript required!%></h4>

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -81,6 +81,16 @@
 				<%- if luci.sys.process.info("uid") == 0 and luci.sys.user.getuser("root") and not luci.sys.user.getpasswd("root") and path ~= "admin-system-admin-password" then -%>
 				<%- end -%>
 
+				<%- if boardinfo.rootfs_type == "initramfs" then -%>
+					<div class="alert-message warning">
+						<h4><%:Sytem running in recovery (initramfs) mode.%></h4>
+						<p><%:No changes to settings will be stored and are lost after rebooting. This mode should only be used to install a firmware upgrade%></p>
+						<% if disp.lookup("admin/system/flash") then %>
+						  <div class="right"><a class="btn" href="<%=url("admin/system/flash")%>"><%:Go to firmware upgrade...%></a></div>
+						<% end %>
+					</div>
+				<%- end -%>
+
 				<noscript>
 					<div class="alert-message warning">
 						<h4><%:JavaScript required!%></h4>

--- a/themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm
+++ b/themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm
@@ -64,4 +64,14 @@
 		</div>
 		<%- end -%>
 
+		<%- if boardinfo.rootfs_type == "initramfs" then -%>
+		<div class="alert-message warning">
+			<h4><%:System running in recovery (initramfs) mode.%></h4>
+			<p><%:No changes to settings will be stored and are lost after rebooting. This mode should only be used to install a firmware upgrade%></p>
+			<% if disp.lookup("admin/system/flash") then %>
+			  <div class="right"><a class="btn" href="<%=url("admin/system/flash")%>"><%:Go to firmware upgrade...%></a></div>
+			<% end %>
+		</div>
+		<%- end -%>
+
 		<div id="tabmenu" style="display:none"></div>

--- a/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
+++ b/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
@@ -83,3 +83,13 @@
 			<% end %>
 		</div>
 		<%- end -%>
+
+		<%- if boardinfo.rootfs_type == "initramfs" then -%>
+		<div class="alert-message warning">
+			<h4><%:System running in recovery (initramfs) mode.%></h4>
+			<p><%:No changes to settings will be stored and are lost after rebooting. This mode should only be used to install a firmware upgrade%></p>
+			<% if disp.lookup("admin/system/flash") then %>
+			  <div class="right"><a class="btn" href="<%=url("admin/system/flash")%>"><%:Go to firmware upgrade...%></a></div>
+			<% end %>
+		</div>
+		<%- end -%>


### PR DESCRIPTION
Some devices offer a full LuCI interface from their recovery interface.
As it's read-only it should only be used for installing sysupgrades and
therefore warn users that no settings are saved.

Signed-off-by: Paul Spooren <mail@aparcar.org>