### PR TITLE
[WIP] luci-base: prevent empty field for adding new entry

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -350,7 +350,7 @@ function cbi_init() {
 function cbi_validate_form(form, errmsg)
 {
 	/* if triggered by a section removal or addition, don't validate */
-	if (form.cbi_state == 'add-section' || form.cbi_state == 'del-section')
+	if (form.cbi_state == 'del-section')
 		return true;
 
 	if (form.cbi_validators) {

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2172,7 +2172,7 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 		else {
 			var nameEl = E('input', {
 				'type': 'text',
-				'class': 'cbi-section-create-name',
+				'class': 'cbi-section-create-name cbi-input-invalid',
 				'disabled': this.map.readonly || null
 			});
 
@@ -2193,7 +2193,7 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 				})
 			]);
 
-			ui.addValidator(nameEl, 'uciname', true, 'blur', 'keyup');
+			ui.addValidator(nameEl, 'uciname', false, 'blur', 'keyup');
 		}
 
 		return createEl;

--- a/modules/luci-compat/luasrc/view/cbi/tblsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tblsection.htm
@@ -192,7 +192,7 @@ end
 					<div class="cbi-section-error"><%:Invalid%></div>
 				<%- end %>
 				<div>
-					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" data-type="uciname" data-optional="true" />
+					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" data-type="uciname" data-optional="false" />
 				</div>
 				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" />
 			<% end %>

--- a/modules/luci-compat/luasrc/view/cbi/tsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tsection.htm
@@ -42,7 +42,7 @@
 					<div class="cbi-section-error"><%:Invalid%></div>
 				<%- end %>
 				<div>
-					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." data-type="uciname" data-optional="true" />
+					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." data-type="uciname" data-optional="false" />
 				</div>
 				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" />
 			<%- end %>


### PR DESCRIPTION
"Old" LUA modules using "cbi/tblsection"  or "cbi/tsection" as template show an "Add" Button with a preceeding input field for a name if the `addremove` attribute is set. This -in a different manner- is the same for the "new" JavaScript modules, too.

This sometimes leads to misunderstandings if the input field is empty and the button is pressed (as nothing happens exept for reloading the page in browser, but no new section is added, or, for the JavaScript by opening a modal which doesn't save then).

This patch visually marks the field red (like other fields which have the `optional = false` attribute set) and shows an alert window (in LUA modules) when submitting an empty value. In JavaScript just nothing will happen.
