### PR TITLE
luci-mod-network: Support for disabling routes

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js
@@ -20,6 +20,7 @@ return view.extend({
 			s.anonymous = true;
 			s.addremove = true;
 			s.sortable = true;
+			s.nodescriptions = true;
 
 			s.tab('general', _('General Settings'));
 			s.tab('advanced', _('Advanced Settings'));
@@ -27,6 +28,10 @@ return view.extend({
 			o = s.taboption('general', widgets.NetworkSelect, 'interface', _('Interface'));
 			o.rmempty = false;
 			o.nocreate = true;
+
+			o = s.taboption('general', form.Flag, 'disabled', _('Disable'), _('Disable this route'));
+			o.rmempty = true;
+			o.default = o.disabled;
 
 			o = s.taboption('general', form.Value, 'target', _('Target'), (i == 4) ? _('Host-<abbr title="Internet Protocol Address">IP</abbr> or Network') : _('<abbr title="Internet Protocol Version 6">IPv6</abbr>-Address or Network (CIDR)'));
 			o.datatype = (i == 4) ? 'ip4addr' : 'ip6addr';


### PR DESCRIPTION
Support for disabling routes in netifd was added in [this] commit. This commit
adds support for disabling routes through the LuCI interface.

Additionally hidden the route options descriptions in the header of the
routes table (they are still available in the modal view).

[this]: https://git.openwrt.org/?p=project/netifd.git;a=commit;h=327da9895327bc56b23413ee91a6e6b6e0e4329d

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>