### PR TITLE
luci-base: form.js: keep config for disabled options

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -1976,7 +1976,10 @@ var CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.AbstractVa
 				return Promise.resolve(this.write(section_id, fval));
 		}
 		else {
-			if (!active || this.rmempty || this.optional) {
+			if (!active) {
+				return Promise.resolve();
+			}
+			else if (this.rmempty || this.optional) {
 				return Promise.resolve(this.remove(section_id));
 			}
 			else if (!isEqual(cval, fval)) {


### PR DESCRIPTION
When using "depends" functionality, fields that do not satisfy the constraint are hidden from view, and on save they are removed from the uci configuration. This causes a loss of information previously stored by the user when for example temporarily disabling a certain functionality. Upon reactivation of the said functionality, it is an improved user experience to restore any configuration previously used.

What do you think about this @jow- ? I'm not sure of side effects this change might cause.
