### PR TITLE
[19.07] luci-app-fwknopd: add support for ENABLE_CMD_EXEC

### DIFF
--- a/applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua
+++ b/applications/luci-app-fwknopd/luasrc/model/cbi/fwknopd.lua
@@ -40,6 +40,9 @@ s:option(Value, "REQUIRE_SOURCE_ADDRESS", "REQUIRE_SOURCE_ADDRESS", translate("F
 					This makes it impossible to use the -s command line argument on the fwknop client command line, so either -R \
 					has to be used to automatically resolve the external address (if the client behind a NAT) or the client must \
 					know the external IP and set it via the -a argument."))
+s:option(Value, "ENABLE_CMD_EXEC", "ENABLE_CMD_EXEC", translate("This instructs fwknopd to accept complete commands that are contained within an authorization packet. \
+							Any such command will be executed on the fwknopd server as the user specified by the “CMD_EXEC_USER” or as the user \
+							that started fwknopd if that is not set."))
 
 s = m:section(TypedSection, "config", translate("fwknopd.conf config options")) 
 s.anonymous=true


### PR DESCRIPTION
Add support for execution commands on the fwknopd server.