### PR TITLE
[Backport] luci-mod-network: issue with breakdown of dnsmasq after duplication o…

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -469,6 +469,25 @@ return view.extend({
 			so.value(mac, hint ? '%s (%s)'.format(mac, hint) : mac);
 		});
 
+		so.write = function(section, value) {
+			var ip = this.map.lookupOption('ip', section)[0].formvalue(section);
+			var hosts = uci.sections('dhcp', 'host');
+			var section_removed = false;
+
+			for (var i = 0; i < hosts.length; i++) {
+				if (ip == hosts[i].ip) {
+					uci.set('dhcp', hosts[i]['.name'], 'mac', [hosts[i].mac, value].join(' '));
+					uci.remove('dhcp', section);
+					section_removed = true;
+					break;
+				}
+			}
+
+			if (!section_removed) {
+				uci.set('dhcp', section, 'mac', value);
+			}
+		}
+
 		so = ss.option(form.Value, 'ip', _('<abbr title="Internet Protocol Version 4">IPv4</abbr>-Address'));
 		so.datatype = 'or(ip4addr,"ignore")';
 		so.validate = function(section, value) {


### PR DESCRIPTION
…f static IP was fixed

Before this commit, assigning the same static IP address to two
different hosts disabled dnsmasq.

Logic of adding a new static lease was modified. If user try to assign a
new MAC address to already reserved IP, old lease will be modified (list
of MAC addresses will be extended by new MAC) instead of creation a new lease with the same IP.

Signed-off-by: Oleksandr Pastushkov <oleks.pastushkov@gmail.com>