### PR TITLE
[19.07] luci-app-simple-adblock: bugfix: template layout on theme-openwrt-2020

### DIFF
--- a/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
@@ -195,7 +195,7 @@ else
 		ss = h:option(DummyValue, "_dummy", translate("Service Status"))
 		ss.template = "simple-adblock/status"
 		if tmpfsStatus == "statusSuccess" then
-			ss.value = translatef("%s is blocking %s domains (with %s).", packageVersion, getFileLines(outputFile), targetDNS)
+			ss.value = translatef("Blocking %s domains (with %s).", getFileLines(outputFile), targetDNS)
 		else
 			ss.value = statusTable[tmpfsStatus]
 		end
@@ -206,7 +206,7 @@ else
 		end
 		if tmpfsError then
 			es = h:option(DummyValue, "_dummy", translate("Collected Errors"))
-			es.template = "simple-adblock/error"
+			es.template = "simple-adblock/status"
 			es.value = ""
 			local err, e, url
 			for err in tmpfsError:gmatch("[%p%w]+") do
@@ -220,7 +220,7 @@ else
 		end
 	end
 	if packageVersion ~= "" then
-		buttons = h:option(DummyValue, "_dummy")
+		buttons = h:option(DummyValue, "_dummy", translate("Service Control"))
 		buttons.template = packageName .. "/buttons"
 	end
 end

--- a/applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm
+++ b/applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm
@@ -47,7 +47,7 @@
 	end
 -%>
 
-<div class="cbi-value"><label class="cbi-value-title">Service Control</label>
+<%+cbi/valueheader%>
 	<div class="cbi-value-field">
 		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
 			onclick="button_action(this)" />
@@ -69,7 +69,7 @@
 			onclick="button_action(this)" />
 		<span id="btn_disable_spinner" class="btn_spinner"></span>
 	</div>
-</div>
+<%+cbi/valuefooter%>
 
 <%-if not btn_start_status then%>
 <script type="text/javascript">document.getElementById("btn_start").disabled = true;</script>

--- a/applications/luci-app-simple-adblock/luasrc/view/simple-adblock/status.htm
+++ b/applications/luci-app-simple-adblock/luasrc/view/simple-adblock/status.htm
@@ -5,6 +5,8 @@ This is free software, licensed under the Apache License, Version 2.0
 
 <%+cbi/valueheader%>
 
-<input name="status" id="status" type="text" class="cbi-input-text" style="outline:none;border:none;box-shadow:none;background:transparent;font-weight:bold;line-height:30px;height:30px;width:50em;" value="<%=self:cfgvalue(section)%>" disabled="disabled" />
+<div style="font-weight:bold;">
+	<%=self:cfgvalue(section):gsub('\n', '<br />' )%>
+</div>
 
 <%+cbi/valuefooter%>

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -9,10 +9,6 @@ msgstr ""
 msgid "%s Error: %s %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:198
-msgid "%s is blocking %s domains (with %s)."
-msgstr ""
-
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:129
 msgid "%s is not installed or not found"
 msgstr ""
@@ -64,6 +60,10 @@ msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:350
 msgid "Blocked Hosts URLs"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:198
+msgid "Blocking %s domains (with %s)."
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:188
@@ -185,6 +185,10 @@ msgstr ""
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
+#: applications/luci-app-simple-adblock/root/usr/share/rpcd/acl.d/luci-app-simple-adblock.json:3
+msgid "Grant UCI and file access for luci-app-simple-adblock"
+msgstr ""
+
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:293
 msgid "IPv6 Support"
 msgstr ""
@@ -263,6 +267,10 @@ msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:300
 msgid "Run service after set delay on boot."
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:223
+msgid "Service Control"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:172


### PR DESCRIPTION
Update status/buttons templates to avoid layout issues in theme-openwrt-2020.

Signed-off-by: Stan Grishin stangri@melmac.net