### PR TITLE
luci-app-transmission: fix '&nbsp' exception in OpenWrt theme

### DIFF
--- a/applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js
+++ b/applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js
@@ -35,7 +35,7 @@ return view.extend({
 
 		var button = '';
 		if (running && webinstalled)
-			button = '&nbsp;<a class="btn" href="http://' + window.location.hostname + ':' + port + '" target="_blank" rel="noreferrer noopener">' + _('Open Web Interface') + '</a>';
+			button = '&#160;<a class="btn" href="http://' + window.location.hostname + ':' + port + '" target="_blank" rel="noreferrer noopener">' + _('Open Web Interface') + '</a>';
 
 		var m, s, o;
 


### PR DESCRIPTION
Convert `&nbsp;` to `&#160;` which is both syntactically correct (semicolon present) and XHTML compliant.

Signed-off-by: Alexander Egorenkov <egorenar-dev@posteo.net>