### PR TITLE
Fix NaN errors in realtime graphs

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/bandwidth.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/bandwidth.js
@@ -209,6 +209,8 @@ return view.extend({
 							y = ctx.height - Math.floor(values[i][j] * data_scale);
 							//y -= Math.floor(y % (1 / data_scale));
 
+							y = isNaN(y) ? ctx.height : y;
+
 							pt += ' ' + x + ',' + y;
 						}
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
@@ -281,6 +281,8 @@ return view.extend({
 							y = ctx.height - Math.floor(values[i][j] * data_scale);
 							//y -= Math.floor(y % (1 / data_scale));
 
+							y = isNaN(y) ? ctx.height : y;
+
 							pt += ' ' + x + ',' + y;
 						}
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/load.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/load.js
@@ -186,6 +186,8 @@ return view.extend({
 							y = ctx.height - Math.floor(values[i][j] * data_scale);
 							//y -= Math.floor(y % (1 / data_scale));
 
+							y = isNaN(y) ? ctx.height : y;
+
 							pt += ' ' + x + ',' + y;
 						}
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js
@@ -202,6 +202,8 @@ return view.extend({
 							y = ctx.height - Math.floor(values[i][j] * data_scale);
 							//y -= Math.floor(y % (1 / data_scale));
 
+							y = isNaN(y) ? ctx.height : y;
+
 							pt += ' ' + x + ',' + y;
 						}
 


### PR DESCRIPTION
When I use Realtime Graphs I see following NaN errors:

Error: <polyline> attribute points: Expected number, "0,298 0,NaN 5,NaN 10,NaN…".
Error: <polyline> attribute points: Expected number, "0,298 0,NaN 5,NaN 10,NaN…".
wireless.js?v=git-21.105.40538-2da37c2:19 Error: <polyline> attribute points: Expected number, "0,298 0,NaN 5,NaN 10,NaN…".
eval @ wireless.js?v=git-21.105.40538-2da37c2:19
Promise.then (async)
eval @ wireless.js?v=git-21.105.40538-2da37c2:8
step @ luci.js?v=git-21.105.40538-2da37c2:91
start @ luci.js?v=git-21.105.40538-2da37c2:87
add @ luci.js?v=git-21.105.40538-2da37c2:82
pollData @ wireless.js?v=git-21.105.40538-2da37c2:7
render @ wireless.js?v=git-21.105.40538-2da37c2:24
Promise.then (async)
__init__ @ luci.js?v=git-21.105.40538-2da37c2:148
super @ luci.js?v=git-21.105.40538-2da37c2:22
Anonymous42Class @ luci.js?v=git-21.105.40538-2da37c2:12
(anonymous) @ luci.js?v=git-21.105.40538-2da37c2:181
Promise.then (async)
compileClass @ luci.js?v=git-21.105.40538-2da37c2:177
Promise.then (async)
require @ luci.js?v=git-21.105.40538-2da37c2:183
instantiateView @ ui.js?v=git-21.105.40538-2da37c2:311
(anonymous) @ wireless:47
Promise.then (async)
(anonymous) @ wireless:46