### PR TITLE
luci-app-xlc: don't build package for arc

### DIFF
--- a/applications/luci-app-lxc/Makefile
+++ b/applications/luci-app-lxc/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LXC management Web UI
-LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +lxc +lxc-attach +lxc-console +lxc-create +liblxc +rpcd-mod-lxc +getopt +!LXC_BUSYBOX_OPTIONS:tar
+LUCI_DEPENDS:=@!arc +luci-compat +luci-mod-admin-full +lxc +lxc-attach +lxc-console +lxc-create +liblxc +rpcd-mod-lxc +getopt +!LXC_BUSYBOX_OPTIONS:tar
 LUCI_PKGARCH:=all
 
 define Package/luci-app-lxc/conffiles


### PR DESCRIPTION
lxc does not build on arc.  Since luci-app-xlc selects lxc, it needs to check @!arc first, to avoid a possible circular dependency.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>