### PR TITLE
luci-theme-openwrt-2020: remove submenu margin-bottom when submenu not visible

### DIFF
--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -167,7 +167,7 @@ body {
 
 #mainmenu ul {
 	padding: 0;
-	margin: 0 0 .5em .5em;
+	margin: 0 0 0 .5em;
 	line-height: 1.5em;
 }
 
@@ -189,6 +189,7 @@ body {
 #mainmenu li.active > ul {
 	max-height: 3000px;
 	transition: max-height 1s ease-in-out;
+	margin: 0 0 .5em .5em;
 }
 
 #mainmenu .l1 > li > a {


### PR DESCRIPTION
When mainmenu submenu is not visible, it still has visible `margin-bottom: .5em` so mixing main menu items with submenu (e.g. System) and without (e.g. Dashboard) causes uneven spaces between menu items.

This little tweek just makes all collapsed main menu items evenly distributed and does not change look of activated/selected items.