### PR TITLE
luci-theme-material: fix wrong active state on common prefix node

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
+++ b/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
@@ -66,7 +66,7 @@
                 var that = $(this);
                 var href = that.attr("href");
 
-                if (href.indexOf(nodeUrl) != -1) {
+                if (href.endsWith(nodeUrl) || href.indexOf('/' + nodeUrl + '/') != -1) {
                     ulNode.click();
                     ulNode.next(".slide-menu").stop(true, true);
                     lastNode = that.parent();


### PR DESCRIPTION
Before fixed, if we have two nodes: 'services/ddns' and 'services/ddnsto',
click any one of they, will show they all actived.

Signed-off-by: Liangbin Lian <jjm2473@gmail.com>
(cherry picked from commit 97d50d2c6b80805cd7e513eeafc8b62fef4ab1b6)