### PR TITLE
luci-app-adblock: sync with adblock 4.1.1

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
@@ -168,7 +168,7 @@ function handleAction(ev) {
 					'click': ui.createHandlerFn(this, async function(ev) {
 						var count = document.getElementById('count').value;
 						var search = document.getElementById('search').value.trim().replace(/[^\w\.\-\:]/g,'') || '+';
-						L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', search, count, 'true', 'json']),'');
+						L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', 'gen', count, search]),'');
 						var running = 1;
 						while (running === 1) {
 							await new Promise(r => setTimeout(r, 1000));
@@ -190,7 +190,7 @@ function handleAction(ev) {
 
 return view.extend({
 	load: function() {
-		return L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', '+', '50', 'false', 'json']),'');
+		return L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', 'json', '50', '+']),'');
 	},
 
 	render: function(dnsreport) {
@@ -204,11 +204,11 @@ return view.extend({
 		var tbl_top  = E('table', { 'class': 'table', 'id': 'top_10' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th right' }, _('Count')),
-				E('th', { 'class': 'th' }, _('Name / IP Address')),
+				E('th', { 'class': 'th' }, _('Clients')),
 				E('th', { 'class': 'th right' }, _('Count')),
-				E('th', { 'class': 'th' }, _('Domain')),
+				E('th', { 'class': 'th' }, _('Domains')),
 				E('th', { 'class': 'th right' }, _('Count')),
-				E('th', { 'class': 'th' }, _('Blocked Domain'))
+				E('th', { 'class': 'th' }, _('Blocked Domains'))
 			])
 		]);
 

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -30,7 +30,11 @@ function handleAction(ev) {
 				E('select', { 'class': 'cbi-input-select', 'id': 'timerA' }, [
 					E('option', { 'value': 'start' }, 'Start'),
 					E('option', { 'value': 'reload' }, 'Reload'),
-					E('option', { 'value': 'restart' }, 'Restart')
+					E('option', { 'value': 'restart' }, 'Restart'),
+					E('option', { 'value': 'suspend' }, 'Suspend'),
+					E('option', { 'value': 'resume' }, 'Resume'),
+					E('option', { 'value': 'report gen' }, 'Report'),
+					E('option', { 'value': 'report mail' }, 'Report &amp; Mail')
 				]),
 				'\xa0\xa0\xa0',
 				_('Adblock action')
@@ -374,7 +378,7 @@ return view.extend({
 
 		o = s.taboption('additional', form.Value, 'adb_triggerdelay', _('Trigger Delay'), _('Additional trigger delay in seconds before adblock processing begins.'));
 		o.placeholder = '2';
-		o.datatype = 'range(1,120)';
+		o.datatype = 'range(1,300)';
 		o.rmempty = true;
 
 		o = s.taboption('additional', form.ListValue, 'adb_maxqueue', _('Download Queue'), _('Size of the download queue for download processing (incl. sorting, merging etc.) in parallel.'));
@@ -401,11 +405,11 @@ return view.extend({
 		o.rmempty = true;
 
 		o = s.taboption('additional', form.ListValue, 'adb_fetchutil', _('Download Utility'), _('List of supported and fully pre-configured download utilities.'));
-		o.value('', _('- unspecified -'));
 		o.value('uclient-fetch');
 		o.value('wget');
 		o.value('curl');
 		o.value('aria2c');
+		o.optional = true;
 		o.rmempty = true;
 
 		o = s.taboption('additional', form.Value, 'adb_fetchparm', _('Download Parameters'), _('Special config options for the selected download utility.'));
@@ -416,12 +420,12 @@ return view.extend({
 		*/
 		o = s.taboption('adv_dns', form.ListValue, 'adb_dns', _('DNS Backend'), _('List of supported DNS backends with their default list directory. \
 			To overwrite the default path use the \'DNS Directory\' option.'));
-		o.value('', _('- unspecified -'));
 		o.value('dnsmasq', _('dnsmasq (/tmp/dnsmasq.d)'));
 		o.value('unbound', _('unbound (/var/lib/unbound)'));
-		o.value('named', _('named (/var/lib/bind)'));
+		o.value('named', _('bind (/var/lib/bind)'));
 		o.value('kresd', _('kresd (/etc/kresd)'));
 		o.value('raw', _('raw (/tmp)'));
+		o.optional = true;
 		o.rmempty = true;
 
 		o = s.taboption('adv_dns', form.Value, 'adb_dnsdir', _('DNS Directory'), _('Target directory for the generated blocklist \'adb_list.overall\'.'));
@@ -441,7 +445,19 @@ return view.extend({
 		o = s.taboption('adv_dns', form.Flag, 'adb_dnsflush', _('Flush DNS Cache'), _('Flush the DNS Cache before adblock processing as well.'));
 		o.rmempty = true;
 
-		o = s.taboption('adv_dns', form.Flag, 'adb_dnsallow', _('Disable DNS Allow'), _('Disable selective DNS whitelisting (RPZ pass through).'));
+		o = s.taboption('adv_dns', form.Flag, 'adb_dnsallow', _('Disable DNS Allow'), _('Disable selective DNS whitelisting (RPZ-PASSTHRU).'));
+		o.rmempty = true;
+
+		o = s.taboption('adv_dns', form.DynamicList, 'adb_denyip', _('Block Local Client IPs'), _('Block all requests of certain DNS clients based on their IP address (RPZ-CLIENT-IP). \
+			Please note: This feature is currently only supported by bind DNS backend.'));
+		o.datatype = 'or(ip4addr("nomask"),ip6addr("nomask"))';
+		o.optional = true;
+		o.rmempty = true;
+
+		o = s.taboption('adv_dns', form.DynamicList, 'adb_allowip', _('Allow Local Client IPs'), _('Allow all requests of certain DNS clients based on their IP address (RPZ-CLIENT-IP). \
+			Please note: This feature is currently only supported by bind DNS backend.'));
+		o.datatype = 'or(ip4addr("nomask"),ip6addr("nomask"))';
+		o.optional = true;
 		o.rmempty = true;
 
 		o = s.taboption('adv_dns', form.Flag, 'adb_jail', _('Additional Jail Blocklist'), _('Builds an additional DNS blocklist to block access to all domains except those listed in the whitelist. \

--- a/applications/luci-app-adblock/po/ar/adblock.po
+++ b/applications/luci-app-adblock/po/ar/adblock.po
@@ -11,16 +11,11 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.5.1\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- غير محدد -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "إجراء"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "المصادر المفعّلة"
 
@@ -29,7 +24,7 @@ msgstr "المصادر المفعّلة"
 msgid "Adblock"
 msgstr "أدبلوك"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "إجراء أدبلوك"
 
@@ -49,43 +44,54 @@ msgstr "أضف هذا النطاق (الفرعي) لقائمتك السوداء 
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "أضف هذا النطاق (الفرعي) لقائمتك المسموحة المحلية."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "قائمة حظر إضافية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "إعدادات إضافية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "وقت انتظار إضافي بالثواني قبل الشروع في تطبيق إعدادات أدبلوك."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "إعدادات DNS متقدمة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "إعدادات متقدمة للبريد الالكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "إعدادات متقدمة للتقارير"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "إجابة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "مجلد النسخ الاحتياطي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "مجلد التخزين المؤقت الأساسي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,19 +112,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "القائمة السوداء..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "طلبات DNS المحظورة"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "نطاق محظور"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "نطاقات محظورة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "نسخة احتياطية لقائمة الحظر"
 
@@ -130,11 +144,11 @@ msgstr "استعلام لقائمة الحظر"
 msgid "Blocklist Query..."
 msgstr "استعلام لقائمة الحظر..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "مصادر قائمة الحظر"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -148,12 +162,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "فئات"
 
@@ -161,7 +175,11 @@ msgstr "فئات"
 msgid "Client"
 msgstr "العميل"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -179,7 +197,7 @@ msgstr ""
 msgid "Count"
 msgstr "العدد"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -187,22 +205,22 @@ msgstr ""
 "إنشاء نسخ احتياطية لقائمة الحظر المضغوطة ، سيتم استخدامها في حالة حدوث أخطاء "
 "في التنزيل أو أثناء بدء التشغيل."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNS الخلفية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "دليل DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "تقرير DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "مهلة إعادة تشغيل DNS"
 
@@ -210,15 +228,15 @@ msgstr "مهلة إعادة تشغيل DNS"
 msgid "Date"
 msgstr "تاريخ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "تعطيل السماح DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "تعطيل إعادة بدء DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -226,48 +244,51 @@ msgstr ""
 "قم بتعطيل عمليات إعادة تشغيل adblock التي تم تشغيلها لخلفيات DNS مع وظائف "
 "التحميل التلقائي / inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "تعطيل القائمة البيضاء الانتقائية لنظام أسماء النطاقات (مرور RPZ)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "اختصاص"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "تنزيل المعلمات"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "تنزيل قائمة الانتظار"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "تحميل الأداة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "إعلام البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "عدد إعلام البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "ملف تعريف البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "عنوان مستقبل البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "عنوان مرسل البريد الإلكتروني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "موضوع البريد الإلكتروني"
 
@@ -281,23 +302,23 @@ msgstr "تحرير القائمة السوداء"
 msgid "Edit Whitelist"
 msgstr "تحرير القائمة البيضاء"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "تمكين SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "تفعيل مرشحات البحث الآمن المعتدلة لموقع youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "قم بتمكين خدمة adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "تمكين التسجيل المطول لتصحيح الأخطاء في حالة وجود أي أخطاء في المعالجة."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "مفعل"
 
@@ -305,7 +326,7 @@ msgstr "مفعل"
 msgid "End Timestamp"
 msgstr "الطابع الزمني للانتهاء"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -316,11 +337,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "الوظائف الحالية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "مجال بحث DNS خارجي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -332,35 +353,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "معايير التصفية مثل التاريخ أو المجال أو العميل (اختياري)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "منافذ جدار الحماية التي يجب فرضها محليًا."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "مناطق مصدر جدار الحماية التي يجب فرضها محليًا."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "مسح ذاكرة التخزين المؤقت DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "امسح ذاكرة التخزين المؤقت ل DNS قبل معالجة adblock أيضًا."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "فرض DNS المحلي"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "البوابات القسرية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "مناطق قسرية"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -370,7 +391,7 @@ msgstr ""
 "يرجى ملاحظة: هذا يحتاج إلى تثبيت حزمة إضافية \"tcpdump-mini\" وإعادة تشغيل "
 "خدمة adblock كاملة لتصبح سارية المفعول."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "الاعدادات العامة"
 
@@ -378,15 +399,15 @@ msgstr "الاعدادات العامة"
 msgid "Grant access to LuCI app adblock"
 msgstr "منح حق الوصول إلى Adblock لتطبيق LuCI"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "معلومة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "دليل السجن"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "آخر تشغيل"
 
@@ -394,23 +415,23 @@ msgstr "آخر تشغيل"
 msgid "Latest DNS Requests"
 msgstr "أحدث طلبات DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "تقييد البحث الآمن"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "قصر البحث الآمن على مقدمي خدمات معينين."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "رقم الخط المراد إزالته"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "قائمة بأجهزة الشبكة المتاحة التي يستخدمها برنامج tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -418,7 +439,7 @@ msgstr ""
 "قائمة واجهات الشبكة المتاحة لبدء تشغيل adblock. اختر \"غير محدد\" لاستخدام "
 "مهلة بدء التشغيل الكلاسيكية بدلاً من مشغل الشبكة."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -426,7 +447,7 @@ msgstr ""
 "قائمة بالخلفيات الخلفية لنظام أسماء النطاقات المدعومة مع دليل القائمة "
 "الافتراضي الخاص بها. للكتابة فوق المسار الافتراضي ، استخدم خيار \"دليل DNS\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "قائمة أدوات التنزيل المدعومة والمجهزة بالكامل مسبقًا"
 
@@ -435,13 +456,9 @@ msgstr "قائمة أدوات التنزيل المدعومة والمجهزة �
 msgid "Log View"
 msgstr "عرض السجل"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "خدمة ذات أولوية منخفضة"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "الاسم / عنوان IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -456,7 +473,7 @@ msgstr "لا توجد سجلات ذات صلة ب adblock حتى الآن!"
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "الملف الشخصي المستخدم من قبل \"msmtp\" لرسائل البريد الإلكتروني الخاصة "
@@ -470,7 +487,7 @@ msgstr "استعلام"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "الاستعلام عن قوائم الحظر والنسخ الاحتياطية النشطة لمجال معين."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -478,11 +495,11 @@ msgstr ""
 "ارفع عدد الإشعارات للحصول على رسائل البريد الإلكتروني إذا كان العدد الإجمالي "
 "لقائمة الحظر أقل من الحد المعطى أو مساويًا له."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "عنوان المستلم لرسائل البريد الإلكتروني الخاصة بإشعار adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -490,7 +507,7 @@ msgstr ""
 "أعد توجيه جميع استعلامات DNS من مناطق محددة إلى محلل DNS المحلي ، ينطبق على "
 "بروتوكول UDP و TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -511,7 +528,7 @@ msgstr "قم بتحديث تقرير DNS"
 msgid "Refresh Timer"
 msgstr "تحديث الموقت"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "تحديث المؤقت ..."
 
@@ -519,47 +536,47 @@ msgstr "تحديث المؤقت ..."
 msgid "Refresh..."
 msgstr "تنعيش الذاكرة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "استرخاء البحث الآمن"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "إعادة تحميل"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "إزالة وظيفة موجودة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "تقرير عدد القطع"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "تقرير حجم القطعة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "دليل التقارير"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "واجهة التقرير"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "تقرير المنافذ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "الإبلاغ عن عدد القطع المستخدم بواسطة tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "الإبلاغ عن حجم القطعة المستخدم بواسطة tcpdump بالميجابايت."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "إعادة تشغيل"
 
@@ -567,29 +584,29 @@ msgstr "إعادة تشغيل"
 msgid "Result"
 msgstr "نتيجة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "تشغيل الدلائل"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "تشغيل الإشارات"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "تشغيل واجهات"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "تشغيل الأدوات"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "إحفض"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -597,7 +614,7 @@ msgstr ""
 "إرسال رسائل البريد الإلكتروني الخاصة بالإشعار عن حظر الإعلانات. يرجى ملاحظة: "
 "هذا يحتاج إلى تثبيت حزمة 'msmtp' إضافية."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "عنوان المرسل لرسائل البريد الإلكتروني الخاصة بإشعار حظر الإعلانات."
 
@@ -605,11 +622,11 @@ msgstr "عنوان المرسل لرسائل البريد الإلكتروني �
 msgid "Set a new adblock job"
 msgstr "تعيين وظيفة adblock جديدة"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "إعدادات"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -617,15 +634,15 @@ msgstr ""
 "حجم قائمة انتظار التنزيل لمعالجة التنزيل (بما في ذلك الفرز والدمج وما إلى "
 "ذلك) بالتوازي."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "المصادر (الحجم والتركيز)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "قائمة منافذ مفصولة بمسافة يستخدمها tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr "خيارات التكوين الخاصة لأداة التنزيل المساعدة المحددة."
 
@@ -633,53 +650,54 @@ msgstr "خيارات التكوين الخاصة لأداة التنزيل ال�
 msgid "Start Timestamp"
 msgstr "بدء الطابع الزمني"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "بدء واجهة التشغيل"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "الحالة / الإصدار"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "تعليق"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr "الدليل الهدف لملفات التقارير المتعلقة ب DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr "الدليل الهدف للنسخ الاحتياطية لقائمة الحظر."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "الدليل المستهدف لقائمة الحظر التي تم إنشاؤها \"adb_list.overall\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "الدليل المستهدف لقائمة منع السجن التي تم إنشاؤها \"adb_list.jail\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "تعذر تحديث مؤقت التحديث."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "تم تحديث مؤقت التحديث."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
-msgstr "يوم الأسبوع (اختياري ، القيم: من 1 إلى 7 من المحتمل أن يفصل بينها أو -)"
+msgstr ""
+"يوم الأسبوع (اختياري ، القيم: من 1 إلى 7 من المحتمل أن يفصل بينها أو -)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "قسم الساعات (مطلوب ، النطاق: 0-23)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "جزء الدقائق (اختياري ، النطاق: 0-59)"
 
@@ -719,7 +737,7 @@ msgstr ""
 msgid "Time"
 msgstr "وقت"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "حان الوقت لانتظار إعادة تشغيل خلفية DNS ناجحة."
 
@@ -735,7 +753,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "أفضل 10 إحصائيات"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "موضوع رسائل البريد الإلكتروني الخاصة بإشعار adblock."
 
@@ -743,7 +761,7 @@ msgstr "موضوع رسائل البريد الإلكتروني الخاصة ب�
 msgid "Total DNS Requests"
 msgstr "إجمالي طلبات DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "تأخير الزناد"
 
@@ -752,12 +770,12 @@ msgstr "تأخير الزناد"
 msgid "Unable to save changes: %s"
 msgstr "تعذر حفظ التغييرات: s%"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "المتغيرات"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "تسجيل مطول للتصحيح"
 
@@ -774,11 +792,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "القائمة البيضاء ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "نظام اسم المجال التخزين المؤقت  dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "محلل العقد الخفي kresd (/etc/kresd)"
 
@@ -786,17 +808,28 @@ msgstr "محلل العقد الخفي kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "مجموعة نتائج أعلى حجم."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "نظام أسماء النطاقات named (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "خام (/ tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "غير ملزم (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- غير محدد -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "نطاق محظور"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "تعطيل القائمة البيضاء الانتقائية لنظام أسماء النطاقات (مرور RPZ)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "الاسم / عنوان IP"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "نظام أسماء النطاقات named (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/bg/adblock.po
+++ b/applications/luci-app-adblock/po/bg/adblock.po
@@ -4,16 +4,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -22,7 +17,7 @@ msgstr ""
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -42,43 +37,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -95,19 +101,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -119,11 +133,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,12 +148,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -147,7 +161,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -161,28 +179,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -190,62 +208,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -259,23 +280,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr ""
 
@@ -283,7 +304,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -293,11 +314,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -307,42 +328,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -350,15 +371,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -366,35 +387,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -403,12 +424,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -424,7 +441,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -436,23 +453,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -471,7 +488,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -479,47 +496,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -527,35 +544,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -563,25 +580,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -589,53 +606,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -667,7 +684,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -681,7 +698,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -689,7 +706,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -698,12 +715,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -718,11 +735,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -730,14 +751,10 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/bn_BD/adblock.po
+++ b/applications/luci-app-adblock/po/bn_BD/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "চালু উৎস"
 
@@ -28,7 +23,7 @@ msgstr "চালু উৎস"
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "অ্যাডব্লক ক্রিয়া"
 
@@ -48,43 +43,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -101,19 +107,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -125,11 +139,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,12 +154,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -153,7 +167,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -167,28 +185,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,62 +214,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,23 +286,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr ""
 
@@ -289,7 +310,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +320,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,42 +334,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -372,35 +393,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -409,12 +430,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -430,7 +447,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -442,23 +459,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -477,7 +494,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -485,47 +502,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -533,35 +550,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -569,25 +586,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,53 +612,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -673,7 +690,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +704,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +712,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,12 +721,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -724,11 +741,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,14 +757,10 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/ca/adblock.po
+++ b/applications/luci-app-adblock/po/ca/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.1\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- no especificat -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Acció"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Fonts actives"
 
@@ -28,7 +23,7 @@ msgstr "Fonts actives"
 msgid "Adblock"
 msgstr "Blocador d’anuncis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Acció d'Adblock"
 
@@ -48,45 +43,56 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Retard addicional en segons de l’activador abans que comenci el processament "
 "del blocador d’anuncis."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Paràmetres DNS avançats"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Paràmetres de correu avançats"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Directori de còpies de seguretat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -103,19 +109,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Llista negra..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Peticions DNS blocades"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Domini blocat"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Dominis blocats"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -127,11 +141,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Fonts de la llista negra"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -142,12 +156,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Cancel•lar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Categories"
 
@@ -155,7 +169,11 @@ msgstr "Categories"
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -169,28 +187,28 @@ msgstr ""
 msgid "Count"
 msgstr "Recompte"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Directori del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,62 +216,65 @@ msgstr ""
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Paràmetres de descàrrega"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Cua de descàrregues"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Notificació de correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Adreça del destinatari de correu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,23 +288,23 @@ msgstr "Edita la llista negra"
 msgid "Edit Whitelist"
 msgstr "Edita la llista blanca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Activat"
 
@@ -291,7 +312,7 @@ msgstr "Activat"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +322,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,42 +336,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Purga la memòria cau del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Força el DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Paràmetres generals"
 
@@ -358,15 +379,15 @@ msgstr "Paràmetres generals"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Darrera execució"
 
@@ -374,35 +395,35 @@ msgstr "Darrera execució"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Llista d’utilitats de descàrrega admeses i plenament preconfigurades."
 
@@ -411,13 +432,9 @@ msgstr "Llista d’utilitats de descàrrega admeses i plenament preconfigurades.
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Servei de prioritat baixa"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -432,7 +449,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -444,23 +461,23 @@ msgstr "Consulta"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -479,7 +496,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -487,47 +504,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Torna a carregar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -535,35 +552,35 @@ msgstr "Reiniciar"
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Desar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -571,25 +588,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Paràmetres"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,53 +614,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -675,7 +692,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -689,7 +706,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -697,7 +714,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -706,12 +723,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
@@ -726,11 +743,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -738,17 +759,19 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "- unspecified -"
+#~ msgstr "- no especificat -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Domini blocat"
 
 #~ msgid "DNS File Reset"
 #~ msgstr "Reinicialització de fitxers del DNS"

--- a/applications/luci-app-adblock/po/cs/adblock.po
+++ b/applications/luci-app-adblock/po/cs/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- nespecifikováno -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akce"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Aktivní zdroje"
 
@@ -28,7 +23,7 @@ msgstr "Aktivní zdroje"
 msgid "Adblock"
 msgstr "Blokování reklamy Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Akce Adblocku"
 
@@ -48,44 +43,55 @@ msgstr "Přidejte tuto (sub)doménu na místní blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Přidat tuto (sub)doménu na místní whitelist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Další nastavení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatečné zpoždění v sekundách před začátkem zpracování blokování reklamy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Pokročilá nastavení DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Pokročilá nastavení e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Pokročilá nastavení hlášení"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Odpověd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Záložní adresář"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Základní dočasný adresář"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,19 +112,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Blacklist..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Blokované domény"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blokované domény"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Záloha blokovacího seznamu"
 
@@ -130,11 +144,11 @@ msgstr "Dotaz na blokovací seznam"
 msgid "Blocklist Query..."
 msgstr "Dotaz na blokovací seznam..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Zdroje seznamů blokování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,12 +159,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Storno"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -158,7 +172,11 @@ msgstr ""
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -172,7 +190,7 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -180,22 +198,22 @@ msgstr ""
 "Vytváří komprimované zálohy blokovacího seznamu, budou použity v případě "
 "chyb při stahování nebo po příštím spuštění."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Adresář DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -203,62 +221,65 @@ msgstr ""
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Parametry stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Fronta stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Oznámení e-mailem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Počet e-mailových oznámení"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "E-mailový profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Adresa příjemce e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Adresa odesílatele e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Téma e-mailu"
 
@@ -272,23 +293,23 @@ msgstr "Upravit blacklist"
 msgid "Edit Whitelist"
 msgstr "Upravit whitelist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Povolit bezpečné vyhledávání (SafeSearch)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Povolit střední filtry SafeSearch pro youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Povolit službu adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Zapnuto"
 
@@ -296,7 +317,7 @@ msgstr "Zapnuto"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -306,11 +327,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Stávající úlohy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -320,42 +341,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Vyprázdnit mezipaměť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Vynutit lokální DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Obecná nastavení"
 
@@ -363,15 +384,15 @@ msgstr "Obecná nastavení"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Informace"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Poslední spuštění"
 
@@ -379,35 +400,35 @@ msgstr "Poslední spuštění"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Seznam podporovaných a plně předkonfigurovaných nástrojů pro stahování."
@@ -417,13 +438,9 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Služba s nízkou prioritou"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Název / IP adresa"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -438,7 +455,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -450,23 +467,23 @@ msgstr "Dotaz"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adresa příjemce pro e-maily s upozorněním."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -485,7 +502,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -493,47 +510,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Počet bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Velikost bloků sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Adresář sestav"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Rozhraní sestavy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -541,35 +558,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Uložit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -577,25 +594,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -603,53 +620,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Pozastavit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Cílový adresář pro vygenerovaný blokovací seznam 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -681,7 +698,7 @@ msgstr ""
 msgid "Time"
 msgstr "Čas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -695,7 +712,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -703,7 +720,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
@@ -712,12 +729,12 @@ msgstr "Prodleva spuštění"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
@@ -732,11 +749,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -744,17 +765,22 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "- unspecified -"
+#~ msgstr "- nespecifikováno -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Blokované domény"
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Název / IP adresa"
 
 #~ msgid "DNS File Reset"
 #~ msgstr "Resetování souboru DNS"

--- a/applications/luci-app-adblock/po/de/adblock.po
+++ b/applications/luci-app-adblock/po/de/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- unbestimmt -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Aktion"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Aktive Quellen"
 
@@ -28,7 +23,7 @@ msgstr "Aktive Quellen"
 msgid "Adblock"
 msgstr "Werbeblocker"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Adblock Aktion"
 
@@ -48,45 +43,56 @@ msgstr "Füge diese (Sub-)Domain zur lokalen Blacklist."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Füge diese (Sub-)Domain zur lokalen Whiteklist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Zusätzliche Jail-Sperrliste"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Zusätzliche Verzögerung (in Sekunden) bis zur Verarbeitung durch den "
 "Werbeblocker."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Fortgeschrittene DNS Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Fortgeschrittene E-Mail Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Fortgeschrittene Berichtseinstellungen"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Antwort"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Backupverzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Basis-Temp-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -107,19 +113,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Blockierliste..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Geblockte DNS-Anfragen"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Blockierte Domain"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Gesperrte Domains"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Sperrliste Backup"
 
@@ -131,11 +145,11 @@ msgstr "Sperrlistenabfrage"
 msgid "Blocklist Query..."
 msgstr "Sperrlisten abfragen..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Blockierlisten-Quellen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,12 +163,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Kategorien"
 
@@ -162,7 +176,11 @@ msgstr "Kategorien"
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -180,7 +198,7 @@ msgstr ""
 msgid "Count"
 msgstr "Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -188,22 +206,22 @@ msgstr ""
 "Erzeuge komprimierte Backups der Sperrlisten, um die Sperrfunktion schon "
 "sofort ab dem Booten oder im Fall von Downloadfehlern zur Verfügung zu haben."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNS-Backend"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-Report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "DNS-Restart-Timeout"
 
@@ -211,15 +229,15 @@ msgstr "DNS-Restart-Timeout"
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Deaktiviere DNS-Zulassen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "DNS-Neustarts deaktivieren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,48 +245,51 @@ msgstr ""
 "Deaktiviere das Triggern von Neustarts des DNS-Backends durch Adblock per "
 "Autoload/inotify-Funktionsaufrufe."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domäne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Download Parameter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Download Warteschlange"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "E-Mail Benachrichtigungszähler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "E-Mail-Profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Empfängeradresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Absenderadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "E-Mail-Thema"
 
@@ -282,23 +303,24 @@ msgstr "Blockierliste bearbeiten"
 msgid "Edit Whitelist"
 msgstr "Positivliste bearbeiten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Aktiviere SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Aktiviere moderate SafeSearch-Filter für YouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Aktiviere den Adblock-Dienst."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
-msgstr "Aktiviere das ausführliche Anwendungs-Logging bei Verarbeitungsfehlern."
+msgstr ""
+"Aktiviere das ausführliche Anwendungs-Logging bei Verarbeitungsfehlern."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Aktiviert"
 
@@ -306,7 +328,7 @@ msgstr "Aktiviert"
 msgid "End Timestamp"
 msgstr "Ende-Zeitstempel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -316,11 +338,11 @@ msgstr "Erzwinge SafeSearch für Google, Bing, DuckDuckGo, Yandex und Pixabay."
 msgid "Existing job(s)"
 msgstr "Bestehende Job(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Externe DNS Lookup Domain"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -332,35 +354,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filterkriterien wie z.B. Datum, Domain oder Client (optional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "Firewall-Ports, die lokal erzwungen/aufgelöst werden sollen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "Firewall-Zonen, die lokal erzwungen/aufgelöst werden sollen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "DNS-Cache leeren"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "DNS-Cache leeren, bevor mit Adblock-Verarbeitung fortgefahren wird."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Lokale DNS-Auflösung erzwingen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "Erzwungene Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Erzwungene Zonen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -370,7 +392,7 @@ msgstr ""
 "auf Abruf bereitstellen zu können. Hinweis: Hierzu muss das Paket \"tcpdump-"
 "mini\" installiert und der Adblock-Dienst danach neugestartet worden sein."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
@@ -378,15 +400,15 @@ msgstr "Allgemeine Einstellungen"
 msgid "Grant access to LuCI app adblock"
 msgstr "Zugriff auf adblock LuCI app erlauten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Informationen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Sperrverzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Letzter Durchgang"
 
@@ -394,25 +416,25 @@ msgstr "Letzter Durchgang"
 msgid "Latest DNS Requests"
 msgstr "Neueste DNS Anfragen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "SafeSearch einschränken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "SafeSearch auf bestimmte Anbieter einschränken."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "Zu entfernende Zeile"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Liste an verfügbaren Netzwerkschnittstellen die von tcpdump verwendet werden "
 "können."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -421,7 +443,7 @@ msgstr ""
 "triggern. Wähle \"unspecified\", um einen herkömmlichen Start-Timeout-"
 "Mechanismuss anstatt eines Netzwerk-Triggers zu verwenden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -429,7 +451,7 @@ msgstr ""
 "Liste an unterstützten DNS-Backens und deren Standard-Listenverzeichnissen. "
 "Um einen Standardpfad zu überschreiben, nutze die \"DNS-Verzeichnis\"-Option."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste der unterstützten und vollständig vorkonfigurierten Download-"
@@ -440,13 +462,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Protokollansicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Dienst mit niedriger Priorität"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Name / IP-Adresse"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -461,7 +479,7 @@ msgstr "Aktuell noch keine Adblock-Logs vorhanden!"
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "\"msmtp\"-Profil, das für Adblock-Benachrichtigunsmails verwendet wird."
@@ -474,7 +492,7 @@ msgstr "Abfrage"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Frage aktive Sperrlisten und Backups über eine spezifische Domain ab."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -482,11 +500,11 @@ msgstr ""
 "Erhöhe den Benachrichtigunszähler um Emails zu erhalten, wenn die Gesamtzahl "
 "der Blocklisten kleiner gleich diesem Schwellwert ist."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Empfängeradresse für Adblock-Benachrichtigungs-E-Mails."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -494,7 +512,7 @@ msgstr ""
 "Leitet alle DNS-Anfragen aus den angegebenen Zonen an den lokalen DNS-"
 "Resolver um, gilt für das UDP- und TCP-Protokoll."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -516,7 +534,7 @@ msgstr "Aktualisiere DNS-Report"
 msgid "Refresh Timer"
 msgstr "Timer"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Timer..."
 
@@ -524,47 +542,47 @@ msgstr "Timer..."
 msgid "Refresh..."
 msgstr "Aktualisiere..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "SafeSearch abschwächen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Neu laden"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "Entferne einen vorhandenen Job"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Berichte Datenblock-Anzahl"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Berichte Datenblock-Größe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Report-Verzeichnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Berichte-Schnittstelle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Berichte Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "Berichte Datenblock-Nutzung durch tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Berichte von tcpdump verwendete Datenblockgröße in MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Neustart"
 
@@ -572,29 +590,29 @@ msgstr "Neustart"
 msgid "Result"
 msgstr "Ergebnis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Run-Verzeichnisse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "Laufzeit-Flags"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Run-Interfaces"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "Run-Werkzeuge"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Speichern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -602,7 +620,7 @@ msgstr ""
 "Sende relevante Adblock-Benachrichtigungen per Email. Hinweis: Hierzu muss "
 "das \"msmtp\"-Zusatzpaket installiert sein."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Absenderadresse für Adblock-Benachrichtigungsmails."
 
@@ -610,11 +628,11 @@ msgstr "Absenderadresse für Adblock-Benachrichtigungsmails."
 msgid "Set a new adblock job"
 msgstr "Setze einen neuen adblock Job"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -622,15 +640,15 @@ msgstr ""
 "Größe der Download-Warteschlange für laufende Downloads (inkl. Platzbedarf "
 "für Sortieren, Zusammenführen)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "Quellen (Größe, Fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Leerzeichengetrennte Liste an Ports die von tcpdump genutzt werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Spezielle Konfigurationseinstellungen für das gewählte Download-Programm."
@@ -639,53 +657,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr "Start-Zeitstempel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "Trigger-Interface fürs Starten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Status / Version"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Anhalten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr "Zielverzeichnis für DNS-bezogene Report Dateien."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr "Zielverzeichnis für Backups von Blocklisten."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Zielverzeichnis für die erzeugte Sperrliste 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Zielverzeichnis für die erzeugte Jail-Sperrliste \"adb_list.jail\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "Der Timer konnte nicht aktualisiert werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "Der Timer wurde aktualisiert."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr "Der Wochentag (opt., Werte: 1-7 getrennt druch \",\" oder \"-\")"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "Der Stundenteil (Werte zw. 0-23)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "Der Minutenteil (Werte zw. 0-59)"
 
@@ -727,7 +745,7 @@ msgstr ""
 msgid "Time"
 msgstr "Zeit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Timeout für erfolgreichen DNS-Backend-Startvorgang."
 
@@ -743,7 +761,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top-10 Statistiken"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "Betreff für Adblock-Benachrichtigungsmails."
 
@@ -751,7 +769,7 @@ msgstr "Betreff für Adblock-Benachrichtigungsmails."
 msgid "Total DNS Requests"
 msgstr "Gesamte DNS-Anfragen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Verzögerung der Trigger-Bedingung"
 
@@ -760,12 +778,12 @@ msgstr "Verzögerung der Trigger-Bedingung"
 msgid "Unable to save changes: %s"
 msgstr "Konnte Änderungen nicht speichern: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "Varianten"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
@@ -782,11 +800,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Positivliste..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -794,17 +816,28 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "Max. Größe des Result-Sets"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "named (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- unbestimmt -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Blockierte Domain"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Deaktiviere selektives DNS-Whitelisting (RPZ-Passthrough)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Name / IP-Adresse"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "named (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/el/adblock.po
+++ b/applications/luci-app-adblock/po/el/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Ενεργές πηγές"
 
@@ -28,7 +23,7 @@ msgstr "Ενεργές πηγές"
 msgid "Adblock"
 msgstr "αντιδιαφημιστικό"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -48,43 +43,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Επιπρόσθετες ρυθμίσεις"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Σύνθετες ρυθμίσεις DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Προηγμένες ρυθμίσεις ηλεκτρονικού ταχυδρομείου"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Σύνθετες ρυθμίσεις αναφοράς"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Απάντηση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "φάκελος διάσωσης"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -101,19 +107,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Αποκλεισμένα αιτήματα DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -125,11 +139,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Λίστα Μπλοκαρισμένων πηγών"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,12 +154,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -153,7 +167,11 @@ msgstr ""
 msgid "Client"
 msgstr "πελάτης"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -167,28 +185,28 @@ msgstr ""
 msgid "Count"
 msgstr "Μέτρηση"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "κατάλογος DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,62 +214,65 @@ msgstr ""
 msgid "Date"
 msgstr "Ημερομηνία"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,23 +286,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Ενεργοποιήθηκε"
 
@@ -289,7 +310,7 @@ msgstr "Ενεργοποιήθηκε"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +320,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,42 +334,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Γενικές ρυθμίσεις"
 
@@ -356,15 +377,15 @@ msgstr "Γενικές ρυθμίσεις"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -372,35 +393,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -409,12 +430,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -430,7 +447,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -442,23 +459,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -477,7 +494,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -485,47 +502,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -533,35 +550,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -569,25 +586,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,53 +612,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -673,7 +690,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +704,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +712,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,12 +721,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -724,11 +741,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,15 +757,11 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/en/adblock.po
+++ b/applications/luci-app-adblock/po/en/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -28,7 +23,7 @@ msgstr ""
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -48,43 +43,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -101,19 +107,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -125,11 +139,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,12 +154,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -153,7 +167,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -167,28 +185,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,62 +214,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,23 +286,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Enabled"
 
@@ -289,7 +310,7 @@ msgstr "Enabled"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +320,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,42 +334,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -372,35 +393,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -409,12 +430,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -430,7 +447,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -442,23 +459,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -477,7 +494,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -485,47 +502,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -533,35 +550,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -569,25 +586,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,53 +612,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -673,7 +690,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +704,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +712,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,12 +721,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -724,11 +741,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,14 +757,10 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/es/adblock.po
+++ b/applications/luci-app-adblock/po/es/adblock.po
@@ -13,16 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- sin especificar -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Acción"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Fuentes activas"
 
@@ -31,7 +26,7 @@ msgstr "Fuentes activas"
 msgid "Adblock"
 msgstr "Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Acción de Adblock"
 
@@ -51,45 +46,56 @@ msgstr "Agregue este (sub) dominio a su lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Agregue este (sub) dominio a su lista blanca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Lista de bloqueo adicional de la cárcel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Configuración adicional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
 "procesamiento de adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Configuración avanzada de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Configuración avanzada de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Configuración avanzada de informes"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Responder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Directorio de respaldo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Directorio temporal base"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -110,19 +116,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Solicitudes de DNS bloqueadas"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Dominio bloqueado"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Dominios bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Copia de seguridad de lista de bloqueo"
 
@@ -134,11 +148,11 @@ msgstr "Consulta de lista de bloqueo"
 msgid "Blocklist Query..."
 msgstr "Consulta de lista de bloqueo..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Fuentes de lista de bloqueo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -153,12 +167,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Categorías"
 
@@ -166,7 +180,11 @@ msgstr "Categorías"
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -184,7 +202,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -192,22 +210,22 @@ msgstr ""
 "Cree copias de seguridad de listas de bloqueo comprimidas, se utilizarán en "
 "caso de errores de descarga o durante el inicio."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "Backend de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Directorio DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Informe DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Tiempo de espera de reinicio de DNS"
 
@@ -215,15 +233,15 @@ msgstr "Tiempo de espera de reinicio de DNS"
 msgid "Date"
 msgstr "Fecha"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Desactivar Permitir DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Desactivar Reinicios de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -231,48 +249,51 @@ msgstr ""
 "Desactivar los reinicios activados por adblock para back-end dns con "
 "funciones de carga automática/inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Descargar parámetros"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Cola de descarga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Notificación por correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Conteo de notificaciones por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "Perfil de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente de correo electrónico"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Tema del correo electrónico"
 
@@ -286,25 +307,25 @@ msgstr "Editar lista negra"
 msgid "Edit Whitelist"
 msgstr "Editar lista blanca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Activar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activar filtros moderados de SafeSearch para YouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Activa el servicio Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activar el registro de depuración detallado en caso de errores de "
 "procesamiento."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Activado"
 
@@ -312,7 +333,7 @@ msgstr "Activado"
 msgid "End Timestamp"
 msgstr "Finalizar marca de tiempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -324,11 +345,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Trabajo(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Dominio de búsqueda de DNS externo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -341,35 +362,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterios de filtro como fecha, dominio o cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "Puertos del cortafuegos que deben forzarse localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas de origen del cortafuegos que deben forzarse localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Vaciar caché de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Vacíe la caché de DNS antes del procesamiento de adblock también."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Forzar DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "Puertos forzados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zonas forzadas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -380,7 +401,7 @@ msgstr ""
 "instalación adicional del paquete 'tcpdump-mini' y un reinicio completo del "
 "servicio adblock para que surta efecto."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Configuración general"
 
@@ -388,15 +409,15 @@ msgstr "Configuración general"
 msgid "Grant access to LuCI app adblock"
 msgstr "Conceder acceso a la aplicación adblock de LuCI"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Información"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Directorio de la cárcel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Último inicio"
 
@@ -404,23 +425,23 @@ msgstr "Último inicio"
 msgid "Latest DNS Requests"
 msgstr "Últimas solicitudes de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "Limitar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limitar SafeSearch a proveedores specíficos."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "Número de línea para eliminar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de dispositivos de red disponibles utilizados por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -429,7 +450,7 @@ msgstr ""
 "Elija 'No especificado' para usar un tiempo de espera de inicio clásico en "
 "lugar de un disparador de red."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -437,7 +458,7 @@ msgstr ""
 "Lista de backends DNS compatibles con su directorio de lista predeterminado. "
 "Para sobrescribir la ruta predeterminada, use la opción 'Directorio DNS'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de utilidades de descarga totalmente preconfiguradas y compatibles."
@@ -447,13 +468,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Vista de registro"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Servicio con prioridad baja"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Nombre / Dirección IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -468,7 +485,7 @@ msgstr "¡Aún no hay registros relacionados con adblock!"
 msgid "Overview"
 msgstr "Vista general"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil utilizado por 'msmtp' para notificaciones de E-Mails adblock."
 
@@ -482,7 +499,7 @@ msgstr ""
 "Consulta listas de bloqueo activas y copias de seguridad para un dominio "
 "específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -490,11 +507,11 @@ msgstr ""
 "Aumente el recuento de notificaciones para obtener correos electrónicos si "
 "el recuento general de la lista de bloqueo es menor o igual al límite dado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Dirección del receptor para la notificación de bloqueos electrónicos."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -502,7 +519,7 @@ msgstr ""
 "Redirigir todas las consultas de DNS de las zonas especificadas al sistema "
 "de resolución de DNS local, se aplica a los protocolos UDP y TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -524,7 +541,7 @@ msgstr "Actualizar informe DNS"
 msgid "Refresh Timer"
 msgstr "Temporizador de actualización"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Actualizar temporizador..."
 
@@ -532,47 +549,47 @@ msgstr "Actualizar temporizador..."
 msgid "Refresh..."
 msgstr "Actualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "Relajar SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Recargar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "Eliminar un trabajo existente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Informe de recuento de fragmentos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Tamaño del fragmento de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Directorio de informes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Interfaz de informe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Informar puertos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "Informe el recuento de fragmentos utilizado por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informe el tamaño del fragmento utilizado por tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -580,29 +597,29 @@ msgstr "Reiniciar"
 msgid "Result"
 msgstr "Resultado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Ejecutar directorios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "Ejecutar banderas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Ejecutar interfaces"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "Ejecutar utilidades"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -610,7 +627,7 @@ msgstr ""
 "Enviar correos electrónicos de notificación relacionados con adblock. Tenga "
 "en cuenta: esto necesita una instalación adicional del paquete 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Dirección del remitente para los correos electrónicos de notificación de "
@@ -620,11 +637,11 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr "Establecer un nuevo trabajo de adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -632,15 +649,15 @@ msgstr ""
 "Tamaño de la cola de descarga para el procesamiento de descarga (incluida la "
 "clasificación, fusión, etc.) en paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "Fuentes (tamaño, enfoque)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista de puertos separados por espacios utilizados por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opciones de configuración especiales para la utilidad de descarga "
@@ -650,57 +667,57 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr "Iniciar marca de tiempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "Interfaz de activación de inicio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Estado/Versión"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr "Directorio de destino para archivos de informes relacionados con DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr "Directorio de destino para copias de seguridad de listas de bloqueo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo generada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Directorio de destino para la lista de bloqueo de cárcel generada 'adb_list."
 "jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "No se pudo actualizar el temporizador de actualización."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "Se ha actualizado el temporizador de actualización."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 "El día de la semana (opt., valores: 1-7 posiblemente separados por , o -)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "El reparto de horas (req., rango: 0-23)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "La porción de minutos (opcional, rango: 0-59)"
 
@@ -743,7 +760,7 @@ msgstr ""
 msgid "Time"
 msgstr "Hora"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tiempo de espera para esperar un reinicio de backend de DNS exitoso."
 
@@ -759,7 +776,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 estadísticas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "Tema para los correos electrónicos de notificación de adblock."
 
@@ -767,7 +784,7 @@ msgstr "Tema para los correos electrónicos de notificación de adblock."
 msgid "Total DNS Requests"
 msgstr "Solicitudes DNS Totales"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
@@ -776,12 +793,12 @@ msgstr "Retraso de disparo"
 msgid "Unable to save changes: %s"
 msgstr "No se pudo guardar los cambios: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "Variantes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
@@ -798,11 +815,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista blanca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -810,17 +831,28 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "máx. tamaño del conjunto de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "llamado (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "crudo (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- sin especificar -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Dominio bloqueado"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Desactivar la lista blanca selectiva de DNS (pasar por RPZ)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Nombre / Dirección IP"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "llamado (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/fi/adblock.po
+++ b/applications/luci-app-adblock/po/fi/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Toiminta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Aktiiviset lähteet"
 
@@ -28,7 +23,7 @@ msgstr "Aktiiviset lähteet"
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Adblockin toimi"
 
@@ -48,44 +43,55 @@ msgstr "Lisää tämä (ali-)verkkonimi kieltolistallesi."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lisää tämä (ali-)verkkonimi sallittujen listallesi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ylimääräinen odotusaika sekunteina ennen adblock-käsittelyn aloittamista."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "DNS-lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Sähköpostin lisäasetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Raportoinnin lisäasetukset"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Vastaus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Varmuuskopiohakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Oletushakemisto väliaikaistiedostoille"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,19 +112,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Kieltolista..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Estetty verkkonimi"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Estetyt verkkonimet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Kieltolistan varmuuskopio"
 
@@ -130,11 +144,11 @@ msgstr "Estolistan kysely"
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Estolistojen lähteet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,12 +159,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -158,7 +172,11 @@ msgstr ""
 msgid "Client"
 msgstr "Asiakas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -172,28 +190,28 @@ msgstr ""
 msgid "Count"
 msgstr "Määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNS-sovellus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 
@@ -201,15 +219,15 @@ msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 msgid "Date"
 msgstr "Päivä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Estä DNS:n salliminen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Estä DNS:n uudelleenkäynnistykset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -217,48 +235,51 @@ msgstr ""
 "Estä adblockin aiheuttamat DNS-sovelluksen uudelleenkäynnistykset autoload/"
 "inotify-funktioilla."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Verkkonimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Latausparametrit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Latausjono"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Lataustyökalu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Sähköposti-ilmoitus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Sähköposti-ilmoitusten määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "Sähköpostiprofiili"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Sähköposti: vastaanottajan osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Sähköposti: lähettäjän osoite"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Sähköposti: otsikko"
 
@@ -272,23 +293,23 @@ msgstr "Editoi estolistaa"
 msgid "Edit Whitelist"
 msgstr "Editoi sallittujen lista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Ota Adblock-palvelu käyttöön."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Runsas lokisisältö toimintojen virheiden etsimistä varten."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Käytössä"
 
@@ -296,7 +317,7 @@ msgstr "Käytössä"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -306,11 +327,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Nykyiset työt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -320,42 +341,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Suodatintekijät kuten päivä, verkkonimi tai asiakas (valinnainen)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Tyhjennä DNS-välimuisti"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Tyhjennä DNS-välimuisti ennen Adblock-sääntöjen käsittelyä."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Pakota paikallinen DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Yleisasetukset"
 
@@ -363,15 +384,15 @@ msgstr "Yleisasetukset"
 msgid "Grant access to LuCI app adblock"
 msgstr "Salli pääsy Adblock-asetuksiin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Tietoja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Viimeksi ajettu"
 
@@ -379,35 +400,35 @@ msgstr "Viimeksi ajettu"
 msgid "Latest DNS Requests"
 msgstr "Viimeiset DNS-kyselyt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Tuetut ja valmiiksi asetetut lataustyökalut."
 
@@ -416,13 +437,9 @@ msgstr "Tuetut ja valmiiksi asetetut lataustyökalut."
 msgid "Log View"
 msgstr "Lokinäkymä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Matala sovelluksen prioriteetti"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Nimi / IP-osoite"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -437,7 +454,7 @@ msgstr "Ei vielä Adblock-lokeja!"
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -449,23 +466,23 @@ msgstr "Kysely"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Vastaanottajan sähköpostiosoite Adblockin ilmoituksille."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -484,7 +501,7 @@ msgstr "Päivitä DNS-raportti"
 msgid "Refresh Timer"
 msgstr "Päivitysajastin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Päivitysajastin..."
 
@@ -492,47 +509,47 @@ msgstr "Päivitysajastin..."
 msgid "Refresh..."
 msgstr "Päivitä..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Raporttipalojen määrä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Raporttipalojen koko"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Raporttihakemisto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Raportoitava sovitin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Raportoitavat portit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -540,35 +557,35 @@ msgstr ""
 msgid "Result"
 msgstr "Tulos"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Ajohakemistot"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "Ajo-parametrit"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Ajettavat sovittimet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Tallenna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Lähettäjän osoite Adblockin sähköposti-ilmoituksille."
 
@@ -576,25 +593,25 @@ msgstr "Lähettäjän osoite Adblockin sähköposti-ilmoituksille."
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Asetukset"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "Lähteet (koko, fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -602,53 +619,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -680,7 +697,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -694,7 +711,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -702,7 +719,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -711,12 +728,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -731,11 +748,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -743,17 +764,19 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Estetty verkkonimi"
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Nimi / IP-osoite"
 
 #~ msgid "DNS File Reset"
 #~ msgstr "DNS-tiedoston resetointi"

--- a/applications/luci-app-adblock/po/fr/adblock.po
+++ b/applications/luci-app-adblock/po/fr/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- non spécifié -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Action"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Sources Actives"
 
@@ -28,7 +23,7 @@ msgstr "Sources Actives"
 msgid "Adblock"
 msgstr "Bloqueur de publicité"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Action Adblock"
 
@@ -48,45 +43,56 @@ msgstr "Ajout sous-domaine au réseau local blacklisté."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Ajout sous-domaine au réseau local whitelisté."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Additionnel Bannis Blocklisté"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Paramètres additionnels"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Délai de déclenchement supplémentaire en secondes avant que le bloqueur de "
 "publicité démarre."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Paramètres DNS avancés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Paramètres de messagerie électronique avancés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Paramètres de rapport avancés"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Répondre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Répertoire de sauvegarde"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Répertoire Temporaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -107,19 +113,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Liste noire ..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Domaines bloqués"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domaines bloqués"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Sauvegarde de la liste de blocage"
 
@@ -131,11 +145,11 @@ msgstr "Demande Blocklist"
 msgid "Blocklist Query..."
 msgstr "Demande Blocklist..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Sources des listes de blocage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -150,12 +164,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Annuler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -163,7 +177,11 @@ msgstr ""
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -182,7 +200,7 @@ msgstr ""
 msgid "Count"
 msgstr "Compteur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -190,22 +208,22 @@ msgstr ""
 "Créer des sauvegardes de listes de blocage compressées, elles seront "
 "utilisées en cas d'erreurs de téléchargement ou lors du démarrage."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "Backend du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Répertoire du DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Rapport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Délai de redémarrage DNS"
 
@@ -213,15 +231,15 @@ msgstr "Délai de redémarrage DNS"
 msgid "Date"
 msgstr "Date"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Désactiver l'autorisation DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Désactiver les redémarrages DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,48 +247,51 @@ msgstr ""
 "Désactiver les redémarrages déclenchés par adblock pour les backends dns "
 "avec des fonctions d'auto-chargement/notification."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domaine"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Paramètres Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Queue de Téléchargement"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Notification E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Nombre de notifications par courrier électronique"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "Email du profil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Adresse e-mail du destinataire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Adresse électronique de l'expéditeur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Objet du courrier électronique"
 
@@ -284,24 +305,24 @@ msgstr "Modifier la liste noire"
 msgid "Edit Whitelist"
 msgstr "Modifier la liste blanche"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Activer Safesearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activez les filtres SafeSearch modérés pour youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Activer le service adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activez la journalisation verbale de débogage en cas d'erreurs de traitement."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Activé"
 
@@ -309,7 +330,7 @@ msgstr "Activé"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -321,11 +342,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Travaux en cours"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Domaine de recherche DNS externe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -338,35 +359,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Critère filtre comme la date, domaine, client (option)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Vider le cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Videz également le cache DNS avant le traitement des adblocs."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Forcer le DNS local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -377,7 +398,7 @@ msgstr ""
 "d'un paquet \"tcpdump-mini\" supplémentaire et le redémarrage complet du "
 "service adblock pour prendre effet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
@@ -385,15 +406,15 @@ msgstr "Paramètres généraux"
 msgid "Grant access to LuCI app adblock"
 msgstr "Donner tout accès à l'application LuCI adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Répertoire des bannis"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Dernière exécution"
 
@@ -401,23 +422,23 @@ msgstr "Dernière exécution"
 msgid "Latest DNS Requests"
 msgstr "Dernière Requêtes DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "Limiter SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limitez SafeSearch à certains fournisseurs."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste des périphériques réseau disponibles utilisés par tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -426,7 +447,7 @@ msgstr ""
 "l'adblock. Choisissez \"non spécifié\" pour utiliser un délai de démarrage "
 "classique au lieu d'un déclencheur réseau."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -435,7 +456,7 @@ msgstr ""
 "Pour écraser le chemin d'accès par défaut, utilisez l'option \"Répertoire DNS"
 "\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste des utilitaires de téléchargement pris en charge et entièrement pré-"
@@ -446,13 +467,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Vue du journal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Service en priorité basse"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Nom / Adresse IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -467,7 +484,7 @@ msgstr "Pas encore de journaux liés à l'adblock !"
 msgid "Overview"
 msgstr "Aperçu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilisé par \"msmtp\" pour les e-mails de notification adblock."
 
@@ -481,7 +498,7 @@ msgstr ""
 "Recherchez des listes de blocage actives et des sauvegardes pour un domaine "
 "spécifique."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -490,19 +507,19 @@ msgstr ""
 "électroniques si le nombre total de blocages est inférieur ou égal à la "
 "limite donnée."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Adresse du destinataire pour les e-mails de notification du bloqueur de "
 "publicité."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -525,7 +542,7 @@ msgstr "Rafraîchir le rapport DNS"
 msgid "Refresh Timer"
 msgstr "Rafraichir Horloge"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Rafraîchir l'horloge..."
 
@@ -533,47 +550,47 @@ msgstr "Rafraîchir l'horloge..."
 msgid "Refresh..."
 msgstr "Rafraichi..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "Relax SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Rapporter le nombre de morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Rapporter la taille des morceaux"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Rapporter le Répertoire"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Rapporter l'Interface"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Rapport des Ports"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "Signalez le nombre de morceaux utilisés par tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Indiquez la taille des morceaux utilisés par tcpdump en MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -581,29 +598,29 @@ msgstr ""
 msgid "Result"
 msgstr "Resultat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Répertoire de travail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "Drapeaux de travail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Interfaces de travail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "Outils de travail"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Enregistrer"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -611,7 +628,7 @@ msgstr ""
 "Envoyer des e-mails de notification relatifs à l'adblock. Veuillez noter que "
 "l'installation du paquet \"msmtp\" supplémentaire est nécessaire."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Adresse de l'expéditeur des courriers électroniques de notification de "
@@ -621,11 +638,11 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Paramètres"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -633,15 +650,15 @@ msgstr ""
 "Taille de la file d'attente pour le traitement des téléchargements (y "
 "compris le tri, la fusion, etc.) en parallèle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "Sources (Taille, Focus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Liste des ports utilisés par tcpdump, séparés par des espaces."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Options de configuration spéciales pour l'utilitaire de téléchargement "
@@ -651,55 +668,55 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "Interface de déclenchmnt de démarrage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Statut / Version"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Mettre en pause"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Répertoire cible pour la liste de blocage générée \"adb_list.overall\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Répertoire cible pour la liste de blocage générée \"adb_list.jail\"."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "L'horloge de rafraîchissement n'a pas pu être mise à jour."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "Horloge mis à jour."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 "Le jour de la semaine (opt., valeurs : 1-7 éventuellement sep. par , ou -)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "La répartition des heures (req., plage : 0-23)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "La répartition des minutes (req., plage : 0-59)"
 
@@ -742,7 +759,7 @@ msgstr ""
 msgid "Time"
 msgstr "Heure"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Délai d'attente pour un redémarrage réussi du backend du DNS."
 
@@ -758,7 +775,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10 Statistiques"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "Objet pour les notifications par e-mails d'adblock."
 
@@ -766,7 +783,7 @@ msgstr "Objet pour les notifications par e-mails d'adblock."
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
@@ -775,12 +792,12 @@ msgstr "Délai de déclenchement"
 msgid "Unable to save changes: %s"
 msgstr "Sauvegarde Impossible : %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
@@ -797,11 +814,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Liste Blanche..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -809,17 +830,28 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "taille max. des résultats"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "named (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- non spécifié -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Domaines bloqués"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Désactiver la liste blanche sélective du DNS (passthrough RPZ)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Nom / Adresse IP"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "named (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/he/adblock.po
+++ b/applications/luci-app-adblock/po/he/adblock.po
@@ -11,16 +11,11 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -29,7 +24,7 @@ msgstr ""
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -49,43 +44,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,19 +108,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,11 +140,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -141,12 +155,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "ביטול"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -154,7 +168,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -168,28 +186,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -197,62 +215,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -266,23 +287,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr ""
 
@@ -290,7 +311,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -300,11 +321,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -314,42 +335,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -357,15 +378,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -373,35 +394,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -410,12 +431,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -431,7 +448,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -443,23 +460,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -478,7 +495,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -486,47 +503,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -534,35 +551,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -570,25 +587,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "הגדרות"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -596,53 +613,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -674,7 +691,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -688,7 +705,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -696,7 +713,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -705,12 +722,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -725,11 +742,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -737,14 +758,10 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hi/adblock.po
+++ b/applications/luci-app-adblock/po/hi/adblock.po
@@ -4,16 +4,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -22,7 +17,7 @@ msgstr ""
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -42,43 +37,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -95,19 +101,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -119,11 +133,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -134,12 +148,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -147,7 +161,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -161,28 +179,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -190,62 +208,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -259,23 +280,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr ""
 
@@ -283,7 +304,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -293,11 +314,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -307,42 +328,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -350,15 +371,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -366,35 +387,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -403,12 +424,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -424,7 +441,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -436,23 +453,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -471,7 +488,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -479,47 +496,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -527,35 +544,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -563,25 +580,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -589,53 +606,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -667,7 +684,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -681,7 +698,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -689,7 +706,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -698,12 +715,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -718,11 +735,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -730,14 +751,10 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/hu/adblock.po
+++ b/applications/luci-app-adblock/po/hu/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Művelet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -28,7 +23,7 @@ msgstr ""
 msgid "Adblock"
 msgstr "Reklámblokkoló"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -48,45 +43,56 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "További aktiválókésleltetés másodpercben, mielőtt a reklámblokkolás "
 "feldolgozása elkezdődik."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Válasz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Biztonsági mentés könyvtára"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -103,19 +109,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Blokkolt tartomány"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -127,11 +141,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Blokkolási lista forrásai"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -142,12 +156,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Mégse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -155,7 +169,11 @@ msgstr ""
 msgid "Client"
 msgstr "Ügyfél"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -169,28 +187,28 @@ msgstr ""
 msgid "Count"
 msgstr "Darabszám"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS könyvtár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,62 +216,65 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Tartomány"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "E-mail értesítés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "E-mail fogadócím"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,23 +288,23 @@ msgstr "Feketelista szerkesztése"
 msgid "Edit Whitelist"
 msgstr "Fehérlista szerkesztése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Engedélyezve"
 
@@ -291,7 +312,7 @@ msgstr "Engedélyezve"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +322,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,42 +336,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "DNS gyorsítótár kiürítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Helyi DNS kényszerítése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Általános Beállítások"
 
@@ -358,15 +379,15 @@ msgstr "Általános Beállítások"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Utolsó futás"
 
@@ -374,35 +395,35 @@ msgstr "Utolsó futás"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "A támogatott és teljesen előre beállított letöltési segédprogramok listája."
@@ -412,13 +433,9 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Alacsony prioritású szolgáltatás"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -433,7 +450,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -445,23 +462,23 @@ msgstr "Lekérdezés"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Fogadó címe a reklámblokkoló értesítési e-mailekhez."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -480,7 +497,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -488,47 +505,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Darabok számának jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Darabok méretének jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Könyvtár jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Csatoló jelentése"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -536,35 +553,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Mentés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -572,25 +589,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -598,53 +615,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Felfüggesztés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Célkönyvtár az előállított „adb_list.overall” blokkolási listához."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -678,7 +695,7 @@ msgstr ""
 msgid "Time"
 msgstr "Idő"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -692,7 +709,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -700,7 +717,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
@@ -709,12 +726,12 @@ msgstr "Aktiváló késleltetése"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
@@ -729,11 +746,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -741,17 +762,16 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Blokkolt tartomány"
 
 #~ msgid "DNS File Reset"
 #~ msgstr "DNS fájlvisszaállítás"

--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -13,16 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Azione"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Sorgenti attive"
 
@@ -31,7 +26,7 @@ msgstr "Sorgenti attive"
 msgid "Adblock"
 msgstr "Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -51,43 +46,54 @@ msgstr "Aggiungi questo (sotto)dominio alla tua lista nera locale."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Aggiungi questo (sotto)dominio alla tua lista bianca locale."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Impostazioni aggiuntive"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Tempo addizionale in secondi di attesa prima che adblock si avvii."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Impostazioni DNS avanzate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Impostazioni E-Mail avanzate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Impostazioni avanzate dei report"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Risposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Directory del Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -104,19 +110,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Domini bloccati"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -128,11 +142,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Fonti lista di Blocco"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -143,12 +157,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Annulla"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -156,7 +170,11 @@ msgstr ""
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -174,7 +192,7 @@ msgstr ""
 msgid "Count"
 msgstr "Numero"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -182,22 +200,22 @@ msgstr ""
 "Crea dei backup delle liste di blocco comrpessi, saranno usati "
 "nell'evenienza di errori nello scaricamento o all'avvio."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "Backend DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Directory DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Report del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Tempo di riavvio del DNS"
 
@@ -205,62 +223,65 @@ msgstr "Tempo di riavvio del DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Utilità di Scaricamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Notifica E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail destinatario"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -274,23 +295,23 @@ msgstr "Modifica Lista Nera"
 msgid "Edit Whitelist"
 msgstr "Modifica Lista Bianca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Inglese (sviluppatore)"
 
@@ -298,7 +319,7 @@ msgstr "Inglese (sviluppatore)"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -308,11 +329,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -322,42 +343,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Pulisci Cache DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Forza DNS Locale"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Impostazioni Generali"
 
@@ -365,15 +386,15 @@ msgstr "Impostazioni Generali"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Ultimo Avvio"
 
@@ -381,35 +402,35 @@ msgstr "Ultimo Avvio"
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Elenco delle utility di download supportate e completamente preconfigurate."
@@ -419,13 +440,9 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Serviio a bassa priorità"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -440,7 +457,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Riassunto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -452,24 +469,24 @@ msgstr "Interrogazione"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Indirizzo del destinatario per e-mail di notifica di blocco degli annunci."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -488,7 +505,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -496,47 +513,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Directory dei report"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -544,35 +561,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Salva"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -580,25 +597,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -606,53 +623,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Sospendi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Directory per la lista di blocco generata 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -685,7 +702,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -699,7 +716,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -707,7 +724,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Ritardo Innesco"
 
@@ -716,12 +733,12 @@ msgstr "Ritardo Innesco"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Registro di Debug Dettagliato"
 
@@ -736,11 +753,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -748,17 +769,16 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Domini bloccati"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -13,16 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "詳細不明"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "アクション"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "アクティブなソース"
 
@@ -31,7 +26,7 @@ msgstr "アクティブなソース"
 msgid "Adblock"
 msgstr "Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "アドブロックアクション"
 
@@ -51,43 +46,54 @@ msgstr "この(サブ)ドメインをローカルのブラックリストに追�
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "この(サブ)ドメインをローカルのホワイトリストに追加します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "追加のJailブロックリスト"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "追加設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Adblock の処理が開始されるまでの、追加の遅延時間（秒）です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "DNS の詳細設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Eメールの詳細設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "リポートの詳細設定"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "バックアップ先 ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "ベースとなるテンポラリディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -107,19 +113,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "ブラックリスト..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "ブロックされたDNSリクエスト"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "ブロックされたドメイン"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "ブロックされたドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "ブロックリストのバックアップ"
 
@@ -131,11 +145,11 @@ msgstr "ブロックリストのクエリ"
 msgid "Blocklist Query..."
 msgstr "ブロックリストのクエリ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "ブロックリスト提供元"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,12 +163,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -162,7 +176,11 @@ msgstr ""
 msgid "Client"
 msgstr "クライアント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -180,7 +198,7 @@ msgstr ""
 msgid "Count"
 msgstr "カウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -188,22 +206,22 @@ msgstr ""
 "圧縮されたブロックリストのバックアップを作成します。ダウンロードエラーや起動"
 "時に使用されます。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNSバックエンド"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNSレポート"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "DNS再起動タイムアウト"
 
@@ -211,15 +229,15 @@ msgstr "DNS再起動タイムアウト"
 msgid "Date"
 msgstr "日付"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "DNS許可を無効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "DNS再起動を無効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,48 +245,51 @@ msgstr ""
 "autoload/inotify機能を使用してDNSバックエンドのadblockの再起動トリガーを無効"
 "にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "セレクティブDNSホワイトリスティングを無効化(RPZパススルー)。"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "ドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "ダウンロードのパラメータ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "ダウンロードキュー"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "ダウンロードユーティリティ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Eメール通知数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "Eメールプロファイル"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Eメール送信者アドレス"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Eメールトピック"
 
@@ -282,23 +303,23 @@ msgstr "ブラックリストの編集"
 msgid "Edit Whitelist"
 msgstr "ホワイトリストの編集"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "セーフサーチを有効化"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "youtube用の適度なセーフサーチフィルタを有効にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "adblockサービスを有効にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "エラーが発生した際に詳細なデバッグロギングを有効にします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "有効"
 
@@ -306,7 +327,7 @@ msgstr "有効"
 msgid "End Timestamp"
 msgstr "終了タイムスタンプ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -318,11 +339,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "既存のジョブ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "外部DNSルックアップドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -334,35 +355,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "日付、ドメイン、クライアントなどのフィルター基準(オプション)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "DNS キャッシュのクリア"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "adblockが正常に動くようにするため、事前にDNSキャッシュをクリアします。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "ローカル DNS の強制"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -372,7 +393,7 @@ msgstr ""
 "ポートを提供します。 注意: これを有効にするには、追加の「tcpdump-mini」パッ"
 "ケージのインストールと完全なadblockサービスの再起動が必要です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -380,15 +401,15 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app adblock"
 msgstr "LuCIアプリのadblockへのアクセスを許可"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "情報"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Jailディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "最終実行"
 
@@ -396,23 +417,23 @@ msgstr "最終実行"
 msgid "Latest DNS Requests"
 msgstr "最新のDNSリクエスト"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "セーフサーチを制限"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "セーフサーチを特定のプロバイダに制限します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "削除する行番号"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdumpが使用する利用可能なネットワークデバイス一覧です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -420,7 +441,7 @@ msgstr ""
 "adblockの開始をトリガーできるネットワークインターフェース一覧です。未指定を選"
 "択するとトリガーの代わりに従来のスタートアップタイムアウトを使用します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -428,7 +449,7 @@ msgstr ""
 "デフォルトのリストディレクトリを使用するDNSバックエンド一覧です。デフォルトの"
 "パスを上書きするには'DNSディレクトリ'オプションを使用してください。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "サポートされ、かつ設定済のダウンロード ユーティリティの一覧です。"
 
@@ -437,13 +458,9 @@ msgstr "サポートされ、かつ設定済のダウンロード ユーティ�
 msgid "Log View"
 msgstr "ログビュー"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "優先度が低いサービス"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "名前 / IPアドレス"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -458,7 +475,7 @@ msgstr "まだadblolck関連のログがありません！"
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp'をadblock通知Eメールに使用するプロファイル。"
 
@@ -470,7 +487,7 @@ msgstr "検索"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "特定のドメインのアクティブなブロックリストとバックアップを検索します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -478,17 +495,17 @@ msgstr ""
 "通知数を上げて、ブロックリスト全体の数が指定された制限以下の場合に電子メール"
 "を取得します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知メールの受信アドレスです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -510,7 +527,7 @@ msgstr "DNSリポートをリフレッシュ"
 msgid "Refresh Timer"
 msgstr "リフレッシュタイマー"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "タイマーをリフレッシュ..."
 
@@ -518,47 +535,47 @@ msgstr "タイマーをリフレッシュ..."
 msgid "Refresh..."
 msgstr "リフレッシュ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "リラックスセーフサーチ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "リロード"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "既存のジョブを削除"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "レポート チャンクカウント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "レポート チャンクサイズ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "レポート インターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "レポートポート"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "tcpdumpによって使用されるレポートチャンク数。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "tcpdumpがメガバイト単位で使用するレポートチャンクサイズ。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "再起動"
 
@@ -566,29 +583,29 @@ msgstr "再起動"
 msgid "Result"
 msgstr "結果"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "実行ディレクトリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "実行フラグ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "実行インターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "実行ユーティリティー"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -596,7 +613,7 @@ msgstr ""
 "adblock関連の通知Eメールを送信します。注意: これは追加の'msmtp'パッケージのイ"
 "ンストールが必要です。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "adblockの通知Eメール送信者アドレス。"
 
@@ -604,11 +621,11 @@ msgstr "adblockの通知Eメール送信者アドレス。"
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -616,15 +633,15 @@ msgstr ""
 "ダウンロード処理(並べ替え、統合など)のダウンロードキューのサイズを並列で指定"
 "します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "ソース(サイズ、フォーカス)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdumpが使用するポートの、スペースで区切られたリスト。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr "選択したダウンロードユーティリティーの特別な設定オプション。"
 
@@ -632,54 +649,54 @@ msgstr "選択したダウンロードユーティリティーの特別な設定
 msgid "Start Timestamp"
 msgstr "開始タイムスタンプ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "起動時トリガーインターフェース"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "ステータス / バージョン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "一時停止"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成されたブロックリスト 'adb_list.overall' の保存先ディレクトリです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "生成されたjailブロックリスト'adb_list.jail'のターゲットディレクトリです。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "リフレッシュタイマーを更新できませんでした。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "リフレッシュタイマーが更新されました。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr "曜日(オプション、1-7の値。, または - で区切る)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "時(必須、0-23の値)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "分(オプション、0-59の値)"
 
@@ -717,7 +734,7 @@ msgstr ""
 msgid "Time"
 msgstr "時刻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "DNSバックエンドの再起動が成功するまでのタイムアウト。"
 
@@ -733,7 +750,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "上位10項目"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "adblockの通知Eメールのトピック。"
 
@@ -741,7 +758,7 @@ msgstr "adblockの通知Eメールのトピック。"
 msgid "Total DNS Requests"
 msgstr "DNSリクエスト合計"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
@@ -750,12 +767,12 @@ msgstr "トリガ遅延"
 msgid "Unable to save changes: %s"
 msgstr "変更を保存できませんでした: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
@@ -772,11 +789,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "ホワイトリスト..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -784,17 +805,28 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "最大の結果セットサイズ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "named (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "詳細不明"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "ブロックされたドメイン"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "セレクティブDNSホワイトリスティングを無効化(RPZパススルー)。"
+
+#~ msgid "Name / IP Address"
+#~ msgstr "名前 / IPアドレス"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "named (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/ko/adblock.po
+++ b/applications/luci-app-adblock/po/ko/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- 명시되지 않음 -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "액션"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "활성화된 소스"
 
@@ -28,7 +23,7 @@ msgstr "활성화된 소스"
 msgid "Adblock"
 msgstr "Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Adblock 액션"
 
@@ -48,45 +43,56 @@ msgstr "이 (서브)도메인을 로컬 블랙리스트에 추가."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "이 (서브)도메인을 로컬 화이트리스트에 추가."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "추가적인 Jail 블록리스트"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "추가 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "고급 DNS 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "고급 이메일 설정"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "고급 리포트 설정"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 #, fuzzy
 msgid "Answer"
 msgstr "답변"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 #, fuzzy
 msgid "Backup Directory"
 msgstr "백업 경로"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -105,19 +111,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "블랙리스트..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "차단된 DNS 요청"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "차단된 도메인"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "차단된 도메인들"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "차단목록 백업"
 
@@ -129,11 +143,11 @@ msgstr "블록리스트 쿼리"
 msgid "Blocklist Query..."
 msgstr "블록리스트 등록..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -144,12 +158,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "취소"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -157,7 +171,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -171,28 +189,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -200,62 +218,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -269,23 +290,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "활성화"
 
@@ -293,7 +314,7 @@ msgstr "활성화"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -303,11 +324,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -317,42 +338,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "기본 설정"
 
@@ -360,15 +381,15 @@ msgstr "기본 설정"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -376,35 +397,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -413,12 +434,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -434,7 +451,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -446,23 +463,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -481,7 +498,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -489,47 +506,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -537,35 +554,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -573,25 +590,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -599,53 +616,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -677,7 +694,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -691,7 +708,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -699,7 +716,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -708,12 +725,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -728,11 +745,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -740,14 +761,16 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "- unspecified -"
+#~ msgstr "- 명시되지 않음 -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "차단된 도메인"

--- a/applications/luci-app-adblock/po/mr/adblock.po
+++ b/applications/luci-app-adblock/po/mr/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -28,7 +23,7 @@ msgstr ""
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -48,43 +43,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -101,19 +107,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -125,11 +139,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,12 +154,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -153,7 +167,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -167,28 +185,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,62 +214,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,23 +286,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "सक्षम केले"
 
@@ -289,7 +310,7 @@ msgstr "सक्षम केले"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +320,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,42 +334,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -372,35 +393,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -409,12 +430,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -430,7 +447,7 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -442,23 +459,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -477,7 +494,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -485,47 +502,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -533,35 +550,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -569,25 +586,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,53 +612,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -673,7 +690,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +704,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +712,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,12 +721,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -724,11 +741,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,15 +757,11 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/ms/adblock.po
+++ b/applications/luci-app-adblock/po/ms/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Tindakan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -28,7 +23,7 @@ msgstr ""
 msgid "Adblock"
 msgstr "Sekatan Iklan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -48,43 +43,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Terdapat kelewatan picu dalam saat sebelum proses adblock bermula."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Jawapan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Direktori Sandaran"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -101,19 +107,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Kawasan Liputan Yang telah disekat"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -125,11 +139,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Punca Senarai Sekatan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,12 +154,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -153,7 +167,11 @@ msgstr ""
 msgid "Client"
 msgstr "Pelanggan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -167,28 +185,28 @@ msgstr ""
 msgid "Count"
 msgstr "Kiraan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Direktori DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,62 +214,65 @@ msgstr ""
 msgid "Date"
 msgstr "Tarikh"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,23 +286,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr ""
 
@@ -289,7 +310,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +320,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,42 +334,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -372,35 +393,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -409,12 +430,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -430,7 +447,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -442,23 +459,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -477,7 +494,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -485,47 +502,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -533,35 +550,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -569,25 +586,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,53 +612,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -673,7 +690,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +704,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +712,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,12 +721,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -724,11 +741,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,17 +757,16 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Kawasan Liputan Yang telah disekat"
 
 #~ msgid "DNS File Reset"
 #~ msgstr "Reset fail DNS"

--- a/applications/luci-app-adblock/po/nb_NO/adblock.po
+++ b/applications/luci-app-adblock/po/nb_NO/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- ubestemt -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Handling"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Aktive kilder"
 
@@ -28,7 +23,7 @@ msgstr "Aktive kilder"
 msgid "Adblock"
 msgstr "Reklameblokkering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Reklameblokkeringshandling"
 
@@ -48,45 +43,56 @@ msgstr "Legg til dette (under-)domenet til i din lokale svarteliste."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Legg til dette (under-)domenet til i din lokale hvitliste."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Ytterligere fengselssvarteliste"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Ytterligere innstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligere utløserforsinkelse i sekunder før behandling av "
 "reklameblokkering starter."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Avanserte DNS-innstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Avanserte e-postinnstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Avanserte rapporteringsinnstillinger"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Sikkerhetskopimappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,19 +112,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Svartelist …"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Blokkerte DNS-forespørsler"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Blokkert domene"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blokkerte domener"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Blokkeringslistesikkerhetskopi"
 
@@ -130,11 +144,11 @@ msgstr "Blokkeringslistespørring"
 msgid "Blocklist Query..."
 msgstr "Blokkeringslistespørring …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Blokklistekilder"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,12 +159,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Kategorier"
 
@@ -158,7 +172,11 @@ msgstr "Kategorier"
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -172,28 +190,28 @@ msgstr ""
 msgid "Count"
 msgstr "Antall"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNS-bakende"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS-mappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-rapport"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "DNS-omstartstidsavbrudd"
 
@@ -201,62 +219,65 @@ msgstr "DNS-omstartstidsavbrudd"
 msgid "Date"
 msgstr "Dato"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Skru av DNS-tillatelse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Skru av DNS-omstarter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Nedlastingsparametre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Nedlastingskø"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "E-postmerknad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "E-postmerknadsantall"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagersadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "E-postsenderadresse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "E-postemne"
 
@@ -270,24 +291,24 @@ msgstr "Rediger svarteliste"
 msgid "Edit Whitelist"
 msgstr "Rediger hvitliste"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Skru på SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 #, fuzzy
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Skru på moderate SafeSearch-filtre for YouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Skru på reklameblokkeringstjenesten."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Påskrudd"
 
@@ -295,7 +316,7 @@ msgstr "Påskrudd"
 msgid "End Timestamp"
 msgstr "Slutt-tidsstempel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -305,11 +326,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Eksisterende jobb(er)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Eksternt DNS-oppslagsdomene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -319,42 +340,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Tøm DNS-hurtiglageret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Tving lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "Påtvingte porter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Påtvingte soner"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Generelle innstillinger"
 
@@ -362,15 +383,15 @@ msgstr "Generelle innstillinger"
 msgid "Grant access to LuCI app adblock"
 msgstr "Innvilg tilgang til LuCI-programreklameblokkering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Info"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Fengselsmappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Sist kjørt"
 
@@ -378,35 +399,35 @@ msgstr "Sist kjørt"
 msgid "Latest DNS Requests"
 msgstr "Siste DNS-forespørsler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "Begrens SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "Begrens SafeSearch til gitte tilbydere."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "Linjenummer å fjerne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "Liste over tilgjengelige nettverksenheter brukt av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -415,13 +436,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Loggvisning"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Lavprioritetstjeneste"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Navn / IP-adresse"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -436,7 +453,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -448,23 +465,23 @@ msgstr "Spørring"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -483,7 +500,7 @@ msgstr "Gjenoppfrisk DNS-rapport"
 msgid "Refresh Timer"
 msgstr "Gjenoppfrisk tidsur"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Gjenoppfrisk tidsur …"
 
@@ -491,47 +508,47 @@ msgstr "Gjenoppfrisk tidsur …"
 msgid "Refresh..."
 msgstr "Gjenoppfrisk …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Last inn igjen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "Fjern en eksisterende jobb"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Rapportmappe"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Rapportgrensesnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Rapportporter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Omstart"
 
@@ -539,39 +556,39 @@ msgstr "Omstart"
 msgid "Result"
 msgstr "Resultat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 #, fuzzy
 msgid "Run Directories"
 msgstr "Kjøringsmapper"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 #, fuzzy
 msgid "Run Flags"
 msgstr "Kjøringsflagg"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 #, fuzzy
 msgid "Run Interfaces"
 msgstr "Kjøringsgrensesnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 #, fuzzy
 msgid "Run Utils"
 msgstr "Kjøringsverktøy"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Lagre"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -579,25 +596,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "Kilder (størrelse, fokus)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Mellomromsinndelt liste over porter brukt av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -606,53 +623,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr "Start-tidsstempel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Status/versjon"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -684,7 +701,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tid"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -698,7 +715,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Topp 10-statistikk"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -706,7 +723,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr "Totalt antall DNS-forespørsler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Utløserforsinkelse"
 
@@ -715,12 +732,12 @@ msgstr "Utløserforsinkelse"
 msgid "Unable to save changes: %s"
 msgstr "Kunne ikke lagre endringer: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "Varianter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -735,11 +752,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Hvitliste …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -747,18 +768,26 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "maks. resultatsettstørrelse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "navngitt (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "rå (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 #, fuzzy
 msgid "unbound (/var/lib/unbound)"
 msgstr "ubundet (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- ubestemt -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Blokkert domene"
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Navn / IP-adresse"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "navngitt (/var/lib/bind)"
 
 #~ msgid "DNS File Reset"
 #~ msgstr "DNS-filtilbakestilling"

--- a/applications/luci-app-adblock/po/pl/adblock.po
+++ b/applications/luci-app-adblock/po/pl/adblock.po
@@ -11,16 +11,11 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- nieokreślony -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akcja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Aktywne źródła"
 
@@ -29,7 +24,7 @@ msgstr "Aktywne źródła"
 msgid "Adblock"
 msgstr "Blokowanie reklam"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Akcje Adblock"
 
@@ -49,45 +44,56 @@ msgstr "Dodaj tę (sub-)domenę do Twojej lokalnej czarnej listy."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Dodaj tę (pod-)domenę do Twojej lokalnej białej listy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Dodatkowa lista blokująca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Dodatkowe ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalacza w sekundach przed rozpoczęciem przetwarzania "
 "adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Ustawienia DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Zaawansowane ustawienia e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Ustawienia raportowania"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Odpowiedź"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Katalog kopii zapasowej"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Podstawowy katalog tymczasowy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,19 +114,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Czarna lista..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Zablokowane żądania DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Zablokowana domena"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Zablokowane domeny"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Kopia zapasowa list blokujących"
 
@@ -132,11 +146,11 @@ msgstr "Zapytanie do list blokujących"
 msgid "Blocklist Query..."
 msgstr "Zapytanie..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Źródła list"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -151,12 +165,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Kategorie"
 
@@ -164,7 +178,11 @@ msgstr "Kategorie"
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -182,7 +200,7 @@ msgstr ""
 msgid "Count"
 msgstr "Licznik"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -190,22 +208,22 @@ msgstr ""
 "Tworzenie skompresowanej kopii zapasowej list, będzie używana w przypadku "
 "błędów pobierania lub podczas startu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "Zaplecze DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Katalog DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Raport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Limit czasu restartu DNS"
 
@@ -213,15 +231,15 @@ msgstr "Limit czasu restartu DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Wyłącz pozwolenie na DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Wyłącz restart DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,48 +247,51 @@ msgstr ""
 "Wyłącz wyzwalane restarty adblocka dla zaplecza DNS z funkcjami Autoload/"
 "Inotify."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domena"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Parametry pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Kolejka pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Powiadomienie e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Licznik powiadomień e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "Profil e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Adres e-mail odbiorcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Adres e-mail nadawcy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Temat e-mail"
 
@@ -284,25 +305,25 @@ msgstr "Czarna lista"
 msgid "Edit Whitelist"
 msgstr "Biała lista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Włącz SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Włącz umiarkowane filtry SafeSearch dla youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Włącz usługę adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Włącz rejestrowanie debugowania w przypadku wystąpienia błędów w "
 "przetwarzaniu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Włączone"
 
@@ -310,7 +331,7 @@ msgstr "Włączone"
 msgid "End Timestamp"
 msgstr "Sygnatura czasowa zakończenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -322,11 +343,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Istniejące zadania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Zewnętrzna domena wyszukiwania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -339,35 +360,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Kryteria filtrowania takie jak data, domena lub klient (opcjonalnie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "Porty zapory, które powinny być wymuszane lokalnie."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "Strefy źródłowe zapory, które powinny być wymuszane lokalnie."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Opróżnij pamięć podręczną DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Opróżnij pamięć podręczną DNS przed przetwarzaniem adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Wymuś lokalny DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "Wymuszone porty"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Strefy wymuszone"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -377,7 +398,7 @@ msgstr ""
 "dostarczaj raport DNS. Uwaga: wymaga to dodatkowej instalacji pakietu "
 "'tcpdump-mini' i pełnego ponownego uruchomienia usługi adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
@@ -385,15 +406,15 @@ msgstr "Ustawienia główne"
 msgid "Grant access to LuCI app adblock"
 msgstr "Udziel dostępu LuCI do aplikacji adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Informacje"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Katalog więzienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Ostatnie uruchomienie"
 
@@ -401,23 +422,23 @@ msgstr "Ostatnie uruchomienie"
 msgid "Latest DNS Requests"
 msgstr "Ostatnie zapytania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "Limit SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limit SafeSearch dla certyfikowanych dostawców."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "Numer wiersza do usunięcia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dostępnych urządzeń sieciowych używanych przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -426,7 +447,7 @@ msgstr ""
 "'nieokreślone', aby użyć klasycznego limitu czasu uruchamiania zamiast "
 "wyzwalacza sieciowego."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -434,7 +455,7 @@ msgstr ""
 "Lista obsługiwanych zapleczy DNS z domyślnym katalogiem list. Aby zastąpić "
 "domyślną ścieżkę, użyj opcji 'Katalog DNS'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista obsługiwanych i wstępnie skonfigurowanych narzędzi do pobierania."
@@ -444,13 +465,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Widok dziennika"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Usługa niskopriorytetowa"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Nazwa/Adres IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -465,7 +482,7 @@ msgstr "Brak dzienników związanych z adblockiem!"
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil używany przez 'msmtp' do powiadamiania o blokadzie e-mail."
 
@@ -479,7 +496,7 @@ msgstr ""
 "Wysyłaj zapytania do aktywnych list blokowania i kopii zapasowych dla "
 "określonej domeny."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -487,11 +504,11 @@ msgstr ""
 "Zwiększ liczbę powiadomień, aby otrzymywać wiadomości e-mail jeśli ogólna "
 "liczba blokowanych list jest mniejsza lub równa podanemu limitowi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adres odbiorcy dla powiadomień e-mail adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -499,7 +516,7 @@ msgstr ""
 "Przekieruj wszystkie zapytania DNS z określonych stref do lokalnego "
 "resolwera DNS, dotyczy protokołów UDP i TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -520,7 +537,7 @@ msgstr "Odśwież raport DNS"
 msgid "Refresh Timer"
 msgstr "Zaktualizuj listy automatycznie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Harmonogram..."
 
@@ -528,47 +545,47 @@ msgstr "Harmonogram..."
 msgid "Refresh..."
 msgstr "Odświeżanie..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "Odpoczynek SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Przeładuj"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "Usuń istniejące zadanie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Zgłoś liczbę fragmentów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Zgłoś wielkość porcji"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Katalog raportów"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Interfejs raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Porty raportowania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "Raportuj liczbę fragmentów używaną przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Raportuj wielkość fragmentów używaną przez tcpdump w MB."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Restart"
 
@@ -576,29 +593,29 @@ msgstr "Restart"
 msgid "Result"
 msgstr "Wynik"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Uruchomione katalogi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "Uruchomione flagi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Uruchomione interfejsy"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "Uruchomione narzędzia"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Zapisz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -606,7 +623,7 @@ msgstr ""
 "Wysyłaj powiadomienia e-mail związane z adblock. Uwaga: wymaga to dodatkowej "
 "instalacji pakietu 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adres nadawcy dla powiadomień e-mailowych adblocka."
 
@@ -614,11 +631,11 @@ msgstr "Adres nadawcy dla powiadomień e-mailowych adblocka."
 msgid "Set a new adblock job"
 msgstr "Ustaw nowe zadanie adblocka"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -626,15 +643,15 @@ msgstr ""
 "Rozmiar kolejki pobierania do przetwarzania plików (w tym sortowanie, "
 "łączenie itp.) równolegle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "Źródła (wielkość, skupienie)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Rozdzielona spacjami lista portów używanych przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr "Specjalne opcje konfiguracji dla wybranego narzędzia do pobierania."
 
@@ -642,55 +659,55 @@ msgstr "Specjalne opcje konfiguracji dla wybranego narzędzia do pobierania."
 msgid "Start Timestamp"
 msgstr "Sygnatura czasowa uruchamiania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "Interfejs wyzwalacza uruchamiania"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Status/Wersja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Zawieś"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr "Katalog docelowy dla plików raportów związanych z DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr "Katalog docelowy dla kopii zapasowych listy blokującej."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy blokowania 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Katalog docelowy dla wygenerowanej listy zablokowanych 'adb_list.jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "Nie można zaktualizować czasu odświeżania."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "Czas odświeżania został zaktualizowany."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr "Dni tygodnia (opcjonalnie, wartości: 1-7, osobno, lub -)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "Godzina (wymagane, zakres: 0–23)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "Minuta (opcjonalnie, zakres: 0–59)"
 
@@ -733,7 +750,7 @@ msgstr ""
 msgid "Time"
 msgstr "Czas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Limit czasu oczekiwania na pomyślne ponowne uruchomienie zaplecza DNS."
 
@@ -749,7 +766,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "Top 10"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "Temat dla powiadomień e-mail adblocka."
 
@@ -757,7 +774,7 @@ msgstr "Temat dla powiadomień e-mail adblocka."
 msgid "Total DNS Requests"
 msgstr "Łączna liczba żądań DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
@@ -766,12 +783,12 @@ msgstr "Opóźnienie wyzwalacza"
 msgid "Unable to save changes: %s"
 msgstr "Nie można zapisać zmian: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "Warianty"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
@@ -788,11 +805,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Biała lista ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -800,17 +821,28 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "maks. rozmiar zestawu wyników"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "named (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- nieokreślony -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Zablokowana domena"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Wyłącz selektywną białą listę DNS (RPZ)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Nazwa/Adres IP"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "named (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/pt/adblock.po
+++ b/applications/luci-app-adblock/po/pt/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- não especificado -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Fontes Ativas"
 
@@ -28,7 +23,7 @@ msgstr "Fontes Ativas"
 msgid "Adblock"
 msgstr "Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Ação do adblock"
 
@@ -48,45 +43,56 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Priosional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso adicional do gatilho em segundos antes do processamento do adblock "
 "começar."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Configurações Avançadas do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Configurações avançadas de E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Configurações Avançadas do Relatório"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Diretório do Backup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,19 +114,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Solicitações de DNS bloqueadas"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Domínio Bloqueado"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -132,11 +146,11 @@ msgstr "Consulta na Lista de Bloqueio"
 msgid "Blocklist Query..."
 msgstr "Pesquisando a Lista de Bloqueio..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Origem da Blocklist"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -151,12 +165,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Categorias"
 
@@ -164,7 +178,11 @@ msgstr "Categorias"
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -182,7 +200,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -190,22 +208,22 @@ msgstr ""
 "Crie cópias de segurança compactados da lista de bloqueio, estes serão "
 "usados em caso de erros de descarregamento ou durante a inicialização."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
@@ -213,15 +231,15 @@ msgstr "Tempo Limite para Reiniciar o DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,48 +247,51 @@ msgstr ""
 "Desativar o adblock que causar a reinicialização das funções autoload/"
 "inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Desativa a lista branca seletiva do DNS (passagem pelo RPZ)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Parâmetros de Descarregamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Fila de Descarregamento"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Ferramenta para Descarregar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Notificação por e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "Perfil de e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de e-mail do destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Endereço de e-mail do remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Assunto do e-mail"
 
@@ -284,25 +305,25 @@ msgstr "Editar Lista Negra"
 msgid "Edit Whitelist"
 msgstr "Editar lista de permissões"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Ativar o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Ativar os filtros SafeSearch de forma moderada para o Youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Ativar o serviço adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registo de depuração detalhado para casos de todos os erros de "
 "processamento."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -310,7 +331,7 @@ msgstr "Ativado"
 msgid "End Timestamp"
 msgstr "Carimbo de tempo final"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -322,11 +343,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -339,35 +360,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "Portas da firewall que devem ser localmente forçadas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas fonte da firewall que devem ser localmente forçadas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Limpar o cache de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também limpar o Cache do DNS antes do adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Forçar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "Portas forçadas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zonas forçadas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -378,7 +399,7 @@ msgstr ""
 "pacote 'tcpdump-mini' e a reinicialização completa do serviço do adblock "
 "para que as modificações entrem em vigor."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Configurações gerais"
 
@@ -386,15 +407,15 @@ msgstr "Configurações gerais"
 msgid "Grant access to LuCI app adblock"
 msgstr "Conceder acesso à app LuCI adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Informação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Última Execução"
 
@@ -402,23 +423,23 @@ msgstr "Última Execução"
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "Limite do SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limite o SafeSearch a determinados provedores."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "Número da linha a remover"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista de aparelhos da rede disponíveis que foram usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -427,7 +448,7 @@ msgstr ""
 "'não especificado' para usar um tempo de inicialização clássico em vez de um "
 "gatilho de rede."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -436,7 +457,7 @@ msgstr ""
 "de diretório. Para substituir o caminho predefinido, use a opção 'Diretório "
 "DNS'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de ferramentas de descarregamento suportadas e completamente pré-"
@@ -447,13 +468,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Vista do registo log"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Nome / Endereço IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -468,7 +485,7 @@ msgstr "Ainda não há registos relacionados ao adblock!"
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Perfil dos e-mails de notificação do adblock utilizado por 'msmtp'."
 
@@ -482,7 +499,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -490,11 +507,11 @@ msgstr ""
 "Aumente a contagem de notificações para receber e-mails caso a contagem "
 "geral das listas de bloqueio seja menor ou igual ao limite informado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Endereço do destinatário para e-mails de notificação do adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -502,7 +519,7 @@ msgstr ""
 "Redirecionar todas as consultas DNS de zonas especificadas para o resolvedor "
 "DNS local, aplica-se ao protocolo UDP e TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -524,7 +541,7 @@ msgstr "Atualizar o Relatório do DNS"
 msgid "Refresh Timer"
 msgstr "Atualizar Temporizador"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Atualizando o Temporizador..."
 
@@ -532,47 +549,47 @@ msgstr "Atualizando o Temporizador..."
 msgid "Refresh..."
 msgstr "Atualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "Alivie o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Recarregar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "Remover uma tarefa existente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Relatar Contagem de Porções"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Tamanho de Porções de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Diretório de Relatórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Interface de Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -580,29 +597,29 @@ msgstr "Reiniciar"
 msgid "Result"
 msgstr "Resultado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Executar Diretórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "Flags de Execução"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Executar Interfaces"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "Executar Utilitários"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -610,7 +627,7 @@ msgstr ""
 "Envie e-mails de notificação relacionados ao adblock. Note que: a instalação "
 "adicional do pacote 'msmtp' é necessária."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Endereço E-Mail do remetente para as notificações do adblock."
 
@@ -618,11 +635,11 @@ msgstr "Endereço E-Mail do remetente para as notificações do adblock."
 msgid "Set a new adblock job"
 msgstr "Definir uma nova tarefa de adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -630,15 +647,15 @@ msgstr ""
 "Tamanho da fila de descarregamento para o processamento de descarregamento "
 "(incl. classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de descarregamento "
@@ -648,56 +665,56 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr "Carimbo de tempo incial"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "Interface do Gatilho de Inicialização"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Condição geral / versão"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr "Diretório de destino para ficheiros de relatório relacionados ao DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr "Diretório de destino para os backups de listas de bloqueio."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 "Diretório de destino para a lista de blocos 'adb_list.overall' gerada ."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
 "prisional 'adb_list.jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "Não foi possível atualizar o tempo de atualização do temporizador."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "O tempo de atualização foi atualizado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr "O dia da semana (valores opc.: 1-7 possivelmente sep. por , ou -)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "A parte das horas (obg., intervalo: 0-23)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "A parte dos minutos (opt., intervalo: 0-59)"
 
@@ -739,7 +756,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -755,7 +772,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos e-mails que serão usados nas notificações do adblock."
@@ -764,7 +781,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr "Total de solicitações de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
@@ -773,12 +790,12 @@ msgstr "Atraso do Gatilho"
 msgid "Unable to save changes: %s"
 msgstr "Impossível gravar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "Variantes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Registos detalhados de depuração"
 
@@ -795,11 +812,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -807,17 +828,28 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "named (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- não especificado -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Domínio Bloqueado"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Desativa a lista branca seletiva do DNS (passagem pelo RPZ)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Nome / Endereço IP"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "named (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/pt_BR/adblock.po
+++ b/applications/luci-app-adblock/po/pt_BR/adblock.po
@@ -13,16 +13,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- não especificado -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Ação"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Fontes Ativas"
 
@@ -31,7 +26,7 @@ msgstr "Fontes Ativas"
 msgid "Adblock"
 msgstr "Bloqueio de anúncios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Ação do adblock"
 
@@ -51,45 +46,56 @@ msgstr "Adicione este (sub)domínio na sua lista negra local."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Adicional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Configurações Adicionais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Atraso de gatilho adicional em segundos antes do processamento do adblock "
 "começar."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Configurações Avançadas do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Configurações Avançadas do E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Configurações Avançadas do Relatório"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Resposta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,19 +117,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Requisições bloqueadas do DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Domínios Bloqueados"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -135,11 +149,11 @@ msgstr "Consulta na Lista de Bloqueio"
 msgid "Blocklist Query..."
 msgstr "Pesquisando a Lista de Bloqueio..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Fontes das listas de bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -154,12 +168,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Categorias"
 
@@ -167,7 +181,11 @@ msgstr "Categorias"
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,7 +203,7 @@ msgstr ""
 msgid "Count"
 msgstr "Contagem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -193,22 +211,22 @@ msgstr ""
 "Crie cópias de segurança compactados da lista de bloqueio, estes serão "
 "usados em caso de erros de download ou durante a inicialização."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
@@ -216,15 +234,15 @@ msgstr "Tempo Limite para Reiniciar o DNS"
 msgid "Date"
 msgstr "Dia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -232,48 +250,51 @@ msgstr ""
 "Desative o bloqueador de anúncios que causar a reinicialização das funções "
 "autoload/inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Fila de Download"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -287,25 +308,25 @@ msgstr "Editar a Lista Negra"
 msgid "Edit Whitelist"
 msgstr "Editar a Lista Branca"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Ativar o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Ativar os filtros SafeSearch de forma moderada para o youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Ativar o serviço de bloqueio de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registro de depuração detalhada nos casos de qualquer erro de "
 "processamento."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Ativado"
 
@@ -313,7 +334,7 @@ msgstr "Ativado"
 msgid "End Timestamp"
 msgstr "Fim da marca temporal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -325,11 +346,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -342,35 +363,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "As portas do firewall que devem ser impostas localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas de origem do firewall que devem ser imposta localmente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Limpar a Cache do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Usar o DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "Portas Impostas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zonas Impostas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -381,7 +402,7 @@ msgstr ""
 "pacote 'tcpdump-mini' e da reinicialização completa do serviço do bloqueio "
 "de anúncios para que as modificações entrem em vigor."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Configurações gerais"
 
@@ -389,15 +410,15 @@ msgstr "Configurações gerais"
 msgid "Grant access to LuCI app adblock"
 msgstr "Conceda acesso ao aplicativo LuCI adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Última Execução"
 
@@ -405,24 +426,24 @@ msgstr "Última Execução"
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "Limite do SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "Limite o SafeSearch a determinados fornecedores."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "O número da linha para remover"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Lista de dispositivos da rede disponíveis que foram usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -431,7 +452,7 @@ msgstr ""
 "Escolha 'não especificado' para usar um tempo de inicialização clássico em "
 "vez de um gatilho de rede."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -440,7 +461,7 @@ msgstr ""
 "de diretório. Para substituir o caminho predefinido, use a opção 'Diretório "
 "DNS'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
 
@@ -449,13 +470,9 @@ msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download.
 msgid "Log View"
 msgstr "Exiba o registro log"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Nome / Endereço-IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -470,7 +487,7 @@ msgstr "Ainda não há registros relacionados ao bloqueio de anúncio!"
 msgid "Overview"
 msgstr "Visão geral"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Perfil dos E-Mails de notificação do bloqueio de anúncio utilizado por "
@@ -486,7 +503,7 @@ msgstr ""
 "Consulta as listas de bloqueios ativos e as cópias de segurança para um "
 "domínio específico."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -494,13 +511,13 @@ msgstr ""
 "Aumente a contagem de notificações para receber E-Mails caso a contagem "
 "geral das listas de bloqueio seja menor ou igual ao limite informado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 "Endereço do E-Mail do destinatário para o recebimento das notificações do "
 "adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -508,7 +525,7 @@ msgstr ""
 "Redirecione todas as consultas DNS das zonas especificadas para o resolvedor "
 "do DNS local, aplica-se ao protocolo UDP e TCP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -531,7 +548,7 @@ msgstr "Atualizar o Relatório do DNS"
 msgid "Refresh Timer"
 msgstr "Atualize o Temporizador"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Atualizando o Temporizador..."
 
@@ -539,47 +556,47 @@ msgstr "Atualizando o Temporizador..."
 msgid "Refresh..."
 msgstr "Atualizar..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "Alivie o SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Recarregar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "Exclua uma tarefa já existente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Contagem de Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Tamanho dos Pedaços do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Interface do Relatório"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Reiniciar"
 
@@ -587,29 +604,29 @@ msgstr "Reiniciar"
 msgid "Result"
 msgstr "Resultado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Executar Diretórios"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "Executar Flags"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Executar Interfaces"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "Executar Utilitários"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Salvar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -617,7 +634,7 @@ msgstr ""
 "Envie E-Mails de notificação relacionados ao bloqueio de anúncios. Note que: "
 "é necessário a instalação adicional do pacote 'msmtp'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Endereço E-Mail do remetente para as notificações do bloqueador de anúncios."
@@ -626,11 +643,11 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr "Defina uma nova tarefa ao adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -638,15 +655,15 @@ msgstr ""
 "Tamanho da fila de download para o processamento de download (incl. "
 "classificação, fusão etc.) em paralelo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de download selecionado."
@@ -655,56 +672,56 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr "Início da marca temporal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "Interface do Gatilho de Inicialização"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Condição Geral / Versão"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 "Diretório de destino dos relatórios para os arquivos relacionados ao DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr "O diretório de destino para os backups da lista de bloqueio."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Caminho do diretório para a lista nega gerada 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
 "prisional 'adb_list.jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "Não foi possível atualizar o tempo de atualização do temporizador."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "O tempo de atualização foi atualizado."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr "O dia da semana (valores opc.: 1-7 possivelmente set. por , ou -)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "A parte das horas (obg., intervalo: 0-23)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "A parte dos minutos (obg., intervalo: 0-59)"
 
@@ -747,7 +764,7 @@ msgstr ""
 msgid "Time"
 msgstr "Tempo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -763,7 +780,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos E-Mais que serão usados nas notificações do bloqueador "
@@ -773,7 +790,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr "Total das solicitações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
@@ -782,12 +799,12 @@ msgstr "Gatilho de Atraso"
 msgid "Unable to save changes: %s"
 msgstr "Impossível salvar as modificações: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "Variantes"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
@@ -804,11 +821,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -816,17 +837,28 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "named (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- não especificado -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Domínios Bloqueados"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Desative a lista branca seletiva do DNS (passagem pelo RPZ)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Nome / Endereço-IP"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "named (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/ro/adblock.po
+++ b/applications/luci-app-adblock/po/ro/adblock.po
@@ -11,16 +11,11 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Actiune"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Surse Active"
 
@@ -29,7 +24,7 @@ msgstr "Surse Active"
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Acțiune Adblock"
 
@@ -49,45 +44,56 @@ msgstr "Adăugați acest (sub) domeniu în lista locală de interzise."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adăugați acest (sub) domeniu la lista locală de admise."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Setări Suplimentare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Întârziere adițională înainte ca procesarea adblock-ului să înceapă (în "
 "secunde)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Setări Avansate DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Setări Avansate E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Setări Avansate Raport"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Răspuns"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Director copie de siguranţă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Director Temporar de Bază"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,19 +114,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Lista de Interzise..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Domeniu blocat"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domenii Blocate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Copie de Rezervă Pentru Lista de Blocate"
 
@@ -132,11 +146,11 @@ msgstr "Interogare Lista de Blocare"
 msgid "Blocklist Query..."
 msgstr "Interogare Lista de Blocare..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Surse de blocare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -151,12 +165,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Renunțare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -164,7 +178,11 @@ msgstr ""
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -182,7 +200,7 @@ msgstr ""
 msgid "Count"
 msgstr "Număr"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -190,22 +208,22 @@ msgstr ""
 "Creare copii de rezervă comprimate a listei de blocate, acestea vor fi "
 "utilizate în cazul erorilor de descărcare sau în timpul pornirii."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Director DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Raport DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Timp Repornire DNS"
 
@@ -213,15 +231,15 @@ msgstr "Timp Repornire DNS"
 msgid "Date"
 msgstr "Data"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Dezactivare Permite DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Dezactivare Repornire DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -229,48 +247,51 @@ msgstr ""
 "Dezactivează repornirile declanșate de adblock pentru backend-urile dns cu "
 "funcții de autoîncărcare /notificare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domeniu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Descărcare Parametri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Coadă de Descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Notificare e-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Număr de Notificări pe E-mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "Profil E-Mail"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Adresa E-Mail Expeditor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Subiect E-Mail"
 
@@ -284,24 +305,24 @@ msgstr "Editare listă neagră"
 msgid "Edit Whitelist"
 msgstr "Editare listă albă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Activare Căutare Sigură"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Activare filtre moderate SafeSearch pentru YouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Activare serviciu adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activare înregistrare detaliată de depanare în cazul unor erori de procesare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Activat"
 
@@ -309,7 +330,7 @@ msgstr "Activat"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -321,11 +342,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Activitate(ăți) existentă(e)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Domeniul de căutare DNS extern"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -338,35 +359,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterii de filtrare precum dată, domeniu sau client (opțional)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Eliberează cache-ul DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spălare memoria cache DNS înainte de procesarea adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Forţează DNS Local"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -377,7 +398,7 @@ msgstr ""
 "pachetului „tcpdump-mini” și o repornire completă a serviciului de blocare, "
 "pentru a avea efect."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Setări generale"
 
@@ -385,15 +406,15 @@ msgstr "Setări generale"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Informare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Director Închisoare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Ultima rulare"
 
@@ -401,23 +422,23 @@ msgstr "Ultima rulare"
 msgid "Latest DNS Requests"
 msgstr "Ultimele Cereri DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista dispozitivelor de rețea utilizate de tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -426,7 +447,7 @@ msgstr ""
 "Alegeți „nespecificat” pentru a utiliza un interval de timp de pornire "
 "clasic în loc de declanșarea rețelei."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -434,7 +455,7 @@ msgstr ""
 "Lista DNS-urilor acceptate cu directorul lor al listelor implicite. Pentru a "
 "rescrie calea implicită, utilizați opțiunea „Director DNS”."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -443,13 +464,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Vizualizare Jurnal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Nume / Adresă IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -464,7 +481,7 @@ msgstr "Nu există încă jurnale adblock!"
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Profil utilizat de „msmtp” pentru e-mailurile de notificare adblock."
 
@@ -478,7 +495,7 @@ msgstr ""
 "Interogare listă de blocări active și copii de rezervă pentru un anumit "
 "domeniu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -486,17 +503,17 @@ msgstr ""
 "Creșteți numărul de notificări pentru a primi e-mailuri dacă numărul total "
 "de blocări este mai mic sau egal cu limita dată."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -518,7 +535,7 @@ msgstr "Actualizare Raport DNS"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -526,47 +543,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -574,35 +591,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Salvează"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -610,25 +627,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -636,53 +653,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Suspendă"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -714,7 +731,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -728,7 +745,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -736,7 +753,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
@@ -745,12 +762,12 @@ msgstr "Intârzierea declanșării"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -765,11 +782,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -777,17 +798,22 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Domeniu blocat"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Dezactivați lista selectivă pentru DNS permise (trecere prin RPZ)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Nume / Adresă IP"
 
 #~ msgid ""
 #~ "List of supported and fully pre-configured adblock sources, already "

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -16,16 +16,11 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- не указано -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Действие"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Активные источники"
 
@@ -34,7 +29,7 @@ msgstr "Активные источники"
 msgid "Adblock"
 msgstr "Блокировщик рекламы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Действие Adblock"
 
@@ -54,43 +49,54 @@ msgstr "Добавить этот (под-)домен в локальный чё
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Добавить этот (под-)домен в локальный белый список."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Дополнительный «тюремный» список блокировок"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "Дополнительная задержка в секундах до начала работы Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Расширенные настройки DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Расширенные настройки электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Расширенные настройки отчётов"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Ответ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Папка для резервных копий"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Расположение временных файлов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -111,19 +117,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Чёрный список..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Заблокированные DNS-запросы"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Блокируемый домен"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Блокируемые домены"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Резервная копия чёрного списка"
 
@@ -135,11 +149,11 @@ msgstr "Поиск по «чёрному списку»"
 msgid "Blocklist Query..."
 msgstr "Поиск по чёрному списку..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Источники черного списка"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -154,12 +168,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Отмена"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Категории"
 
@@ -167,7 +181,11 @@ msgstr "Категории"
 msgid "Client"
 msgstr "Клиент"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -185,7 +203,7 @@ msgstr ""
 msgid "Count"
 msgstr "Количество"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -193,22 +211,22 @@ msgstr ""
 "Создание сжатых резервных копий списков блокировок для использования при "
 "различных проблемах с загрузкой или во время запуска."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "Служба DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "Папка DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "Отчёт DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Тайм-аут перезапуска DNS"
 
@@ -216,15 +234,15 @@ msgstr "Тайм-аут перезапуска DNS"
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Отключить пропуск DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Отключить перезагрузки DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -232,49 +250,51 @@ msgstr ""
 "Отключить перезапуски служб DNS с функциями автозагрузки/inotify, вызываемые "
 "Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-#, fuzzy
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Запретить избирательное применение белого списка DNS (сквозное RPZ)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Параметры загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Очередь загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Утилита для загрузки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Уведомление по электронной почте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Счётчик e-mail уведомлений"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Адрес получателя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Адрес отправителя"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "Тема"
 
@@ -288,23 +308,23 @@ msgstr "Редактировать чёрный список"
 msgid "Edit Whitelist"
 msgstr "Редактировать белый список"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Включить Безопасный поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Включить более умеренные фильтры Безопасного поиска для УouTube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Включить службу Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Включить подробное формирование отчёта на случай возникновения ошибок."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Включено"
 
@@ -312,7 +332,7 @@ msgstr "Включено"
 msgid "End Timestamp"
 msgstr "Время окончания"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -324,11 +344,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Существующие задания"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Внешний домен DNS Lookup"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -341,39 +361,39 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Критерии фильтрации, такие как дата, домен или клиент (необязательно)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "Порты файерволла, перенаправляемые локально."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 #, fuzzy
 msgid "Firewall source zones that should be forced locally."
 msgstr "Зоны файерволла, перенаправляемые локально."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Очистка кэша DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Дополнительная очистка кэша DNS до его обработки Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 #, fuzzy
 msgid "Force Local DNS"
 msgstr "Принудительный локальный DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 #, fuzzy
 msgid "Forced Ports"
 msgstr "Перенаправляемые порты"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 #, fuzzy
 msgid "Forced Zones"
 msgstr "Перенаправляемые зоны"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -383,7 +403,7 @@ msgstr ""
 "<i>Обратите внимание: для работы этой функции необходим пакет 'tcpdump-mini' "
 "и полная перезагрузка службы Adblock.</i>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Общие настройки"
 
@@ -391,15 +411,15 @@ msgstr "Общие настройки"
 msgid "Grant access to LuCI app adblock"
 msgstr "Предоставить доступ к приложению Adblock для LuCI"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Информация"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Папка для «тюрьмы»"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Последний запуск"
 
@@ -407,25 +427,25 @@ msgstr "Последний запуск"
 msgid "Latest DNS Requests"
 msgstr "Последние DNS-запросы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "Ограничить Безопасный поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 "Ограничить использование Безопасного поиска определёнными поисковыми "
 "службами."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "Номер строки для удаления"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "Список доступных сетевых устройств, используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -433,7 +453,7 @@ msgstr ""
 "Список сетевых интерфейсов для запуска Adblock в случае их доступности. "
 "Выберите «не определено» для стандартного запуска по тайм-ауту."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -441,7 +461,7 @@ msgstr ""
 "Список поддерживаемых служб DNS с их каталогом по умолчанию. Чтобы "
 "перезаписать путь по умолчанию, используйте опцию «Каталог DNS»."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Список поддерживаемых предварительно настроенных утилит для загрузки списков."
@@ -451,13 +471,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Просмотр журнала"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Низкий приоритет службы"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Имя / IP-адрес"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -472,7 +488,7 @@ msgstr "Ещё нет журналов, связанных с Adblock!"
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "Профиль, используемый 'msmtp' для отправки почтовых уведомлений."
 
@@ -485,7 +501,7 @@ msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 "Поиск определенного домена в активных списках блокировок и резервных копиях."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 #, fuzzy
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
@@ -494,11 +510,11 @@ msgstr ""
 "Увеличение количества уведомлений для отправки письма в случае, если "
 "количество блокировок не превышает указанного числа."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Адрес получателя для уведомлений по электронной почте."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -506,7 +522,7 @@ msgstr ""
 "Перенаправление всех DNS-запросов из указанных зон к локальной службе DNS "
 "Lookup. Применяется к протоколам TCP и UDP."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -528,7 +544,7 @@ msgstr "Обновить отчёт DNS"
 msgid "Refresh Timer"
 msgstr "Обновить таймер"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Обновить таймер..."
 
@@ -536,47 +552,47 @@ msgstr "Обновить таймер..."
 msgid "Refresh..."
 msgstr "Обновить..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "Ослабить Безопасный поиск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Перезапустить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "Удалить существующее задание"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Количество фрагментов отчёта"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Размер фрагментов отчёта"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Папка для отчётов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Интерфейсы в отчёте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Порты в отчёте"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "Количество фрагментов отчёта, используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Размер фрагментов отчёта, используемых tcpdump, в мегабайтах."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Перезапустить"
 
@@ -584,30 +600,30 @@ msgstr "Перезапустить"
 msgid "Result"
 msgstr "Результат"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Рабочие папки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 #, fuzzy
 msgid "Run Flags"
 msgstr "Рабочие флаги"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Рабочие интерфейсы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "Рабочие утилиты"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Сохранить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
@@ -615,7 +631,7 @@ msgstr ""
 "Отправлять на e-mail уведомления, касающиеся Adblock. <br /> <i>Обратите "
 "внимание: требуется установка дополнительного пакета \"msmtp\".</i>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "E-Mail адрес отправителя уведомлений Adblock."
 
@@ -623,11 +639,11 @@ msgstr "E-Mail адрес отправителя уведомлений Adblock.
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
@@ -635,16 +651,16 @@ msgstr ""
 "Размер очереди загрузки для параллельной обработки (сортировки, объединения "
 "и т.п.)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 #, fuzzy
 msgid "Sources (Size, Focus)"
 msgstr "Источники (Размер, Фокусировка)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Разделенный пробелами список портов, используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr "Специальные опции конфигурации для выбранной утилиты загрузки."
 
@@ -652,53 +668,53 @@ msgstr "Специальные опции конфигурации для выб
 msgid "Start Timestamp"
 msgstr "Время начала"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "Интерфейс для запуска"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Статус / Версия"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Приостановить"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Папка для созданного списка блокировки 'adb_list.overall'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "Папка для «тюремного» списка блокировки 'adb_list.jail'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "Не удалось обновить таймер обновления."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "Таймер обновления обновлён."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr "День недели (необязательно, значения: 1–7, запятые или дефисы)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "Распределение часов (обязательно, значения: 0–23)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "Распределение минут (обязательно, значения: 0–59)"
 
@@ -740,7 +756,7 @@ msgstr ""
 msgid "Time"
 msgstr "Время"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Тайм-аут ожидания успешного перезапуска службы DNS."
 
@@ -754,7 +770,7 @@ msgstr "Чтобы списки были актуальны, настройте 
 msgid "Top 10 Statistics"
 msgstr "Топ-10 статистики"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "Тема, используемая для отправки электронных писем."
 
@@ -762,7 +778,7 @@ msgstr "Тема, используемая для отправки электр�
 msgid "Total DNS Requests"
 msgstr "Всего DNS-запросов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
@@ -771,12 +787,12 @@ msgstr "Задержка запуска"
 msgid "Unable to save changes: %s"
 msgstr "Невозможно сохранить изменения: %s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
@@ -793,11 +809,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr "Белый список..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -805,17 +825,30 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "макс. размер списка результатов"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "named (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- не указано -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Блокируемый домен"
+
+#, fuzzy
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr ""
+#~ "Запретить избирательное применение белого списка DNS (сквозное RPZ)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Имя / IP-адрес"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "named (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/si/adblock.po
+++ b/applications/luci-app-adblock/po/si/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- නිශ්චිතව දක්වා නැත -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -28,7 +23,7 @@ msgstr ""
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -48,43 +43,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "පිළිතුර"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -101,19 +107,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -125,11 +139,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -140,12 +154,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -153,7 +167,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -167,28 +185,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -196,62 +214,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -265,23 +286,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr ""
 
@@ -289,7 +310,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -299,11 +320,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -313,42 +334,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -356,15 +377,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -372,35 +393,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -409,12 +430,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -430,7 +447,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -442,23 +459,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -477,7 +494,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -485,47 +502,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -533,35 +550,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -569,25 +586,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -595,53 +612,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -673,7 +690,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -687,7 +704,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -695,7 +712,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -704,12 +721,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -724,11 +741,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -736,14 +757,13 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "- unspecified -"
+#~ msgstr "- නිශ්චිතව දක්වා නැත -"

--- a/applications/luci-app-adblock/po/sk/adblock.po
+++ b/applications/luci-app-adblock/po/sk/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Akcia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -28,7 +23,7 @@ msgstr ""
 msgid "Adblock"
 msgstr "Blokovanie reklamy Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Akcia"
 
@@ -48,46 +43,57 @@ msgstr "Pridať túto (sub-) doménu medzi lokálne zakázané domény."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Pridať túto (sub-) doménu medzi lokálne povolené domény."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Ďalšie nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Dodatočné oneskorenie v sekundách pred začiatkom spracovania blokovania "
 "reklamy."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Pokročilé DNS nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Pokročilé nastavenia e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 #, fuzzy
 msgid "Advanced Report Settings"
 msgstr "Pokročilé nastavenia"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Odpoveď"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Záložný priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Základný Temp priečinok"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,19 +112,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Zoznam zakázaných domén..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Blokovaná doména"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blokované domény"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Záloha zoznamu blokovaných domén"
 
@@ -130,11 +144,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Zdroje zoznamov blokovaní"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -145,12 +159,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -158,7 +172,11 @@ msgstr ""
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -172,28 +190,28 @@ msgstr ""
 msgid "Count"
 msgstr "Počet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS adresár"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -201,62 +219,65 @@ msgstr ""
 msgid "Date"
 msgstr "Dátum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "Upozornenie e-mailom"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "Adresa príjemcu e-mailu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -270,23 +291,23 @@ msgstr "Upraviť čiernu listinu"
 msgid "Edit Whitelist"
 msgstr "Upraviť bielu listinu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Povolené"
 
@@ -294,7 +315,7 @@ msgstr "Povolené"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -304,11 +325,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -318,42 +339,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Vyprázdniť medzipamäť DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Všeobecné nastavenia"
 
@@ -361,15 +382,15 @@ msgstr "Všeobecné nastavenia"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Informácie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -377,35 +398,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -414,12 +435,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -435,7 +452,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -447,23 +464,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -482,7 +499,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -490,47 +507,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -538,35 +555,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Uložiť"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -574,25 +591,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -600,53 +617,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -678,7 +695,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -692,7 +709,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -700,7 +717,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -709,12 +726,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -729,11 +746,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -741,17 +762,16 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Blokovaná doména"
 
 #~ msgid "DNS File Reset"
 #~ msgstr "Inicializácia DNS súboru"

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- ospecificerad -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Åtgärd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Aktiva källor"
 
@@ -28,7 +23,7 @@ msgstr "Aktiva källor"
 msgid "Adblock"
 msgstr "Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Reklamblockeringshandling"
 
@@ -48,45 +43,56 @@ msgstr "Lägg till denna (under-)domän till din lokala svartlista."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lägg till denna (under-)domän i din lokala vitlista."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Ytterligare arrest-blocklista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Fler inställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Ytterligare trigger fördröjning i sekunder innan Adblock-bearbetningen "
 "påbörjas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Avancerade DNS-inställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Avancerade e-post-inställingar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Avancerade rapportinställningar"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Svar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Tempkatalogbas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -107,19 +113,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Svartlista..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Blockerade DNS-uppslag"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Blockerad domän"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blockerade domäner"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Blockeringslistssäkerhetskopia"
 
@@ -131,11 +145,11 @@ msgstr "Blockeringslistsfråga"
 msgid "Blocklist Query..."
 msgstr "Blockeringslistsfråga..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Källor för blockeringslistor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,12 +163,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -162,7 +176,11 @@ msgstr ""
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -180,7 +198,7 @@ msgstr ""
 msgid "Count"
 msgstr "Räkna"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -188,22 +206,22 @@ msgstr ""
 "Skapa komprimerade säkerhetskopior av spärrlistor för att användas vid "
 "uppstart i händelse av nedladdningsfel."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNS-bakände"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS-mapp"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS-rapport"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "Tidsgräns för DNS-omstart"
 
@@ -211,15 +229,15 @@ msgstr "Tidsgräns för DNS-omstart"
 msgid "Date"
 msgstr "Datum"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "Inaktivera DNS-tillåtelse"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "Inaktivera DNS-omstarter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -227,48 +245,51 @@ msgstr ""
 "Inaktivera annonsblockeringsstyrda omstarter av DNS-bakändar med autoload/"
 "inotify funktionalitet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Inaktivera selektiv DNS-vitlistning (RPZ-genomflöde)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Domän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "Ladda ner parametrar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "Nedladdningskö"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "E-postavisering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "Antal E-postaviseringar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "E-postmottagaradress"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "Avsändaradress för e-post"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "E-postämne"
 
@@ -282,23 +303,23 @@ msgstr "Redigera svartlista"
 msgid "Edit Whitelist"
 msgstr "Redigera vitlista"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "Aktivera SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Aktivera måttliga SafeSearch-filter för Youtube."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Aktivera annonsblockerinstjänsten."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Aktivera utförlig avlusningsloggning i händelse av behandlingsfel."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Aktiverad"
 
@@ -306,7 +327,7 @@ msgstr "Aktiverad"
 msgid "End Timestamp"
 msgstr "Sluttidstämpel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -316,11 +337,11 @@ msgstr "Påtvingar SafeSearch på Google, Bing, DuckDuckGo, Yandex och Pixbay."
 msgid "Existing job(s)"
 msgstr "Befintliga jobb"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Extern DNS-uppslagsdomän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -332,35 +353,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtreringsvillkor som datum, domän eller klient (valfritt)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "Brandväggsportar som ska forceras lokalt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "Brandväggskällzoner som ska forceras lokalt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "Töm DNS-cache"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Spola också DNS-cachen innan annonsblockeringshantering."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Tvinga lokal DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "Forcerade portar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Forcerade zoner"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -371,7 +392,7 @@ msgstr ""
 "'tcpdump-mini'-paketet och en fullständig omstart av "
 "annonsblockeringstjänsten för att få verkan."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Generella inställningar"
 
@@ -379,15 +400,15 @@ msgstr "Generella inställningar"
 msgid "Grant access to LuCI app adblock"
 msgstr "Ge tillgång till LuCi-programmet annonsblockering"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Arrestkatalog"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Kördes senast"
 
@@ -395,23 +416,23 @@ msgstr "Kördes senast"
 msgid "Latest DNS Requests"
 msgstr "Senaste DNS-begäranden"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "Begränsa SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "Begränsa SafeSearch till vissa leverantörer."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista med tillgängliga nätverksenheter använda av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -420,7 +441,7 @@ msgstr ""
 "annonsblockeringen. Välj 'unspecified' för att använda en klassisk "
 "upstartstidsgräns istället för en nätverksaktivering."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -428,7 +449,7 @@ msgstr ""
 "Lista med tillgängliga DNS-bakändar med deras standardlistskatalog. För att "
 "åsidosätta standardsökvägen; använd alternativet 'DNS-katalog'."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista över stödda och helt förkonfigurerade nedladdningsverktyg."
 
@@ -437,13 +458,9 @@ msgstr "Lista över stödda och helt förkonfigurerade nedladdningsverktyg."
 msgid "Log View"
 msgstr "Logutsikt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Lågprioriterad tjänst"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "Namn / IP-adress"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -458,7 +475,7 @@ msgstr "Inga annonsblockerinsrelaterade loggar ännu!"
 msgid "Overview"
 msgstr "Överblick"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Profil som används av 'msmtp' för annonsblockeringsaviserinse-"
@@ -472,7 +489,7 @@ msgstr "Fråga"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "Fråga aktiva svartlistor och säkerhetskopior efter en given domän."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -480,11 +497,11 @@ msgstr ""
 "Öka aviseringsantalet för att få e-post om den sammantagna spärrlistans "
 "antal är mindre än eller lika med den givna gränsen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Mottagande adress för annonsblockeringsaviserings-e-postmeddelanden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -492,7 +509,7 @@ msgstr ""
 "Omdirigera alla DNS-frågor från specifika zoner till den lokala DNS-"
 "utredaren, gäller för UDP- och TCP-protokoll."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -514,7 +531,7 @@ msgstr "Förnya DNS-rapporten"
 msgid "Refresh Timer"
 msgstr "Förnya stoppuret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "Förnya stoppuret..."
 
@@ -522,47 +539,47 @@ msgstr "Förnya stoppuret..."
 msgid "Refresh..."
 msgstr "Fräscha upp..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "Slappna av SafeSearch"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "Rapportera klimpantal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "Rapportera klimpstorlek"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "Rapportkatalog"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "Rapportgränssnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "Rapporthamnar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "Rapportera klimpantal använt av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Rapportera klimpstorlek som används av tcpdump i MByte."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -570,35 +587,35 @@ msgstr ""
 msgid "Result"
 msgstr "Resultat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "Körkataloger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "Förflaggor"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "Körgränssnitt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "Kör verktyg"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Spara"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -606,25 +623,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Inställningar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -632,53 +649,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "Status / Version"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "Stäng av"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -710,7 +727,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -724,7 +741,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -732,7 +749,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -741,12 +758,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -761,11 +778,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -773,17 +794,25 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "- unspecified -"
+#~ msgstr "- ospecificerad -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Blockerad domän"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Inaktivera selektiv DNS-vitlistning (RPZ-genomflöde)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "Namn / IP-adress"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -1,16 +1,11 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -19,7 +14,7 @@ msgstr ""
 msgid "Adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -39,43 +34,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -92,19 +98,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -116,11 +130,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -131,12 +145,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -144,7 +158,11 @@ msgstr ""
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -158,28 +176,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -187,62 +205,65 @@ msgstr ""
 msgid "Date"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -256,23 +277,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr ""
 
@@ -280,7 +301,7 @@ msgstr ""
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -290,11 +311,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -304,42 +325,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -347,15 +368,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -363,35 +384,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -400,12 +421,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -421,7 +438,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -433,23 +450,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -468,7 +485,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -476,47 +493,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -524,35 +541,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -560,25 +577,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -586,53 +603,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -664,7 +681,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -678,7 +695,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -686,7 +703,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -695,12 +712,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -715,11 +732,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -727,14 +748,10 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""

--- a/applications/luci-app-adblock/po/tr/adblock.po
+++ b/applications/luci-app-adblock/po/tr/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "belirtilmemiş"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Eylem"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Etkin Kaynaklar"
 
@@ -28,7 +23,7 @@ msgstr "Etkin Kaynaklar"
 msgid "Adblock"
 msgstr "Reklam Engelleyici"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Reklam engelleme eylemi"
 
@@ -48,44 +43,55 @@ msgstr "Bu (alt-)alan adını yerel kara listenize ekleyin."
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Bu (alt)alan adını yerel izin verilen listenize ekleyin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "Ek \"Hapis\" Engelleme listesi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "Ek Ayarlar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Reklam engelleme işlemi başlamadan önce saniye cinsinden gecikme süresi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "Gelişmiş DNS Ayarları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "Gelişmiş E-Posta Ayarları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "Gelişmiş Rapor Ayarları"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Cevap"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Yedekleme Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "Temel Geçici Dizin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -106,19 +112,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr "Kara liste..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "Engellenen DNS İstekleri"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Engellenmiş Alan Adı"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Engellenen Alan Adları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "Engelleme Listesi Yedekleme"
 
@@ -130,11 +144,11 @@ msgstr "Engelleme Listesi Sorgusu"
 msgid "Blocklist Query..."
 msgstr "Engelleme Listesi Sorgusu..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Engelleme Listesi Kaynakları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,12 +163,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "İptal"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "Kategoriler"
 
@@ -162,7 +176,11 @@ msgstr "Kategoriler"
 msgid "Client"
 msgstr "İstemci"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -181,7 +199,7 @@ msgstr ""
 msgid "Count"
 msgstr "Adet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -189,22 +207,22 @@ msgstr ""
 "Sıkıştırılmış kara liste yedekleri oluşturun, bunlar indirme hataları ve "
 "başlatma sırasında kullanılacaktır."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNS Arka Uç"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS Raporu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "DNS Yeniden Başlatma Zaman Aşımı"
 
@@ -212,15 +230,15 @@ msgstr "DNS Yeniden Başlatma Zaman Aşımı"
 msgid "Date"
 msgstr "Tarih"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "DNS İzin Vermeyi Devre Dışı bırakın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "DNS Yeniden Başlatmalarını Devre Dışı bırakın"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
@@ -228,48 +246,51 @@ msgstr ""
 "Adblock tarafından tetiklenen autoload/inotify fonksiyonları ile dns arka uç "
 "yeniden başlatmasını devre dışı bırakın."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "Seçilebilir DNS beyaz listesini (RPZ geçişi) devre dışı bırakın."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Alan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "İndirme Parametreleri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "İndirme Kuyruğu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "İndirme Aracı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "E-Posta Bildirimi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "E-Posta Bildirim Sayısı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "E-Posta Profili"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "E-Posta Alıcı Adresi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "E-Posta Gönderen Adresi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "E-Posta Konusu"
 
@@ -283,25 +304,25 @@ msgstr "Karalisteyi Düzenle"
 msgid "Edit Whitelist"
 msgstr "Beyazlisteyi Düzenle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "GüvenliArama'yı Etkinleştir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "Youtube için hafif GüvenliArama'yı etkinleştir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "Adblock servisini etkinleştir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Herhangi bir işleme hatası durumunda ayrıntılı hata ayıklama günlüğünü "
 "etkinleştir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Etkin"
 
@@ -309,7 +330,7 @@ msgstr "Etkin"
 msgid "End Timestamp"
 msgstr "Zaman damgasını bitir"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -321,11 +342,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Mevcut iş(ler)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "Harici DNS Arama Alanı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -338,35 +359,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Tarih, alan, client gibi filtre özellikleri (opsiyonel)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "Yerel olarak zorlanması gereken güvenlik duvarı bağlantı noktaları."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "Yerel olarak zorunlu olması gereken güvenlik duvarı kaynak bölgeleri."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "DNS Önbelleğini Temizle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "Adblock işleminden önce de DNS Önbelleğini temizle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "Yerel DNS zorla"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "Zorlanan Erişim Noktaları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "Zorlanan Bölgeler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -377,7 +398,7 @@ msgstr ""
 "'tcpdump-mini' paket kurulumuna ve adblock hizmetinin tamamen yeniden "
 "başlatılması gerekir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Genel Ayarlar"
 
@@ -385,15 +406,15 @@ msgstr "Genel Ayarlar"
 msgid "Grant access to LuCI app adblock"
 msgstr "LuCI uygulaması adblock'a izin verin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Bilgi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Kafes Dizini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "Son çalışma zamanı"
 
@@ -401,35 +422,35 @@ msgstr "Son çalışma zamanı"
 msgid "Latest DNS Requests"
 msgstr "Yeni DNS Sorguları"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "GüvenliArama'yı limitle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "Belirli sağlayıcılar için GüvenliArama'yı limitle."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "Kaldırılacak satırın numarası"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump tarafından kullanılan mevcut ağ aygıtlarının listesi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -438,13 +459,9 @@ msgstr ""
 msgid "Log View"
 msgstr "Günlük Kayıtlarını Göster"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "Düşük Öncelikli Servis"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "İsim / IP Adresi"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -459,7 +476,7 @@ msgstr "Henüz adblock ile ilgili kayıt yok!"
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -471,23 +488,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -506,7 +523,7 @@ msgstr "DNS Raporunu Yenile"
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -514,47 +531,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "Yeniden yükle"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "Yeniden başlat"
 
@@ -562,35 +579,35 @@ msgstr "Yeniden başlat"
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Kaydet"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -598,25 +615,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -624,53 +641,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -702,7 +719,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -716,7 +733,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -724,7 +741,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -733,12 +750,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -753,11 +770,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -765,17 +786,25 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "- unspecified -"
+#~ msgstr "belirtilmemiş"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Engellenmiş Alan Adı"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "Seçilebilir DNS beyaz listesini (RPZ geçişi) devre dışı bırakın."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "İsim / IP Adresi"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/uk/adblock.po
+++ b/applications/luci-app-adblock/po/uk/adblock.po
@@ -11,16 +11,11 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Дія"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "Активні джерела"
 
@@ -29,7 +24,7 @@ msgstr "Активні джерела"
 msgid "Adblock"
 msgstr "Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -49,43 +44,54 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,19 +108,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,11 +140,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -141,12 +155,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -154,7 +168,11 @@ msgstr ""
 msgid "Client"
 msgstr "Клієнт"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -168,28 +186,28 @@ msgstr ""
 msgid "Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -197,62 +215,65 @@ msgstr ""
 msgid "Date"
 msgstr "Дата"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -266,23 +287,23 @@ msgstr "Редагувати чорний список"
 msgid "Edit Whitelist"
 msgstr "Редагувати білий список"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Увімкнено"
 
@@ -290,7 +311,7 @@ msgstr "Увімкнено"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -300,11 +321,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -314,42 +335,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "Загальні налаштування"
 
@@ -357,15 +378,15 @@ msgstr "Загальні налаштування"
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "Інформація"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -373,35 +394,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -410,12 +431,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -431,7 +448,7 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -443,23 +460,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -478,7 +495,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -486,47 +503,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -534,35 +551,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "Зберегти"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -570,25 +587,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -596,53 +613,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -674,7 +691,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -688,7 +705,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -696,7 +713,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr ""
 
@@ -705,12 +722,12 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr ""
 
@@ -725,11 +742,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -737,15 +758,11 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 

--- a/applications/luci-app-adblock/po/vi/adblock.po
+++ b/applications/luci-app-adblock/po/vi/adblock.po
@@ -10,16 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr ""
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "Hành động"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr ""
 
@@ -28,7 +23,7 @@ msgstr ""
 msgid "Adblock"
 msgstr "Chặn quảng cáo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr ""
 
@@ -48,44 +43,55 @@ msgstr ""
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr ""
 "Kích hoạt độ trễ trong vài giây trước khi bắt đầu tiến trình chặn quảng cáo."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "Phản hồi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "Thư mục sao lưu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -102,19 +108,27 @@ msgstr ""
 msgid "Blacklist..."
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "Tên miền bị chặn"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr ""
 
@@ -126,11 +140,11 @@ msgstr ""
 msgid "Blocklist Query..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "Bộ lọc"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -141,12 +155,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr ""
 
@@ -154,7 +168,11 @@ msgstr ""
 msgid "Client"
 msgstr "Khách hàng"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -168,29 +186,29 @@ msgstr ""
 msgid "Count"
 msgstr "Bộ đếm"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 #, fuzzy
 msgid "DNS Directory"
 msgstr "Thư mục DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr ""
 
@@ -198,62 +216,65 @@ msgstr ""
 msgid "Date"
 msgstr "Ngày"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -267,23 +288,23 @@ msgstr ""
 msgid "Edit Whitelist"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "Bật"
 
@@ -291,7 +312,7 @@ msgstr "Bật"
 msgid "End Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -301,11 +322,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -315,42 +336,42 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr ""
 
@@ -358,15 +379,15 @@ msgstr ""
 msgid "Grant access to LuCI app adblock"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr ""
 
@@ -374,35 +395,35 @@ msgstr ""
 msgid "Latest DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
@@ -411,12 +432,8 @@ msgstr ""
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
@@ -432,7 +449,7 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 
@@ -444,23 +461,23 @@ msgstr ""
 msgid "Query active blocklists and backups for a specific domain."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -479,7 +496,7 @@ msgstr ""
 msgid "Refresh Timer"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr ""
 
@@ -487,47 +504,47 @@ msgstr ""
 msgid "Refresh..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr ""
 
@@ -535,35 +552,35 @@ msgstr ""
 msgid "Result"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 
@@ -571,25 +588,25 @@ msgstr ""
 msgid "Set a new adblock job"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -597,53 +614,53 @@ msgstr ""
 msgid "Start Timestamp"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
@@ -675,7 +692,7 @@ msgstr ""
 msgid "Time"
 msgstr "Thời gian"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -689,7 +706,7 @@ msgstr ""
 msgid "Top 10 Statistics"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
@@ -697,7 +714,7 @@ msgstr ""
 msgid "Total DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
@@ -706,12 +723,12 @@ msgstr "Kích hoạt độ trễ"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 #, fuzzy
 msgid "Verbose Debug Logging"
 msgstr "Nhật ký gỡ lỗi khởi động"
@@ -727,11 +744,15 @@ msgstr ""
 msgid "Whitelist..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-msgid "dnsmasq (/tmp/dnsmasq.d)"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+msgid "dnsmasq (/tmp/dnsmasq.d)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
@@ -739,17 +760,16 @@ msgstr ""
 msgid "max. result set size"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr ""
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Blocked Domain"
+#~ msgstr "Tên miền bị chặn"
 
 #~ msgid "DNS File Reset"
 #~ msgstr "Đặt lại tệp DNS"

--- a/applications/luci-app-adblock/po/zh_Hans/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hans/adblock.po
@@ -17,16 +17,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "- 未指定 -"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "操作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "活动源"
 
@@ -35,7 +30,7 @@ msgstr "活动源"
 msgid "Adblock"
 msgstr "广告拦截"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "拦截操作"
 
@@ -55,43 +50,54 @@ msgstr "添加此域名到本地黑名单。"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "添加此域名到本地白名单。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "其它被屏蔽列表"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "额外设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "事件触发启动前的延时（秒）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "高级设置 - DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "高级设置 - 邮箱"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "高级设置 - 报告"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "备份目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "基础临时目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,19 +114,27 @@ msgstr "黑名单更改已保存。刷新您的广告拦截列表以使更改生
 msgid "Blacklist..."
 msgstr "黑名单..."
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "阻止的DNS请求"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "已拦截的域名"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "已拦截域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "黑名单列表的备份"
 
@@ -132,11 +146,11 @@ msgstr "拦截列表查询"
 msgid "Blocklist Query..."
 msgstr "黑名单查询..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "阻止列表内容"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,12 +163,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "类别"
 
@@ -162,16 +176,20 @@ msgstr "类别"
 msgid "Client"
 msgstr "客户端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
 "master/net/adblock/files/README.md\" target=\"_blank\" rel=\"noreferrer "
 "noopener\" >check the online documentation</a>"
 msgstr ""
-"配置广告拦截软件包，以通过 DNS 屏蔽广告/滥用域名。更多有关信息，请<a href=\"https://github.com/openwrt/"
-"packages/blob/master/net/adblock/files/README.md\" target=\"_blank\" rel="
-"\"noreferrer noopener\" >查看在线文档</a>"
+"配置广告拦截软件包，以通过 DNS 屏蔽广告/滥用域名。更多有关信息，请<a href="
+"\"https://github.com/openwrt/packages/blob/master/net/adblock/files/README.md"
+"\" target=\"_blank\" rel=\"noreferrer noopener\" >查看在线文档</a>"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
@@ -179,28 +197,28 @@ msgstr ""
 msgid "Count"
 msgstr "计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr "创建压缩的阻止列表备份，将在下载错误或启动期间使用它们。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNS后端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS 目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS报告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "DNS重新启动超时"
 
@@ -208,62 +226,65 @@ msgstr "DNS重新启动超时"
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "禁用DNS允许"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "禁用DNS重新启动"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "禁止广告拦截触发具有 自动加载/inotify 功能的 DNS 后端的重新启动。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "禁止选择性DNS白名单(RPZ通过)."
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "下载参数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "下载队列"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "电子邮件通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "电子邮件通知计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "电子邮件概要"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "电子邮件收件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -277,23 +298,23 @@ msgstr "编辑黑名单"
 msgid "Edit Whitelist"
 msgstr "编辑白名单"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "启用安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "为YouTube启用适度的安全搜索过滤器."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "启用广告拦截服务。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在出现任何处理错误时启用详细的调试日志。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "已启用"
 
@@ -301,7 +322,7 @@ msgstr "已启用"
 msgid "End Timestamp"
 msgstr "结束时间戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -311,11 +332,11 @@ msgstr "强制执行Google，Bing，Duckduckgo，Yandex，youtube和Google的Saf
 msgid "Existing job(s)"
 msgstr "现有任务"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "外部DNS查找域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -327,44 +348,44 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "过滤条件，例如日期，域或客户（可选）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "本地应强制使用的防火墙端口。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "本地应强制使用的防火墙源域。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "清空 DNS 缓存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "在处理广告过滤之前刷新 DNS 缓存。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "强制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "强制端口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "强制域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
 "installation and a full adblock service restart to take effect."
 msgstr ""
-"通过 tcpdump 收集与 DNS 相关的网络流量，并按需提供 DNS 报告。请注意：这需要额外的“tcpdump-"
-"mini”软件包，并重新启动完整的广告拦截服务才能生效。"
+"通过 tcpdump 收集与 DNS 相关的网络流量，并按需提供 DNS 报告。请注意：这需要额"
+"外的“tcpdump-mini”软件包，并重新启动完整的广告拦截服务才能生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "常规设置"
 
@@ -372,15 +393,15 @@ msgstr "常规设置"
 msgid "Grant access to LuCI app adblock"
 msgstr "授予访问 LuCI 应用 adblock 的权限"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "黑名单目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "最后运行"
 
@@ -388,23 +409,23 @@ msgstr "最后运行"
 msgid "Latest DNS Requests"
 msgstr "最新的DNS请求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "限定安全搜索"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "限定特定搜索引擎使用安全搜索。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "要移除的行号"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "tcpdump使用的可用网络设备列表."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -412,14 +433,14 @@ msgstr ""
 "触发adblock启动的可用网络接口列表.选择“未指定”以使用传统的启动超时而不是网络"
 "触发器."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 "支持的DNS后端列表及其默认列表目录.要覆盖默认路径，请使用“ DNS目录”选项."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支持和完全预配置的下载实用程序列表。"
 
@@ -428,13 +449,9 @@ msgstr "支持和完全预配置的下载实用程序列表。"
 msgid "Log View"
 msgstr "日志视图"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "低优先级服务"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "名称 / IP 地址"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -449,7 +466,7 @@ msgstr "尚无与广告拦截相关的日志！"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "'msmtp' 用于adblock通知电子邮件的配置文件。"
 
@@ -461,24 +478,24 @@ msgstr "查询"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查询特定域的活动阻止列表和备份."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
 msgstr ""
 "如果总体阻止列表总数小于或等于给定的限制，请提高通知数量，以获取电子邮件."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "adblock 通知 E-Mail 的收件人地址。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
 msgstr "将所有DNS查询从指定区域重定向到本地DNS解析器，适用于UDP和TCP协议。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -499,7 +516,7 @@ msgstr "刷新DNS报告"
 msgid "Refresh Timer"
 msgstr "定时恢复"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "定时恢复中..."
 
@@ -507,47 +524,47 @@ msgstr "定时恢复中..."
 msgid "Refresh..."
 msgstr "刷新..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "放宽安全搜寻"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "重新加载"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "移除一个现有任务"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "报告区块计数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "报告区块大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "报告目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "报告接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "报告端口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "报告 tcpdump 所使用的区块数量。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "报告 tcpdump 所使用的区块大小 (以 MByte 显示)。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "重启"
 
@@ -555,35 +572,35 @@ msgstr "重启"
 msgid "Result"
 msgstr "结果"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "运行目录"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "运行标记"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "运行接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "运行工具"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr "发送 AdBlock 相关的通知邮件。请留意：此功能需要安装 \"msmtp\"。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "AdBlock 通知邮件的发送地址。"
 
@@ -591,25 +608,25 @@ msgstr "AdBlock 通知邮件的发送地址。"
 msgid "Set a new adblock job"
 msgstr "设置一个新的广告拦截作业"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr "并行下载处理 (分类、合并等) 的下载队列大小。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "来源（大小，焦点）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump使用的端口列表，用空格分隔端口。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr "所选下载工具的特殊配置选项。"
 
@@ -617,53 +634,53 @@ msgstr "所选下载工具的特殊配置选项。"
 msgid "Start Timestamp"
 msgstr "开始时间戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "启动触发接口"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "状态 / 版本"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "暂停"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr "DNS 相关报告文件的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr "拦截列表备份的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "生成拦截列表“adb_list.overall”的目标目录。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "无法更新刷新计时器。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "刷新计时器已更新。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr "星期几（可选。取值范围：1-7，可用 , 或 - 分隔）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "小时（必须。取值范围：0-23）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "分钟（可选。取值范围：0-59）"
 
@@ -699,7 +716,7 @@ msgstr "此选项卡显示上次生成的 DNS 报告，按“刷新”按钮获�
 msgid "Time"
 msgstr "时间"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "等待成功的DNS后端重新启动的超时。"
 
@@ -713,7 +730,7 @@ msgstr "为了使您的广告过滤列表保持最新，您应该为这些列表
 msgid "Top 10 Statistics"
 msgstr "前 10 统计数据"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "广告拦截通知邮件的主题。"
 
@@ -721,7 +738,7 @@ msgstr "广告拦截通知邮件的主题。"
 msgid "Total DNS Requests"
 msgstr "DNS 请求总数"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "触发延时"
 
@@ -730,12 +747,12 @@ msgstr "触发延时"
 msgid "Unable to save changes: %s"
 msgstr "无法保存更改：%s"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "变种"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
@@ -750,11 +767,15 @@ msgstr "白名单更改已保存。刷新您的广告拦截列表以使更改生
 msgid "Whitelist..."
 msgstr "白名单..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "抑制 (/etc/kresd)"
 
@@ -762,17 +783,28 @@ msgstr "抑制 (/etc/kresd)"
 msgid "max. result set size"
 msgstr "最大结果集大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "BIND(/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "原始（/ tmp）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "未绑定 (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "- 未指定 -"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "已拦截的域名"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "禁止选择性DNS白名单(RPZ通过)."
+
+#~ msgid "Name / IP Address"
+#~ msgstr "名称 / IP 地址"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "BIND(/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/po/zh_Hant/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hant/adblock.po
@@ -16,16 +16,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:404
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:419
-msgid "- unspecified -"
-msgstr "未指定"
-
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
 msgid "Action"
 msgstr "動作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
 msgid "Active Sources"
 msgstr "活躍的來源"
 
@@ -34,7 +29,7 @@ msgstr "活躍的來源"
 msgid "Adblock"
 msgstr "Adblock"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:36
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:40
 msgid "Adblock action"
 msgstr "Adblock 動作"
 
@@ -54,43 +49,54 @@ msgstr "加入該（子）域名到您的本地黑名單。"
 msgid "Add this (sub-)domain to your local whitelist."
 msgstr "加入該（子）域名到您的本地白名單。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid "Additional Jail Blocklist"
 msgstr "附加 Jail 封鎖清單"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:296
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
 msgid "Additional Settings"
 msgstr "附加設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Additional trigger delay in seconds before adblock processing begins."
 msgstr "附加觸發 Adblock 行程延遲開始的秒數。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:301
 msgid "Advanced DNS Settings"
 msgstr "進階 DNS 設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:303
 msgid "Advanced E-Mail Settings"
 msgstr "進階電郵設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:302
 msgid "Advanced Report Settings"
 msgstr "進階報告設定"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid "Allow Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:457
+msgid ""
+"Allow all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
 msgid "Answer"
 msgstr "回答"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Backup Directory"
 msgstr "備份目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid "Base Temp Directory"
 msgstr "基本臨時目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:389
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:393
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -108,19 +114,27 @@ msgstr "黑名單變更已儲存；請重新整理您的 Adblock 清單來使變
 msgid "Blacklist..."
 msgstr "黑名單…"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid "Block Local Client IPs"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+msgid ""
+"Block all requests of certain DNS clients based on their IP address (RPZ-"
+"CLIENT-IP). Please note: This feature is currently only supported by bind "
+"DNS backend."
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
 msgid "Blocked DNS Requests"
 msgstr "封鎖的 DNS 請求"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
-msgid "Blocked Domain"
-msgstr "封鎖的域名"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "封鎖的域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid "Blocklist Backup"
 msgstr "黑名單備份"
 
@@ -132,11 +146,11 @@ msgstr "封鎖清單查詢"
 msgid "Blocklist Query..."
 msgstr "黑名單查詢…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:300
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:304
 msgid "Blocklist Sources"
 msgstr "封鎖清單來源"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:463
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -149,12 +163,12 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:68
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:551
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:566
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:567
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:582
 msgid "Categories"
 msgstr "類別"
 
@@ -162,7 +176,11 @@ msgstr "類別"
 msgid "Client"
 msgstr "客户端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:132
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+msgid "Clients"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:136
 msgid ""
 "Configuration of the adblock package to block ad/abuse domains by using DNS. "
 "For further information <a href=\"https://github.com/openwrt/packages/blob/"
@@ -180,28 +198,28 @@ msgstr ""
 msgid "Count"
 msgstr "計數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
 msgstr "建立壓縮的封鎖清單備份；它們將在下載錯誤時或啟動期間被使用。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:233
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "DNS Backend"
 msgstr "DNS 後端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "DNS Directory"
 msgstr "DNS 目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 #: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
 msgid "DNS Report"
 msgstr "DNS 報告"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "DNS Restart Timeout"
 msgstr "DNS 重新啟動逾時值"
 
@@ -209,62 +227,65 @@ msgstr "DNS 重新啟動逾時值"
 msgid "Date"
 msgstr "日期"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
 msgid "Disable DNS Allow"
 msgstr "停用 DNS 解析修改"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid "Disable DNS Restarts"
 msgstr "停用 DNS 重新啟動"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
 msgid ""
 "Disable adblock triggered restarts for dns backends with autoload/inotify "
 "functions."
 msgstr "停用 Adblock 觸發具有「自動載入／inotify 」功能的 DNS 後端重新啟動。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
-msgid "Disable selective DNS whitelisting (RPZ pass through)."
-msgstr "停用 DNS 選擇性白名單解析（忽略 RPZ，一律放行）。"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:448
+msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
+msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
 msgid "Domain"
 msgstr "網域名稱"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+msgid "Domains"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Download Parameters"
 msgstr "下載參數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid "Download Queue"
 msgstr "下載佇列"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "Download Utility"
 msgstr "下載工具"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid "E-Mail Notification"
 msgstr "電子郵件通知"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid "E-Mail Notification Count"
 msgstr "電郵通知數量"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "E-Mail Profile"
 msgstr "電郵設定檔"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "E-Mail Receiver Address"
 msgstr "電郵收件人位址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "E-Mail Sender Address"
 msgstr "電郵寄件人位址"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "E-Mail Topic"
 msgstr "電郵主旨"
 
@@ -278,23 +299,23 @@ msgstr "編輯黑名單"
 msgid "Edit Whitelist"
 msgstr "編輯白名單"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid "Enable SafeSearch"
 msgstr "啟用安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Enable moderate SafeSearch filters for youtube."
 msgstr "啟用為 YouTube 設定的中度安全搜尋篩選器。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enable the adblock service."
 msgstr "啟用 Adblock 服務。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在出現任何處理錯誤的情況下，請啟用詳細除錯日誌記錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:309
 msgid "Enabled"
 msgstr "啟用"
 
@@ -302,7 +323,7 @@ msgstr "啟用"
 msgid "End Timestamp"
 msgstr "結束時間戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:335
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:339
 msgid ""
 "Enforcing SafeSearch for google, bing, duckduckgo, yandex, youtube and "
 "pixabay."
@@ -314,11 +335,11 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "現存工作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid "External DNS Lookup Domain"
 msgstr "供 DNS 查詢的外部域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:440
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -330,35 +351,35 @@ msgstr ""
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "篩選器準則（例如：日期、域名或客戶端，可選）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Firewall ports that should be forced locally."
 msgstr "本地應被強制重新導向的防火牆通訊埠號。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Firewall source zones that should be forced locally."
 msgstr "本地應被強制重新導向的防火牆來源區域。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush DNS Cache"
 msgstr "清除 DNS 快取"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Flush the DNS Cache before adblock processing as well."
 msgstr "在 Adblock 行程啟動前也要清除 DNS 快取。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid "Force Local DNS"
 msgstr "強制本地 DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:324
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:328
 msgid "Forced Ports"
 msgstr "強制埠號"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:317
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:321
 msgid "Forced Zones"
 msgstr "強制區域"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
 msgid ""
 "Gather DNS related network traffic via tcpdump and provide a DNS Report on "
 "demand. Please note: this needs additional 'tcpdump-mini' package "
@@ -367,7 +388,7 @@ msgstr ""
 "透過 tcpdump 收集與 DNS 相關的網路流量，並隨需提供 DNS 報告；請注意：這需要安"
 "裝 \"tcpdump-mini\" 附加套件，且在完全重新啟動 Adblock 服務後才能生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:295
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:299
 msgid "General Settings"
 msgstr "一般設定"
 
@@ -375,15 +396,15 @@ msgstr "一般設定"
 msgid "Grant access to LuCI app adblock"
 msgstr "授予 luci-app-adblock 擁有 UCI 存取的權限"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:219
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:223
 msgid "Information"
 msgstr "資訊"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Jail Directory"
 msgstr "Jail 檔案目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:257
 msgid "Last Run"
 msgstr "最後執行"
 
@@ -391,23 +412,23 @@ msgstr "最後執行"
 msgid "Latest DNS Requests"
 msgstr "最新 DNS 請求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch"
 msgstr "限制性安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:338
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:342
 msgid "Limit SafeSearch to certain providers."
 msgstr "啟用限制性安全搜尋，以限制給定搜尋引擎的搜尋範圍。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:65
 msgid "Line number to remove"
 msgstr "要移除的行號"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "List of available network devices used by tcpdump."
 msgstr "用於 tcpdump 的可用網路裝置清單。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid ""
 "List of available network interfaces to trigger the adblock start. Choose "
 "'unspecified' to use a classic startup timeout instead of a network trigger."
@@ -415,14 +436,14 @@ msgstr ""
 "用來觸發 Adblock 啟動的可用網路介面清單；選擇「未指定」則使用傳統的啟動逾時，"
 "而不透過網路觸發。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:417
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
 msgstr ""
 "支援的 DNS 後端清單及其預設清單目錄；要重寫預設路徑，請使用「DNS 目錄」選項。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支援的下載工具清單（完全預先配置）。"
 
@@ -431,13 +452,9 @@ msgstr "支援的下載工具清單（完全預先配置）。"
 msgid "Log View"
 msgstr "日誌檢視"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid "Low Priority Service"
 msgstr "低優先權服務"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
-msgid "Name / IP Address"
-msgstr "名稱／IP 位址"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:124
 msgid "No Query results!"
@@ -452,7 +469,7 @@ msgstr "尚無與 Adblock 相關的日誌！"
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:501
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:517
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr "\"msmtp\" 使用的設定檔，用於 Adblock 寄送通知電子郵件。"
 
@@ -464,7 +481,7 @@ msgstr "查詢"
 msgid "Query active blocklists and backups for a specific domain."
 msgstr "查詢「特定網域」的活躍封鎖清單和備份。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:521
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -472,11 +489,11 @@ msgstr ""
 "提高通知數量；除非整體「封鎖清單數」小於或等於給定的限制，否則將不再取得電子"
 "郵件。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:363
 msgid "Receiver address for adblock notification e-mails."
 msgstr "Adblock 通知電子郵件的收件人位址。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:314
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:318
 msgid ""
 "Redirect all DNS queries from specified zones to the local DNS resolver, "
 "applies to UDP and TCP protocol."
@@ -484,7 +501,7 @@ msgstr ""
 "重新導向指定區域的所有「DNS 查詢」到本地 DNS 解析器（適用於 UDP 與 TCP 協"
 "定）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:370
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:374
 msgid ""
 "Reduce the priority of the adblock background processing to take fewer "
 "resources from the system. Please note: This change requires a full adblock "
@@ -505,7 +522,7 @@ msgstr "重新整理 DNS 報告"
 msgid "Refresh Timer"
 msgstr "重新整理計時器"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:262
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:266
 msgid "Refresh Timer..."
 msgstr "重新整理計時器…"
 
@@ -513,47 +530,47 @@ msgstr "重新整理計時器…"
 msgid "Refresh..."
 msgstr "重新整理…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:347
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:351
 msgid "Relax SafeSearch"
 msgstr "放寬安全搜尋"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:277
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:281
 msgid "Reload"
 msgstr "重新載入"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:57
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:61
 msgid "Remove an existing job"
 msgstr "移除一個現存工作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report Chunk Count"
 msgstr "報告區塊數量"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report Chunk Size"
 msgstr "報告區塊大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Report Directory"
 msgstr "報告目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Report Interface"
 msgstr "報告介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Report Ports"
 msgstr "報告埠號"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:476
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:492
 msgid "Report chunk count used by tcpdump."
 msgstr "報告 tcpdump 使用的區塊數量。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:481
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "報告 tcpdump 使用的區塊大小（單位：MB）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:284
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:288
 msgid "Restart"
 msgstr "重新啟動"
 
@@ -561,36 +578,36 @@ msgstr "重新啟動"
 msgid "Result"
 msgstr "結果"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
 msgid "Run Directories"
 msgstr "執行目錄"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:249
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:253
 msgid "Run Flags"
 msgstr "執行旗標"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:245
 msgid "Run Interfaces"
 msgstr "執行介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:241
 msgid "Run Utils"
 msgstr "執行工具"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:39
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:74
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:102
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:106
 msgid "Save"
 msgstr "儲存"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:355
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:359
 msgid ""
 "Send adblock related notification e-mails. Please note: this needs "
 "additional 'msmtp' package installation."
 msgstr ""
 "寄送與 Adblock 相關的通知電子郵件；請注意：這需要安裝 \"msmtp\" 附加套件。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:493
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Adblock 通知電子郵件的寄件人位址。"
 
@@ -598,25 +615,25 @@ msgstr "Adblock 通知電子郵件的寄件人位址。"
 msgid "Set a new adblock job"
 msgstr "設定一個新的廣告攔截工作"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:293
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:297
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:380
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:384
 msgid ""
 "Size of the download queue for download processing (incl. sorting, merging "
 "etc.) in parallel."
 msgstr "平行下載處理（包含排序、合併等）的下載佇列大小。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:543
 msgid "Sources (Size, Focus)"
 msgstr "來源（大小、聚焦的類別）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:502
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump 使用的通訊埠號（以空格分隔）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:415
 msgid "Special config options for the selected download utility."
 msgstr "已選擇下載工具的特殊組態選項。"
 
@@ -624,53 +641,53 @@ msgstr "已選擇下載工具的特殊組態選項。"
 msgid "Start Timestamp"
 msgstr "啟動時間戳"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:308
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:312
 msgid "Startup Trigger Interface"
 msgstr "啟動觸發介面"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:221
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:225
 msgid "Status / Version"
 msgstr "狀態／版本"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:270
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:274
 msgid "Suspend"
 msgstr "掛起"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:472
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
 msgid "Target directory for DNS related report files."
 msgstr "DNS 相關報告檔案的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:398
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:402
 msgid "Target directory for blocklist backups."
 msgstr "攔截清單備份的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "產生封鎖清單 \"adb_list.overall\" 的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr "產生 Jail 封鎖清單 \"adb_list.jail\" 的目標目錄。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:82
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:91
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:86
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:95
 msgid "The Refresh Timer could not been updated."
 msgstr "重新整理計時器無法更新。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:84
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:93
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:88
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:97
 msgid "The Refresh Timer has been updated."
 msgstr "重新整理計時器已更新。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:52
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:56
 msgid "The day of the week (opt., values: 1-7 possibly sep. by , or -)"
 msgstr "一週內的某天（取值範圍：1-7，以 \",\" 抑或 \"-\" 分隔，可選）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:42
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:46
 msgid "The hours portition (req., range: 0-23)"
 msgstr "小時部分（取值範圍：0-23，必需）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:47
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:51
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "分鐘部分（取值範圍：0-59，必需）"
 
@@ -708,7 +725,7 @@ msgstr "此頁籤顯示上次產生的 DNS 報告，按「更新」按鈕取得�
 msgid "Time"
 msgstr "時間"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "等待 DNS 後端成功重新啟動的逾時值。"
 
@@ -722,7 +739,7 @@ msgstr "要保持最新的 Adblock 清單，您應該設定這些清單的自動
 msgid "Top 10 Statistics"
 msgstr "前 10 統計"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:497
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Topic for adblock notification E-Mails."
 msgstr "Adblock 通知電子郵件的主旨。"
 
@@ -730,7 +747,7 @@ msgstr "Adblock 通知電子郵件的主旨。"
 msgid "Total DNS Requests"
 msgstr "DNS 請求總數"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:375
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:379
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
@@ -739,12 +756,12 @@ msgstr "觸發延遲"
 msgid "Unable to save changes: %s"
 msgstr "無法儲存變更（訊息：%s）"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:581
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:597
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:613
 msgid "Variants"
 msgstr "變體"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:367
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:371
 msgid "Verbose Debug Logging"
 msgstr "詳細除錯日誌"
 
@@ -759,11 +776,15 @@ msgstr "白名單變更已儲存；請重新整理您的 Adblock 清單來使變
 msgid "Whitelist..."
 msgstr "白名單…"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:425
+msgid "bind (/var/lib/bind)"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "Dnsmasq (/tmp/dnsmasq.d)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:426
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
@@ -771,17 +792,28 @@ msgstr "kresd (/etc/kresd)"
 msgid "max. result set size"
 msgstr "最大結果集大小"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-msgid "named (/var/lib/bind)"
-msgstr "BIND (/var/lib/bind)"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "raw (/tmp)"
 msgstr "原始 (/tmp)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "unbound (/var/lib/unbound)"
 msgstr "Unbound (/var/lib/unbound)"
+
+#~ msgid "- unspecified -"
+#~ msgstr "未指定"
+
+#~ msgid "Blocked Domain"
+#~ msgstr "封鎖的域名"
+
+#~ msgid "Disable selective DNS whitelisting (RPZ pass through)."
+#~ msgstr "停用 DNS 選擇性白名單解析（忽略 RPZ，一律放行）。"
+
+#~ msgid "Name / IP Address"
+#~ msgstr "名稱／IP 位址"
+
+#~ msgid "named (/var/lib/bind)"
+#~ msgstr "BIND (/var/lib/bind)"
 
 #~ msgid ""
 #~ "Changes on this tab needs a full adblock service restart to take effect."

--- a/applications/luci-app-adblock/root/usr/share/rpcd/acl.d/luci-app-adblock.json
+++ b/applications/luci-app-adblock/root/usr/share/rpcd/acl.d/luci-app-adblock.json
@@ -22,7 +22,7 @@
 				"/etc/init.d/adblock restart" : [ "exec" ],
 				"/etc/init.d/adblock suspend" : [ "exec" ],
 				"/etc/init.d/adblock resume" : [ "exec" ],
-				"/etc/init.d/adblock report * [0-9]* [a-z]* json" : [ "exec" ],
+				"/etc/init.d/adblock report [a-z]* [0-9]* *" : [ "exec" ],
 				"/etc/init.d/adblock timer list" : [ "exec" ],
 				"/etc/init.d/adblock timer remove [0-9]*" : [ "exec" ],
 				"/etc/init.d/adblock timer add * [0-9]* [0-9*]* [1-7,-*]*" : [ "exec" ],


### PR DESCRIPTION
* support new RPZ-Trigger 'RPZ-CLIENT-IP' (currently bind only)
* Reporting tweaks/mailing
* cosmetics
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>