### PR TITLE
luci-app-simple-adblock: bugfix: crash when dnsmasq.ipset selected

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.8.5-1
+PKG_VERSION:=1.8.7-3
 
 LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.

--- a/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
+++ b/applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua
@@ -83,6 +83,10 @@ elseif targetDNS == "dnsmasq.conf" then
 	outputFile="/var/dnsmasq.d/" .. packageName .. ""
 	outputCache="/var/run/" .. packageName .. ".dnsmasq.cache"
 	outputGzip="/etc/" .. packageName .. ".dnsmasq.gz"
+elseif targetDNS == "dnsmasq.ipset" then
+	outputFile="/var/dnsmasq.d/" .. packageName .. ".ipset"
+	outputCache="/var/run/" .. packageName .. ".ipset.cache"
+	outputGzip="/etc/" .. packageName .. ".ipset.gz"
 elseif targetDNS == "dnsmasq.servers" then
 	outputFile="/var/run/" .. packageName .. ".servers"
 	outputCache="/var/run/" .. packageName .. ".servers.cache"

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -1,167 +1,167 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:217
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:221
 msgid "%s Error: %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:215
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:219
 msgid "%s Error: %s %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:129
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:133
 msgid "%s is not installed or not found"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:295
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:299
 msgid "Add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:293
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:297
 msgid "Add IPv6 entries to block-list."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:263
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:267
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:339
 msgid "Allowed Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:334
 msgid "Allowed Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:328
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:332
 msgid "Allowed and Blocked Lists Management"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:321
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
 msgid "Automatic Config Update"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:230
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:349
 msgid "Blocked Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:344
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:350
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:354
 msgid "Blocked Hosts URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:198
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:202
 msgid "Blocking %s domains (with %s)."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:188
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:192
 msgid "Cache file containing %s domains found."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:208
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:212
 msgid "Collected Errors"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:192
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:196
 msgid "Compressed cache file found."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:228
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:237
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:241
 msgid "Controls system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:308
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
 msgid "Curl download retry"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:279
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:283
 msgid "DNS Service"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:281
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:285
 msgid "DNSMASQ Additional Hosts"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:282
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:286
 msgid "DNSMASQ Config"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:284
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
 msgid "DNSMASQ IP Set"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:286
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:290
 msgid "DNSMASQ Servers File"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:300
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:304
 msgid "Delay (in seconds) for on-boot start"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:233
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:237
 #: applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm:68
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:323
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:327
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:294
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:298
 msgid "Do not add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:318
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:322
 msgid "Do not store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:313
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
 msgid "Do not use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:304
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:308
 msgid "Download time-out (in seconds)"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:134
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:138
 msgid "Downloading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:238
 #: applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm:65
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:322
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:324
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:326
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:328
 msgid "Enable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:322
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:326
 msgid "Enables debug output to /tmp/simple-adblock.log."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:135
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:139
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:137
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:141
 msgid "Fail"
 msgstr ""
 
@@ -169,19 +169,19 @@ msgstr ""
 msgid "Force Re-Download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:133
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:137
 msgid "Force Reloading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
 msgid "Force Router DNS"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:245
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:249
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
@@ -189,40 +189,40 @@ msgstr ""
 msgid "Grant UCI and file access for luci-app-simple-adblock"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:293
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:297
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:308
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
 msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:334
 msgid "Individual domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:340
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:344
 msgid "Individual domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:190
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:194
 msgid "Info"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:254
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:258
 msgid "LED to indicate status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:316
 msgid ""
 "Launch all lists downloads and processing simultaneously, reducing service "
 "start time."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:244
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:248
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
@@ -230,73 +230,72 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:203
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:207
 msgid "Message"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:237
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:241
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
 msgid "Perform config update before downloading the block/allow-lists."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:265
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:269
 msgid ""
 "Pick the DNS resolution option to create the adblock list for, see the "
 "%sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:255
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:259
 msgid "Pick the LED not already used in %sSystem LED Configuration%s."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:268
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:269
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:270
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:271
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:272
 #: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:273
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:276
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:274
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:275
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:277
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:280
 msgid "Please note that %s is not supported on this system."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:132
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:136
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:300
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:304
 msgid "Run service after set delay on boot."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:223
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:227
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:172
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:195
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:199
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:166
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:170
 msgid "Service Status [%s %s]"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/controller/simple-adblock.lua:4
-#: applications/luci-app-simple-adblock/root/usr/share/luci/menu.d/luci-app-simple-adblock.json:3
 msgid "Simple AdBlock"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:160
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:164
 msgid "Simple AdBlock Settings"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:316
 msgid "Simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:239
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
 msgid "Some output"
 msgstr ""
 
@@ -304,7 +303,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:131
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:135
 msgid "Starting"
 msgstr ""
 
@@ -312,142 +311,142 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:304
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:308
 msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:130
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:134
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:319
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:323
 msgid "Store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:321
 msgid "Store compressed cache file on router"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:138
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:142
 msgid "Success"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:238
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:242
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:180
 msgid "Task"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:339
 msgid "URLs to lists of domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:349
 msgid "URLs to lists of domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:350
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:354
 msgid "URLs to lists of hosts to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:289
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:293
 msgid "Unbound AdBlock List"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:314
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:318
 msgid "Use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:240
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:244
 msgid "Verbose output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:136
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:140
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:141
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:145
 msgid "failed to access shared memory"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:139
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:143
 msgid "failed to create '%s' file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:151
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:155
 msgid "failed to create block-list or restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:147
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:151
 msgid "failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:155
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:159
 msgid "failed to download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:154
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:158
 msgid "failed to download Config Update file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:145
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:149
 msgid "failed to format data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:150
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:154
 msgid "failed to move '%s' to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:146
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:150
 msgid "failed to move temporary data file to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:143
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:147
 msgid "failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:157
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:161
 msgid "failed to parse"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:156
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:160
 msgid "failed to parse Config Update file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:144
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:148
 msgid "failed to process allow-list"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:153
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:157
 msgid "failed to reload/restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:148
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:152
 msgid "failed to remove temporary files"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:140
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:144
 msgid "failed to restart/reload DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:142
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:146
 msgid "failed to sort data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:152
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:156
 msgid "failed to stop %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:149
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:153
 msgid "failed to unpack compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:158
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:162
 msgid "no HTTPS/SSL support on device"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:257
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:261
 msgid "none"
 msgstr ""


### PR DESCRIPTION
Fixes https://github.com/stangri/source.openwrt.melmac.net/issues/131 reported by @wengole. 

Signed-off-by: Stan Grishin <stangri@melmac.net>