### PR TITLE
luci-app-advanced-reboot: support 5.10 kernel on Zyxel

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.0.0-1
+PKG_VERSION:=1.0.1-1
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/

--- a/applications/luci-app-advanced-reboot/htdocs/luci-static/resources/view/system/advanced_reboot.js
+++ b/applications/luci-app-advanced-reboot/htdocs/luci-static/resources/view/system/advanced_reboot.js
@@ -8,7 +8,8 @@
 return view.extend({
 	translateTable: {
 		NO_BOARD_NAME : function(args) { return _('Unable to find Device Board Name.')},
-		NO_DUAL_FLAG : function(args) {return _('Unable to find Dual Boot Flag Partition.')},
+		NO_DUAL_FLAG: function (args) { return _('Unable to find Dual Boot Flag Partition.') },
+		NO_DUAL_FLAG_BLOCK: function (args) { return _('The Dual Boot Flag Partition: %s is not a block device.').format(args[0])},
 		ERR_SET_DUAL_FLAG : function(args) { return _('Unable to set Dual Boot Flag Partition entry for partition: %s.').format(args[0])},
 		NO_FIRM_ENV : function(args) { return _('Unable to obtain firmware environment variable: %s.').format(args[0])},
 		ERR_SET_ENV : function(args) { return _('Unable to set firmware environment variable: %s to %s.').format(args[0],args[1])}

--- a/applications/luci-app-advanced-reboot/root/usr/libexec/rpcd/luci.advanced_reboot
+++ b/applications/luci-app-advanced-reboot/root/usr/libexec/rpcd/luci.advanced_reboot
@@ -100,7 +100,7 @@ find_device_data(){
 print_json() { json_init; json_add_string "$1" "$2"; json_dump; json_cleanup; }
 
 obtain_device_info(){
-	local romBoardName p zyxelFlagPartition
+	local romBoardName p zyxelFlagPartition i
 	local vendorName deviceName partition1MTD partition2MTD labelOffset
 	local bootEnv1 bootEnv1Partition1Value bootEnv1Partition2Value
 	local bootEnv2 bootEnv2Partition1Value bootEnv2Partition2Value
@@ -167,15 +167,20 @@ obtain_device_info(){
 			current_partition="$(/usr/sbin/fw_printenv -n "${bootEnv1}")"
 		fi
 	else
+		for i in '0:dual_flag' '0:DUAL_FLAG'; do
+			zyxelFlagPartition="$(find_mtd_part "$i" 2>/dev/null)"
+			[ -n "$zyxelFlagPartition" ] && break
+		done
 		if [ -z "$zyxelFlagPartition" ]; then
-			zyxelFlagPartition="$(find_mtd_part 0:DUAL_FLAG 2>/dev/null)"
-		fi
-		if [ -n "$zyxelFlagPartition" ]; then
-			current_partition="$(dd if="${zyxelFlagPartition}" bs=1 count=1 2>/dev/null | hexdump -n 1 -e '1/1 "%d"')"
-		else
 			print_json 'error' 'NO_DUAL_FLAG'
 			logger "Unable to find Dual Boot Environment or Dual Boot Flag Partition."
 			return
+		elif [ ! -b "$zyxelFlagPartition" ]; then
+			print_json 'error' 'NO_DUAL_FLAG_BLOCK'
+			logger "The Dual Boot Flag Partition: $zyxelFlagPartition is not block device."
+			return
+		else
+			current_partition="$(dd if="${zyxelFlagPartition}" bs=1 count=1 2>/dev/null | hexdump -n 1 -e '1/1 "%d"')"
 		fi
 	fi
 
@@ -201,7 +206,6 @@ obtain_device_info(){
 	if [ -n "$p2_os" ] && [ -n "$p2_version" ]; then
 		p2_os="$p2_os (Linux ${p2_version})"
 	fi
-
 
 	json_init
 	json_add_int 'current_partition' "$current_partition"
@@ -231,7 +235,7 @@ obtain_device_info(){
 }
 
 toggle_boot_partition(){
-	local zyxelFlagPartition zyxelBootFlag zyxelNewBootFlag curEnvSetting newEnvSetting
+	local zyxelFlagPartition i zyxelBootFlag zyxelNewBootFlag curEnvSetting newEnvSetting
 	local romBoardName p
 	local bev1 bev2 bev1p1 bev1p2 bev2p1 bev2p2
 	local vendorName deviceName partition1MTD partition2MTD labelOffset
@@ -333,12 +337,17 @@ toggle_boot_partition(){
 		json_init
 		json_dump; json_cleanup;
 	else # NetGear device
+		for i in '0:dual_flag' '0:DUAL_FLAG'; do
+			zyxelFlagPartition="$(find_mtd_part "$i" 2>/dev/null)"
+			[ -n "$zyxelFlagPartition" ] && break
+		done
 		if [ -z "$zyxelFlagPartition" ]; then
-			zyxelFlagPartition="$(find_mtd_part 0:DUAL_FLAG 2>/dev/null)"
-		fi
-		if [ -z "$zyxelFlagPartition" ]; then
-			logger "Unable to find Dual Boot Flag Partition."
 			print_json 'error' 'NO_DUAL_FLAG'
+			logger "Unable to find Dual Boot Environment or Dual Boot Flag Partition."
+			return
+		elif [ ! -b "$zyxelFlagPartition" ]; then
+			print_json 'error' 'NO_DUAL_FLAG_BLOCK'
+			logger "The Dual Boot Flag Partition: $zyxelFlagPartition is not block device."
 			return
 		else
 			zyxelBootFlag="$(dd if="${zyxelFlagPartition}" bs=1 count=1 2>/dev/null | hexdump -n 1 -e '1/1 "%d"')"


### PR DESCRIPTION
As discovered by @Ansuel and @pkgadd, with the 5.10 kernel the partition name which used to be `0:DUAL_FLAG` is now in lowercase (`0:dual_flag`). This patch is based on the code originally developed by @pkgadd to address this and also includes an additional error case handling. Original discussion/code: https://github.com/openwrt/openwrt/pull/3954.

Tested-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>
Signed-off-by: Stan Grishin <stangri@melmac.net>