### PR TITLE
luci-base: allow direct syslog login for perror

### DIFF
--- a/modules/luci-base/luasrc/dispatcher.lua
+++ b/modules/luci-base/luasrc/dispatcher.lua
@@ -563,15 +563,13 @@ local function session_setup(user, pass)
 			ubus_rpc_session = login.ubus_rpc_session,
 			values = { token = sys.uniqueid(16) }
 		})
-
-		io.stderr:write("luci: accepted login on /%s for %s from %s\n"
-			%{ rp, user or "?", http.getenv("REMOTE_ADDR") or "?" })
+		nixio.syslog("info", tostring("luci: accepted login on /%s for %s from %s\n"
+			%{ rp, user or "?", http.getenv("REMOTE_ADDR") or "?" }))
 
 		return session_retrieve(login.ubus_rpc_session)
 	end
-
-	io.stderr:write("luci: failed login on /%s for %s from %s\n"
-		%{ rp, user or "?", http.getenv("REMOTE_ADDR") or "?" })
+	nixio.syslog("info", tostring("luci: failed login on /%s for %s from %s\n"
+		%{ rp, user or "?", http.getenv("REMOTE_ADDR") or "?" }))
 end
 
 local function check_authentication(method)


### PR DESCRIPTION
This PR replaces io.stderr:write with perror in dispatcher.lua and modifies perror in such way, that in can send error messages to stderr or syslog based on value stored in /etc/config/luci

```
luci.main.log='syslog'
or
luci.main.log='stderr'
```
Fixes https://github.com/openwrt/luci/issues/4877


Signed-off-by: Jan Pavlinec <jan.pavlinec@nic.cz>