### PR TITLE
luci-theme-openwrt-2020: add missing css success color

### DIFF
--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -5,6 +5,7 @@
 	--secondary-dark-color: #212322;
 	--danger-color: #CC1111;
 	--warning-color: #CC8800;
+	--success-color: #5CB85C;
 	--regular-font: "GalanoGrotesqueW00-Regular";
 	--base-font-size: 16px;
 }
@@ -846,6 +847,10 @@ ul > li {
 
 .alert-message.danger {
 	background: var(--danger-color);
+}
+
+.alert-message.success {
+	background: var(--success-color);
 }
 
 .alert-message .btn {


### PR DESCRIPTION
This fixes #4734

I would also cherry-pick this to openwrt-21.02 if this works for @ajayramaswamy you.