### PR TITLE
luci-app-banip: sync with banIP 0.7.7

### DIFF
--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js
@@ -388,6 +388,10 @@ return view.extend({
 			Logging such packets may cause an increase in latency due to it requiring additional system resources.'));
 		o.rmempty = false;
 
+		o = s.taboption('general', form.Flag, 'ban_whitelistonly', _('Whitelist Only'), _('Restrict the internet access from/to a small number of secure websites/IPs \
+			and block access from/to the rest of the internet.'));
+		o.rmempty = true;
+
 		o = s.taboption('general', form.Flag, 'ban_mail_enabled', _('E-Mail Notification'), _('Send banIP related notification e-mails. \
 			This needs the installation and setup of the additional \'msmtp\' package.'));
 		o.rmempty = false;

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.5.1\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -111,34 +111,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "مجلد النسخ الاحتياطي"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -186,39 +186,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -228,39 +228,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "تنزيل المعلمات"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "تنزيل قائمة الانتظار"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "تحميل الأداة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "إعلام البريد الإلكتروني"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "ملف تعريف البريد الإلكتروني"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "عنوان مستقبل البريد الإلكتروني"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "عنوان مرسل البريد الإلكتروني"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "موضوع البريد الإلكتروني"
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "تمكين التسجيل المطول لتصحيح الأخطاء في حالة وجود أي أخطاء في المعالجة."
 
@@ -315,7 +315,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "الوظائف الحالية"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -323,7 +323,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "الاعدادات العامة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,11 +331,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -372,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr "معلومة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -386,23 +386,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "آخر تشغيل"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -414,15 +414,15 @@ msgstr "رقم الخط المراد إزالته"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "قائمة أدوات التنزيل المدعومة والمجهزة بالكامل مسبقًا"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -449,11 +449,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -483,7 +483,7 @@ msgstr "لا توجد نتائج استعلام!"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -511,18 +511,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -533,11 +533,11 @@ msgstr ""
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Query"
 msgstr "استعلام"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -566,13 +566,19 @@ msgstr "تحديث المؤقت ..."
 msgid "Remove an existing job"
 msgstr "إزالة وظيفة موجودة"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "دليل التقارير"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "إعادة تشغيل"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -586,23 +592,23 @@ msgstr "تشغيل الإشارات"
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -621,17 +627,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -639,50 +645,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -690,15 +696,15 @@ msgstr ""
 msgid "Settings"
 msgstr "إعدادات"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr "خيارات التكوين الخاصة لأداة التنزيل المساعدة المحددة."
 
@@ -720,11 +726,11 @@ msgstr "الحالة / الإصدار"
 msgid "Suspend"
 msgstr "تعليق"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -751,7 +757,7 @@ msgstr "قسم الساعات (مطلوب ، النطاق: 0-23)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "جزء الدقائق (اختياري ، النطاق: 0-59)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -800,11 +806,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "تأخير الزناد"
 
@@ -818,17 +824,17 @@ msgstr "نوع"
 msgid "Unable to save changes: %s"
 msgstr "تعذر حفظ التغييرات: s%"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "تسجيل مطول للتصحيح"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -836,7 +842,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/bg/banip.po
+++ b/applications/luci-app-banip/po/bg/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.1-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/bn_BD/banip.po
+++ b/applications/luci-app-banip/po/bn_BD/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.1-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "১ ঘন্টা"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "১২ ঘন্টা"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "২৪ ঘন্টা"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "২৪ ঘন্টা"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "৩০ মিনিট"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "৬ ঘন্টা"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr "চালু উৎস"
 msgid "Active Subnets"
 msgstr "চালু সাবনেটগুলো"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "স্বয়ংক্রিয় সাদা তালিকাভুক্ত"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.1\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr "Fonts actives"
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr "Paràmetres de correu avançats"
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Directori de còpies de seguretat"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Paràmetres de descàrrega"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Cua de descàrregues"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Utilitat de baixades"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "Notificació de correu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "Adreça del destinatari de correu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "Paràmetres generals"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Darrera execució"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Llista d’utilitats de descàrrega admeses i plenament preconfigurades."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr "Consulta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,13 +565,19 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Reiniciar"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr "Paràmetres"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/sec (výchozí)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 hodina"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr "Dodatečné zpoždění v sekundách před začátkem zpracování banIP."
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Záložní adresář"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Nástroj pro stahování"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Poslední spuštění"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Podrobné protokolování ladění"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/sec (default)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 Stunde"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 Stunden"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 Stunden"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 Stunden"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 Minuten"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 Stunden"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr "Autonome Systemnummern"
 
@@ -73,7 +73,7 @@ msgstr "Aktive Quellen"
 msgid "Active Subnets"
 msgstr "Aktive Subnetze"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -88,7 +88,7 @@ msgstr "Fügen Sie diese IP / CIDR Ihrer lokalen Whitelist hinzu."
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Zusätzliche Auslöseverzögerung in Sekunden, bevor die BanIP-Verarbeitung "
@@ -106,7 +106,7 @@ msgstr "Fortgeschrittene E-Mail Einstellungen"
 msgid "Advanced Log Settings"
 msgstr "Erweiterte Protokolleinstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr "Automatische Blacklist"
 
@@ -114,11 +114,11 @@ msgstr "Automatische Blacklist"
 msgid "Auto Detection"
 msgstr "Automatische Erkennung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "Automatische Whitelist"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
@@ -126,28 +126,28 @@ msgstr ""
 "Automatische Übertragung von verdächtigen IP-Adressen aus dem Protokoll in "
 "die banIP Blacklist während der Laufzeit."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 "Automatische Übertragung von Uplink-IP-Adressen an die banIP Whitelist "
 "während der Laufzeit."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Backupverzeichnis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "Basis-Temp-Verzeichnis"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 "Basis Temp-Verzeichnis, das für alle banIP-bezogenen Laufzeitvorgänge "
 "verwendet wird."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr "Timeout der Blockierliste"
 
@@ -201,39 +201,39 @@ msgstr "Anzahl MAC"
 msgid "Count SUM"
 msgstr "Anzahl SUM"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr "Länder"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr "DST IPset Typ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr "DST Log-Optionen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr "DST Ziel"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr "Die banIP-Standardkette lautet 'forwarding_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr "Die banIP-Standardkette lautet 'forwarding_wan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr "Die banIP-Standardkette lautet 'input_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr "Die banIP-Standardkette lautet 'input_wan_rule'"
 
@@ -243,39 +243,39 @@ msgid ""
 "automatically."
 msgstr "Erkenne automatisch alle relevanten Schnittstellen, Protokolle etc."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Download Parameter"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Download Warteschlange"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Download-Werkzeug"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr "E-Mail-Aktionen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "E-Mail-Benachrichtigung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "E-Mail-Profil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Empfängeradresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Absenderadresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "E-Mail-Thema"
 
@@ -306,9 +306,10 @@ msgstr "SRC Logging einschalten"
 msgid "Enable the banIP service."
 msgstr "Aktiviere den banIP-Service."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
-msgstr "Aktiviere das ausführliche Anwendungs-Logging bei Verarbeitungsfehlern."
+msgstr ""
+"Aktiviere das ausführliche Anwendungs-Logging bei Verarbeitungsfehlern."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:352
 msgid "Enabled"
@@ -330,7 +331,7 @@ msgstr "Details"
 msgid "Existing job(s)"
 msgstr "Bestehende Job(s)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr "Spezielle Quellen"
 
@@ -338,7 +339,7 @@ msgstr "Spezielle Quellen"
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr "Globaler IPSet Typ"
 
@@ -346,11 +347,11 @@ msgstr "Globaler IPSet Typ"
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr "Hohe Priorität"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr "Höchste Priorität"
 
@@ -387,13 +388,13 @@ msgstr "IPv6 Unterstützung"
 msgid "Information"
 msgstr "Informationen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr "LAN Forward"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr "LAN Input"
 
@@ -401,23 +402,23 @@ msgstr "LAN Input"
 msgid "Last Run"
 msgstr "Letzter Durchgang"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr "Niedrigste Priorität"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr "Niedrige Priorität"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr "Beschränke den E-Mail-Trigger auf bestimmte banIP-Aktionen."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr "Beschränke den Log-Monitor auf bestimmte Suchbegriffe."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr "Beschränke die Auswahl an lokalen Quellen."
 
@@ -429,17 +430,17 @@ msgstr "Zu entfernende Zeile"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Liste der unterstützten und vollständig vorkonfigurierten Download-"
 "Hilfsprogramme."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr "Lokale Quellen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -447,7 +448,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -466,11 +467,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -480,7 +481,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -500,7 +501,7 @@ msgstr "Keine Abfrageergebnisse!"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -528,18 +529,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -550,11 +551,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -562,7 +563,7 @@ msgstr ""
 msgid "Query"
 msgstr "Abfrage"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -583,13 +584,19 @@ msgstr "Timer..."
 msgid "Remove an existing job"
 msgstr "Entferne einen vorhandenen Job"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "Report-Verzeichnis"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Neustart"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -603,23 +610,23 @@ msgstr "Laufzeit-Flags"
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -638,17 +645,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -656,50 +663,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -707,15 +714,15 @@ msgstr ""
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Spezielle Konfigurationseinstellungen für das gewählte Download-Programm."
@@ -738,11 +745,11 @@ msgstr "Status / Version"
 msgid "Suspend"
 msgstr "Anhalten"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -768,7 +775,7 @@ msgstr "Der Stundenteil (Werte zw. 0-23)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "Der Minutenteil (Werte zw. 0-59)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -817,11 +824,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Verzögerung der Trigger-Bedingung"
 
@@ -835,17 +842,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr "Konnte Änderungen nicht speichern: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -853,7 +860,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/el/banip.po
+++ b/applications/luci-app-banip/po/el/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "φάκελος διάσωσης"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/en/banip.po
+++ b/applications/luci-app-banip/po/en/banip.po
@@ -4,42 +4,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -96,7 +96,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -104,34 +104,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -179,39 +179,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -221,39 +221,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -308,7 +308,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -316,7 +316,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -324,11 +324,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -365,13 +365,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -379,23 +379,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -407,15 +407,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -442,11 +442,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -504,18 +504,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -526,11 +526,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -559,12 +559,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -579,23 +585,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -614,17 +620,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -632,50 +638,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -683,15 +689,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -713,11 +719,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -743,7 +749,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -792,11 +798,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -810,17 +816,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -828,7 +834,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -13,42 +13,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/sec (predeterminado)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 hora"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 horas"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 horas"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 horas"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 minutos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 horas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr "ASNs"
 
@@ -76,7 +76,7 @@ msgstr "Fuentes activas"
 msgid "Active Subnets"
 msgstr "Subredes activas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -91,7 +91,7 @@ msgstr "Agregue esta IP/CIDR a su lista blanca local."
 msgid "Additional Settings"
 msgstr "Configuración adicional"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
@@ -109,7 +109,7 @@ msgstr "Configuración avanzada de correo electrónico"
 msgid "Advanced Log Settings"
 msgstr "Configuración de registro avanzada"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr "Lista negra automática"
 
@@ -117,11 +117,11 @@ msgstr "Lista negra automática"
 msgid "Auto Detection"
 msgstr "Detección automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "Lista blanca automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
@@ -129,28 +129,28 @@ msgstr ""
 "Transfiere automáticamente las direcciones IP sospechosas del registro a la "
 "lista negra de banIP durante el tiempo de ejecución."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 "Transfiere automáticamente IPs de enlace ascendente a la lista blanca banIP "
 "durante el tiempo de ejecución."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Directorio de respaldo"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "Directorio temporal base"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 "Directorio temporal base utilizado para todas las operaciones en tiempo de "
 "ejecución relacionadas con banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr "Tiempo de espera de lista negra"
 
@@ -204,39 +204,39 @@ msgstr "Cuenta MAC"
 msgid "Count SUM"
 msgstr "Cuenta SUM"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr "Países"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr "Tipo de IPSet DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr "Opciones de registro DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr "Objetivo DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr "La cadena predeterminada utilizada por banIP es 'forwarding_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr "La cadena predeterminada utilizada por banIP es 'forwarding_wan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr "La cadena predeterminada utilizada por banIP es 'input_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr "La cadena predeterminada utilizada por banIP es 'input_wan_rule'"
 
@@ -248,39 +248,39 @@ msgstr ""
 "Detecte interfaces de red, dispositivos, subredes y protocolos relevantes "
 "automáticamente."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Descargar parámetros"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Cola de descarga"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Utilidad de descarga"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr "Acciones de correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "Notificación por correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "Perfil de correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario de correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente de correo electrónico"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "Tema del correo electrónico"
 
@@ -311,7 +311,7 @@ msgstr "Activar el registro de SRC"
 msgid "Enable the banIP service."
 msgstr "Activar el servicio banIP.."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activar el registro de depuración detallado en caso de errores de "
@@ -337,7 +337,7 @@ msgstr "Detalles de entrada"
 msgid "Existing job(s)"
 msgstr "Trabajo(s) existente(s)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr "Fuentes extra"
 
@@ -345,7 +345,7 @@ msgstr "Fuentes extra"
 msgid "General Settings"
 msgstr "Configuración general"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr "Tipo de IPSet global"
 
@@ -353,11 +353,11 @@ msgstr "Tipo de IPSet global"
 msgid "Grant access to LuCI app banIP"
 msgstr "Otorgar acceso a la aplicación banIP de LuCI"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr "Alta prioridad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr "Prioridad más alta"
 
@@ -394,13 +394,13 @@ msgstr "Soporte IPv6"
 msgid "Information"
 msgstr "Información"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr "Reenvío LAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr "Entrada LAN"
 
@@ -408,24 +408,24 @@ msgstr "Entrada LAN"
 msgid "Last Run"
 msgstr "Último inicio"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr "Prioridad mínima"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr "Menos prioridad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 "Limite el disparador de correo electrónico a determinadas acciones de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr "Limite el monitor de registro a ciertos términos de registro."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr "Limite la selección a determinadas fuentes locales."
 
@@ -438,16 +438,16 @@ msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 "Lista de interfaces de red disponibles para activar el inicio de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de utilidades de descarga totalmente preconfiguradas y compatibles."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr "Fuentes locales"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr "Límite de registro"
 
@@ -455,7 +455,7 @@ msgstr "Límite de registro"
 msgid "Log Monitor"
 msgstr "Monitor de registro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr "Términos de registro"
 
@@ -477,11 +477,11 @@ msgstr ""
 "registro de dichos paquetes puede provocar un aumento de la latencia debido "
 "a que requiere recursos adicionales del sistema."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr "Contador de registro de LuCI"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr "Tiempo de espera de Maclist"
 
@@ -493,7 +493,7 @@ msgstr ""
 "Se han guardado los cambios de Maclist. Actualice sus listas de banIP para "
 "que los cambios surtan efecto."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr "Contador de registro de NGINX"
 
@@ -513,7 +513,7 @@ msgstr "¡No hay resultados de consulta!"
 msgid "No banIP related logs yet!"
 msgstr "¡Aún no hay registros relacionados con banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr "Prioridad normal (predeterminado)"
 
@@ -541,7 +541,7 @@ msgstr "Número de todos los IPSets"
 msgid "Number of all entries"
 msgstr "Número de todas las entradas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
@@ -549,14 +549,14 @@ msgstr ""
 "Número de intentos de acceso desde la misma ip en el registro antes de "
 "bloquear."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 "Número de solicitudes nginx fallidas de la misma IP en el registro antes de "
 "bloquear."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -569,13 +569,13 @@ msgstr ""
 msgid "Overview"
 msgstr "Vista general"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 "Analice solo el último número indicado de entradas de registro para detectar "
 "eventos sospechosos."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Perfil utilizado por 'msmtp' para correos electrónicos de notificación de "
@@ -585,7 +585,7 @@ msgstr ""
 msgid "Query"
 msgstr "Consulta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 "Dirección del receptor de los correos electrónicos de notificación de banIP."
@@ -607,13 +607,19 @@ msgstr "Actualizar temporizador..."
 msgid "Remove an existing job"
 msgstr "Eliminar un trabajo existente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "Directorio de informes"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Reiniciar"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -627,23 +633,23 @@ msgstr "Ejecutar banderas"
 msgid "Run Information"
 msgstr "Ejecutar información"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr "Tipo IPSet SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr "Opciones de registro SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr "Objetivo SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr "Tipo de IPSet SRC+DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr "Cuenta de registros SSH"
 
@@ -664,7 +670,7 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr "Seleccione las interfaces de red relevantes manualmente."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
@@ -672,12 +678,12 @@ msgstr ""
 "Envíe correos electrónicos de notificación relacionados con banIP. Esto "
 "necesita la instalación y configuración del paquete adicional 'msmtp'."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 "Dirección del remitente para correos electrónicos de notificación de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr "Prioridad de servicio"
 
@@ -685,54 +691,54 @@ msgstr "Prioridad de servicio"
 msgid "Set a new banIP job"
 msgstr "Establecer un nuevo trabajo banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 "Configure el tipo de DST individual por IPset para bloquear solo los "
 "paquetes salientes."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 "Configure el tipo de SRC individual por IPset para bloquear solo los "
 "paquetes entrantes."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 "Configure el tipo de SRC+DST individual por IPset para bloquear los paquetes "
 "entrantes y salientes."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 "Establecer opciones especiales de registro DST, p. Ej. para establecer una "
 "tasa límite."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 "Configure opciones especiales de registro de SRC, por ejemplo, para "
 "establecer una tasa límite."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr "Configure el tiempo de espera de IPSet de la lista negra."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 "Establezca el destino del firewall para todas las reglas relacionadas con "
 "DST."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 "Establezca el objetivo del firewall para todas las reglas relacionadas con "
 "SRC."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
@@ -740,11 +746,11 @@ msgstr ""
 "Establezca el tipo de IPset global predeterminado para bloquear los paquetes "
 "entrantes (SRC) y/o salientes (DST)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr "Establezca el tiempo de espera de maclist IPSet."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr "Establezca el tiempo de espera de IPSet de la lista blanca."
 
@@ -752,16 +758,16 @@ msgstr "Establezca el tiempo de espera de IPSet de la lista blanca."
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 "Tamaño de la cola de descarga para el procesamiento de descargas en paralelo."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr "Fuentes (Información)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opciones de configuración especiales para la utilidad de descarga "
@@ -787,12 +793,12 @@ msgstr "Estado/Versión"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 "Directorio de destino para archivos de informes relacionados con IPSet."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 "Directorio de destino para copias de seguridad de listas de origen "
@@ -821,7 +827,7 @@ msgstr "El reparto de horas (req., rango: 0-23)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "La porción de minutos (opcional, rango: 0-59)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -892,11 +898,11 @@ msgstr ""
 "Para mantener actualizadas sus listas de banIP, debe configurar un trabajo "
 "de actualización automática para estas listas."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr "Tema para correos electrónicos de notificación de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
@@ -910,17 +916,17 @@ msgstr "Tipo"
 msgid "Unable to save changes: %s"
 msgstr "No se pudo guardar los cambios: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr "Reenvío WAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr "Entrada WAN"
 
@@ -928,7 +934,11 @@ msgstr "Entrada WAN"
 msgid "Whitelist IP/CIDR"
 msgstr "Lista blanca de IP/CIDR"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr "Tiempo de espera de lista blanca"
 

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Varmuuskopiohakemisto"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Lataustyökalu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Viimeksi ajettu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/sec (défaut)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 heure"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 heures"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 heures"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 heures"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 minutes"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 heures"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr "Sources Actives"
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Paramètres additionnels"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Délai de déclenchement supplémentaire en secondes avant le début du "
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -112,34 +112,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Répertoire de sauvegarde"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -187,39 +187,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -229,39 +229,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Télécharger l'utilitaire"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "Notification E-Mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "Email du profil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -332,11 +332,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -373,13 +373,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -387,23 +387,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Dernière exécution"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -450,11 +450,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -512,18 +512,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -534,11 +534,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Aperçu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -567,12 +567,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -587,23 +593,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -622,17 +628,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -640,50 +646,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -691,15 +697,15 @@ msgstr ""
 msgid "Settings"
 msgstr "Paramètres"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -721,11 +727,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -751,7 +757,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -801,11 +807,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
@@ -819,17 +825,17 @@ msgstr "Type"
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -837,7 +843,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/he/banip.po
+++ b/applications/luci-app-banip/po/he/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -111,34 +111,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -186,39 +186,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -228,39 +228,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -315,7 +315,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -323,7 +323,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,11 +331,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -372,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -386,23 +386,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -414,15 +414,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -449,11 +449,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -483,7 +483,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -511,18 +511,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -533,11 +533,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -566,12 +566,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -586,23 +592,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -621,17 +627,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -639,50 +645,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -690,15 +696,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -720,11 +726,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -750,7 +756,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -799,11 +805,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -817,17 +823,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -835,7 +841,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/hi/banip.po
+++ b/applications/luci-app-banip/po/hi/banip.po
@@ -4,42 +4,42 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -67,7 +67,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -80,7 +80,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -96,7 +96,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -104,34 +104,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -179,39 +179,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -221,39 +221,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -284,7 +284,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -308,7 +308,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -316,7 +316,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -324,11 +324,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -365,13 +365,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -379,23 +379,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -407,15 +407,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -442,11 +442,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -456,7 +456,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -476,7 +476,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -504,18 +504,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -526,11 +526,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -559,12 +559,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -579,23 +585,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -614,17 +620,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -632,50 +638,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -683,15 +689,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -713,11 +719,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -743,7 +749,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -792,11 +798,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -810,17 +816,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -828,7 +834,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "További aktiválókésleltetés másodpercben, mielőtt a banIP feldolgozása "
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -112,34 +112,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Biztonsági mentés könyvtára"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -187,39 +187,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -229,39 +229,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Letöltési segédprogram"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -332,11 +332,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -373,13 +373,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -387,23 +387,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Utolsó futás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -450,11 +450,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -512,18 +512,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -534,11 +534,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -567,12 +567,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -587,23 +593,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -622,17 +628,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -640,50 +646,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -691,15 +697,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -721,11 +727,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -751,7 +757,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -802,11 +808,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
@@ -820,17 +826,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Részletes hibakeresési naplózás"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -838,7 +844,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Directory del Backup"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Utilità di Scaricamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "Impostazioni Generali"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr "アクティブなソース"
 msgid "Active Subnets"
 msgstr "アクティブなサブネット"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "追加設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr "Eメールの詳細設定"
 msgid "Advanced Log Settings"
 msgstr "ログの詳細設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr "自動ブラックリスト"
 
@@ -110,34 +110,34 @@ msgstr "自動ブラックリスト"
 msgid "Auto Detection"
 msgstr "自動検出"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "自動ホワイトリスト"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "バックアップ先 ディレクトリ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "ベースとなるテンポラリディレクトリ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr "MAC をカウント"
 msgid "Count SUM"
 msgstr "SUM をカウント"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr "国"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "ダウンロードのパラメータ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "ダウンロードキュー"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "ダウンロードユーティリティ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr "Eメールアクション"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "Eメール通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "Eメールプロファイル"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "Eメール送信者アドレス"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "Eメールトピック"
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr "banIP サービスを有効にする。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "エラーが発生した際に詳細なデバッグロギングを有効にします。"
 
@@ -314,7 +314,7 @@ msgstr "エントリ詳細"
 msgid "Existing job(s)"
 msgstr "既存のジョブ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr "高い優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr "最高の優先度"
 
@@ -371,13 +371,13 @@ msgstr "IPv6 サポート"
 msgid "Information"
 msgstr "情報"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "最終実行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr "最低の優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr "低い優先度"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr "削除する行番号"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "サポートされ、かつ設定済のダウンロード ユーティリティの一覧です。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr "ログ制限"
 
@@ -429,7 +429,7 @@ msgstr "ログ制限"
 msgid "Log Monitor"
 msgstr "ログモニター"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr "検索結果がありません！"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr "通常の優先度 (デフォルト)"
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr "全エントリ数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr "検索"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,13 +565,19 @@ msgstr "タイマーをリフレッシュ..."
 msgid "Remove an existing job"
 msgstr "既存のジョブを削除"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "レポート ディレクトリ"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "再起動"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -585,23 +591,23 @@ msgstr "実行フラグ"
 msgid "Run Information"
 msgstr "実行情報"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr "サービス優先度"
 
@@ -638,50 +644,50 @@ msgstr "サービス優先度"
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr "選択したダウンロードユーティリティーの特別な設定オプション。"
 
@@ -719,11 +725,11 @@ msgstr "ステータス / バージョン"
 msgid "Suspend"
 msgstr "一時停止"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr "時(必須、0-23の値)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "分(オプション、0-59の値)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
@@ -816,17 +822,17 @@ msgstr "タイプ"
 msgid "Unable to save changes: %s"
 msgstr "変更を保存できませんでした: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ko/banip.po
+++ b/applications/luci-app-banip/po/ko/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,35 +110,35 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 #, fuzzy
 msgid "Backup Directory"
 msgstr "백업 경로"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -186,39 +186,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -228,39 +228,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -315,7 +315,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -323,7 +323,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "기본 설정"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,11 +331,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -372,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -386,23 +386,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -414,15 +414,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -449,11 +449,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -483,7 +483,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -511,18 +511,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -533,11 +533,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -566,12 +566,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -586,23 +592,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -621,17 +627,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -639,50 +645,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -690,15 +696,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -720,11 +726,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -750,7 +756,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -799,11 +805,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -817,17 +823,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -835,7 +841,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/mr/banip.po
+++ b/applications/luci-app-banip/po/mr/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ms/banip.po
+++ b/applications/luci-app-banip/po/ms/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Direktori Sandaran"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr "Aktive kilder"
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Ytterligere innstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr "Avanserte e-postinnstillinger"
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Sikkerhetskopimappe"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Nedlastingsparametre"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Nedlastingskø"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Nedlastingsverktøy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "E-postsenderadresse"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "E-postemne"
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Eksisterende jobb(er)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "Generelle innstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr "IPv6-støtte"
 msgid "Information"
 msgstr "Info"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Sist kjørt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr "Linjenummer å fjerne"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr "Spørring"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,13 +565,19 @@ msgstr "Gjenoppfrisk tidsur …"
 msgid "Remove an existing job"
 msgstr "Fjern en eksisterende jobb"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "Rapportmappe"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Omstart"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -586,23 +592,23 @@ msgstr "Kjøringsflagg"
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -621,17 +627,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -639,50 +645,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -690,15 +696,15 @@ msgstr ""
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -720,11 +726,11 @@ msgstr "Status/versjon"
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -750,7 +756,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -799,11 +805,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Utløserforsinkelse"
 
@@ -817,17 +823,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr "Kunne ikke lagre endringer: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -835,7 +841,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/nl/banip.po
+++ b/applications/luci-app-banip/po/nl/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m-limiet --limiet 2/sec (standaard)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 uur"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 uren"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 uur"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 uur"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 minuten"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 uur"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr "ASN's"
 
@@ -73,7 +73,7 @@ msgstr "Actieve bronnen"
 msgid "Active Subnets"
 msgstr "Actieve subnetten"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -88,7 +88,7 @@ msgstr "Voeg dit IP/CIDR toe aan uw lokale whitelist."
 msgid "Additional Settings"
 msgstr "Aanvullende instellingen"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -104,7 +104,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -112,34 +112,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -187,39 +187,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -229,39 +229,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -292,7 +292,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -332,11 +332,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -373,13 +373,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -387,23 +387,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -450,11 +450,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -512,18 +512,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -534,11 +534,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -567,12 +567,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -587,23 +593,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -622,17 +628,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -640,50 +646,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -691,15 +697,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -721,11 +727,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -751,7 +757,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -800,11 +806,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -818,17 +824,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -836,7 +842,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/sec (domyślnie)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 godzina"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 1 godzin"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 godziny"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 godziny"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 minut"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 godzin"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr "ASNs"
 
@@ -74,7 +74,7 @@ msgstr "Aktywne źródła"
 msgid "Active Subnets"
 msgstr "Aktywne podsieci"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -89,7 +89,7 @@ msgstr "Dodaj ten adres IP/CIDR do lokalnej białej listy."
 msgid "Additional Settings"
 msgstr "Dodatkowe ustawienia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalania w sekundach przed rozpoczęciem przetwarzania "
@@ -107,7 +107,7 @@ msgstr "Zaawansowane ustawienia e-mail"
 msgid "Advanced Log Settings"
 msgstr "Zaawansowane ustawienia dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr "Automatyczna czarna lista"
 
@@ -115,11 +115,11 @@ msgstr "Automatyczna czarna lista"
 msgid "Auto Detection"
 msgstr "Automatyczne wykrywanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "Automatyczna biała lista"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
@@ -127,27 +127,27 @@ msgstr ""
 "Automatycznie przenosi podejrzane IP z logu na czarną listę banIP w czasie "
 "działania programu."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 "Automatycznie przenosi adresy IP uplink do białej listy banIP podczas pracy."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Katalog kopii zapasowej"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "Podstawowy katalog tymczasowy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 "Bazowy katalog Temp używany dla wszystkich operacji runtime związanych z "
 "banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr "Limit czasu czarnej listy"
 
@@ -201,39 +201,39 @@ msgstr "Policz MAC"
 msgid "Count SUM"
 msgstr "Policz SUM"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr "Kraje"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr "Typ zestawu DST IPSet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr "Opcje dziennika DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr "Cel DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr "Domyślny łańcuch używany przez banIP 'forwarding_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr "Domyślny łańcuch używany przez banIP 'forwarding_wan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr "Domyślny łańcuch używany przez banIP 'input_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr "Domyślny łańcuch używany przez banIP 'input_wan_rule'"
 
@@ -245,39 +245,39 @@ msgstr ""
 "Automatyczne wykrywanie odpowiednich interfejsów sieciowych, urządzeń, "
 "podsieci i protokołów."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Parametry pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Kolejka pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Narzędzie pobierania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr "Akcje poczty e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "Powiadomienie e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "Profil e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "Adres e-mail odbiorcy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "Adres e-mail nadawcy"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "Temat e-mail"
 
@@ -308,7 +308,7 @@ msgstr "Włącz logowanie SRC"
 msgid "Enable the banIP service."
 msgstr "Włącz usługę BanIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Włącz rejestrowanie debugowania w przypadku wystąpienia błędów w "
@@ -334,7 +334,7 @@ msgstr "Szczegóły wpisu"
 msgid "Existing job(s)"
 msgstr "Istniejące zadania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr "Dodatkowe źródła"
 
@@ -342,7 +342,7 @@ msgstr "Dodatkowe źródła"
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr "Typ globalnego zestawu IPSet"
 
@@ -350,11 +350,11 @@ msgstr "Typ globalnego zestawu IPSet"
 msgid "Grant access to LuCI app banIP"
 msgstr "Udziel dostępu LuCI do aplikacji banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr "Wysoki priorytet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr "Najwyższy priorytet"
 
@@ -391,13 +391,13 @@ msgstr "Obsługa IPv6"
 msgid "Information"
 msgstr "Informacje"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr "Przekazywanie sieci LAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr "Wejście LAN"
 
@@ -405,23 +405,23 @@ msgstr "Wejście LAN"
 msgid "Last Run"
 msgstr "Ostatnie uruchomienie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr "Najniższy priorytet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr "Mniejszy priorytet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr "Ogranicz wyzwalacz wiadomości e-mail do niektórych działań banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr "Ogranicz monitor dziennika do określonych warunków dziennika."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr "Ogranicz wybór do niektórych źródeł lokalnych."
 
@@ -434,16 +434,16 @@ msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 "Lista dostępnych interfejsów sieciowych wyzwalających uruchomienie banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista obsługiwanych i wstępnie skonfigurowanych narzędzi do pobierania."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr "Źródła lokalne"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr "Limit dziennika"
 
@@ -451,7 +451,7 @@ msgstr "Limit dziennika"
 msgid "Log Monitor"
 msgstr "Monitor dziennika"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr "Warunki dziennika"
 
@@ -473,11 +473,11 @@ msgstr ""
 "Rejestrowanie takich pakietów może spowodować wzrost opóźnienia ze względu "
 "na to, że wymaga dodatkowych zasobów systemowych."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr "Liczba dzienników LuCI"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr "Limit czasu listy Mac"
 
@@ -489,7 +489,7 @@ msgstr ""
 "Zmiany na Maclistach zostały zapisane. Odśwież swoje listy banIP, aby zmiany "
 "zaczęły obowiązywać."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr "Liczba dzienników NGINX"
 
@@ -509,7 +509,7 @@ msgstr "Brak wyników zapytania!"
 msgid "No banIP related logs yet!"
 msgstr "Brak dzienników związanych z banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr "Normalny priorytet (domyślny)"
 
@@ -537,7 +537,7 @@ msgstr "Liczba wszystkich zestawów IP"
 msgid "Number of all entries"
 msgstr "Liczba wszystkich wpisów"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
@@ -545,13 +545,13 @@ msgstr ""
 "Liczba nieudanych powtórzeń logowania LuCI z tego samego ip w logu przed "
 "zbanowaniem."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 "Liczba nieudanych żądań nginx z tego samego ip w logu przed zbanowaniem."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -564,13 +564,13 @@ msgstr ""
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 "Analizuj tylko ostatnią podaną liczbę wpisów w dzienniku w poszukiwaniu "
 "podejrzanych zdarzeń."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 "Profil używany przez \"msmtp\" dla wiadomości e-mail z powiadomieniem BanIP."
@@ -579,7 +579,7 @@ msgstr ""
 msgid "Query"
 msgstr "Zapytanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr "Adres odbiorcy wiadomości e-mail z powiadomieniem BanIP."
 
@@ -600,13 +600,19 @@ msgstr "Harmonogram..."
 msgid "Remove an existing job"
 msgstr "Usuń istniejące zadanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "Katalog raportów"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Restart"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -620,23 +626,23 @@ msgstr "Uruchomione flagi"
 msgid "Run Information"
 msgstr "Uruchom informacje"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr "Typ zestawu IPSet SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr "Opcje dziennika SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr "Cel SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr "Typ zestawu IP SRC+DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr "Liczba dzienników SSH"
 
@@ -657,7 +663,7 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr "Ręcznie wybierz odpowiednie interfejsy sieciowe."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
@@ -665,11 +671,11 @@ msgstr ""
 "Wyślij wiadomości e-mail z powiadomieniami związanymi z banIP. Wymaga to "
 "instalacji i konfiguracji dodatkowego pakietu 'msmtp'."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Adres nadawcy wiadomości e-mail z powiadomieniem BanIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr "Priorytet usługi"
 
@@ -677,47 +683,47 @@ msgstr "Priorytet usługi"
 msgid "Set a new banIP job"
 msgstr "Ustaw nowe zadanie BanIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 "Ustaw indywidualny typ DST dla każdego zestawu IP, aby blokować tylko "
 "pakiety wychodzące."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 "Ustaw indywidualny typ SRC dla każdego zestawu IP, aby blokować tylko "
 "pakiety przychodzące."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 "Ustaw indywidualny typ SRC+DST dla każdego zestawu IP, aby blokować "
 "przychodzące i wychodzące pakiety."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr "Ustaw specjalne opcje dziennika DST, np. aby ustawić limit."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr "Ustaw specjalne opcje logów SRC, np. aby ustawić limit."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr "Ustaw limit czasu zestawu IP na czarnej liście."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 "Ustaw cel zapory sieciowej dla wszystkich reguł związanych z czasem letnim."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr "Ustaw miejsce docelowe zapory dla wszystkich reguł związanych z SRC."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
@@ -725,11 +731,11 @@ msgstr ""
 "Ustaw domyślny typ globalnego zestawu IP, aby blokować pakiety przychodzące "
 "(SRC) i/lub wychodzące (DST)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr "Ustaw limit czasu dla maclist IPSet."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr "Ustaw limit czasu zestawu IP na białej liście."
 
@@ -737,15 +743,15 @@ msgstr "Ustaw limit czasu zestawu IP na białej liście."
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr "Rozmiar kolejki pobierania dla równoległego przetwarzania pobierania."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr "Źródła (informacje)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr "Specjalne opcje konfiguracji dla wybranego narzędzia do pobierania."
 
@@ -769,11 +775,11 @@ msgstr "Status/Wersja"
 msgid "Suspend"
 msgstr "Zawieś"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr "Katalog docelowy dla plików raportów związanych z IPSet."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr "Katalog docelowy dla kopii zapasowych skompresowanej listy źródeł."
 
@@ -799,7 +805,7 @@ msgstr "Godzina (wymagane, zakres: 0–23)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "Minuta (opcjonalnie, zakres: 0–59)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -868,11 +874,11 @@ msgstr ""
 "Aby listy BanIP były aktualne, należy skonfigurować zadanie automatycznej "
 "aktualizacji tych list."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr "Temat dla wiadomości e-mail z powiadomieniem BanIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
@@ -886,17 +892,17 @@ msgstr "Typ"
 msgid "Unable to save changes: %s"
 msgstr "Nie można zapisać zmian: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr "Przekazywanie WAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr "Wejście WAN"
 
@@ -904,7 +910,11 @@ msgstr "Wejście WAN"
 msgid "Whitelist IP/CIDR"
 msgstr "Biała lista IP/CIDR"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr "Limit czasu białej listy"
 

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/seg (predefinição)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 hora"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 horas"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 horas"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 horas"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 minutos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 horas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr "ASNs"
 
@@ -73,7 +73,7 @@ msgstr "Fontes Ativas"
 msgid "Active Subnets"
 msgstr "Sub-redes ativas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -88,7 +88,7 @@ msgstr "Adicionar esta IP/CIDR à sua lista local."
 msgid "Additional Settings"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Atraso de gatilho adicional em segundos antes do início do processamento de "
@@ -106,7 +106,7 @@ msgstr "Configurações avançadas de E-Mail"
 msgid "Advanced Log Settings"
 msgstr "Configurações avançadas de registos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr "Lista negra automática"
 
@@ -114,11 +114,11 @@ msgstr "Lista negra automática"
 msgid "Auto Detection"
 msgstr "Deteção automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "Lista branca automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
@@ -126,26 +126,26 @@ msgstr ""
 "Transfere automaticamente os IPs suspeitos do registo para a lista negra do "
 "banIP durante o tempo de execução."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 "Transfere automaticamente os IPs de ligações ascendentes para a lista branca "
 "do banIP durante o tempo de execução."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Diretório do Backup"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -193,39 +193,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -235,39 +235,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Parâmetros de Descarregamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Fila de Descarregamento"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Ferramenta para Descarregar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "Notificação por e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "Perfil de e-mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de e-mail do destinatário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "Endereço de e-mail do remetente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "Assunto do e-mail"
 
@@ -298,7 +298,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registo de depuração detalhado para casos de todos os erros de "
@@ -324,7 +324,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -332,7 +332,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -340,11 +340,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr "Suporte de IPv6"
 msgid "Information"
 msgstr "Informação"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -395,23 +395,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -423,17 +423,17 @@ msgstr "Número da linha a remover"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Lista de ferramentas de descarregamento suportadas e completamente pré-"
 "configuradas."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -441,7 +441,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -460,11 +460,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr "A consulta não retornou resultados!"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -522,18 +522,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -544,11 +544,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Query"
 msgstr "Consulta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -577,13 +577,19 @@ msgstr "Atualizando o Temporizador..."
 msgid "Remove an existing job"
 msgstr "Remover uma tarefa existente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "Diretório de Relatórios"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Reiniciar"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -597,23 +603,23 @@ msgstr "Flags de Execução"
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -632,17 +638,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr "Prioridade do serviço"
 
@@ -650,50 +656,50 @@ msgstr "Prioridade do serviço"
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -701,15 +707,15 @@ msgstr ""
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de descarregamento "
@@ -733,11 +739,11 @@ msgstr "Condição geral / versão"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -763,7 +769,7 @@ msgstr "A parte das horas (obg., intervalo: 0-23)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "A parte dos minutos (opt., intervalo: 0-59)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -813,11 +819,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
@@ -831,17 +837,17 @@ msgstr "Tipo"
 msgid "Unable to save changes: %s"
 msgstr "Impossível gravar as modificações: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Registos detalhados de depuração"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -849,7 +855,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/seg (padrão)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 hora"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 horas"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 horas"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 horas"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 minutos"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 horas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr "ASNs"
 
@@ -73,7 +73,7 @@ msgstr "Fontes Ativas"
 msgid "Active Subnets"
 msgstr "Sub-redes Ativas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -88,7 +88,7 @@ msgstr "Adicione essa IP/CIDR a sua lista local."
 msgid "Additional Settings"
 msgstr "Configurações Adicionais"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Atraso de disparo adicional em segundos antes do início do processamento de "
@@ -106,7 +106,7 @@ msgstr "Configurações Avançadas do E-Mail"
 msgid "Advanced Log Settings"
 msgstr "Configuração de registros avançada"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr "Lista negra automática"
 
@@ -114,11 +114,11 @@ msgstr "Lista negra automática"
 msgid "Auto Detection"
 msgstr "Detecção Automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "Lista Branca Automática"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
@@ -126,28 +126,28 @@ msgstr ""
 "Transfira automaticamente os IPs suspeitos dos registros para a lista negra "
 "do banIP durante a execução."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 "Transfira automaticamente os IPs do enlace para a lista branca durante a "
 "execução."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 "O Diretório Base Temporário usado para todas as operações relacionadas com o "
 "tempo de execução do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr "Tempo limite da Lista negra"
 
@@ -201,39 +201,39 @@ msgstr "Contagem MAC"
 msgid "Count SUM"
 msgstr "Contagem SOMA"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr "Países"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr "Tipo do IPSet DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr "Opções de log do DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr "Alvo DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr "A cadeia padrão utilizada pelo banIP é 'forwarding_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr "A cadeia padrão utilizada pelo banIP é 'forwarding_wan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr "A cadeia padrão utilizada pelo banIP é 'input_lan_rule'"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr "A cadeia padrão utilizada pelo banIP é 'input_wan_rule'"
 
@@ -245,39 +245,39 @@ msgstr ""
 "Detecte automaticamente as interfaces de rede, os dispositivos, as sub-redes "
 "e os protocolos relevantes."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Fila de Download"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr "Ações do E-Mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
@@ -308,7 +308,7 @@ msgstr "Active o log do SRC"
 msgid "Enable the banIP service."
 msgstr "Ative o serviço banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registro de depuração detalhada nos casos de qualquer erro de "
@@ -334,7 +334,7 @@ msgstr "Detalhes da entrada"
 msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr "Outras Origens"
 
@@ -342,7 +342,7 @@ msgstr "Outras Origens"
 msgid "General Settings"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr "Tipo do IPSet global"
 
@@ -350,11 +350,11 @@ msgstr "Tipo do IPSet global"
 msgid "Grant access to LuCI app banIP"
 msgstr "Conceda acesso ao aplicativo LuCI banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr "Alta prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr "Máxima Prioridade"
 
@@ -391,13 +391,13 @@ msgstr "Suporte ao IPv6"
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr "Encaminhamento LAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr "Entrada LAN"
 
@@ -405,23 +405,23 @@ msgstr "Entrada LAN"
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr "Mínima Prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr "Menor Prioridade"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr "Limite o acionador de e-mail para certas ações do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr "Limite o monitor de registro para certos termos."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr "Limita a seleção a certas fontes locais."
 
@@ -431,17 +431,18 @@ msgstr "O número da linha para remover"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:355
 msgid "List of available network interfaces to trigger the banIP start."
-msgstr "Lista de interfaces de rede disponíveis para acionar o início do banIP."
+msgstr ""
+"Lista de interfaces de rede disponíveis para acionar o início do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr "Fontes Locais"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr "Limite do Registro"
 
@@ -449,7 +450,7 @@ msgstr "Limite do Registro"
 msgid "Log Monitor"
 msgstr "Monitor do registro"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr "Termos do registro"
 
@@ -471,11 +472,11 @@ msgstr ""
 "registro de tais pacotes pode causar um aumento na latência devido à "
 "necessidade de recursos adicionais do sistema."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr "A contagem dos registros do LuCI"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr "Tempo Limite do Maclist"
 
@@ -487,7 +488,7 @@ msgstr ""
 "As alterações do Maclist foram salvas. Atualize as suas listas banIP para "
 "que as alterações sejam aplicadas."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr "Contagem dos registros do NGINX"
 
@@ -507,7 +508,7 @@ msgstr "A Consulta Não Retornou Resultados!"
 msgid "No banIP related logs yet!"
 msgstr "Ainda não há nenhum registro relacionado ao banIP!"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr "Prioridade Normal (padrão)"
 
@@ -535,7 +536,7 @@ msgstr "A quantidade de todos os IPSets"
 msgid "Number of all entries"
 msgstr "A quantidade de todas as entradas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
@@ -543,14 +544,14 @@ msgstr ""
 "A quantidade das autenticações LuCI repetidas, vindas a partir do mesmo IP "
 "que falharam e que estão no registro antes do banimento."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 "A quantidade de solicitações com falha do nginx do mesmo IP no registro "
 "antes do banimento."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -563,13 +564,13 @@ msgstr ""
 msgid "Overview"
 msgstr "Visão geral"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 "Analise apenas o último número declarado das entradas de registro na busca "
 "dos eventos suspeitos."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "O perfil usado pelo 'msmtp' para os e-mails de notificação do banIP."
 
@@ -577,7 +578,7 @@ msgstr "O perfil usado pelo 'msmtp' para os e-mails de notificação do banIP."
 msgid "Query"
 msgstr "Consulta"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr "O endereço do destinatário para os e-mails de notificação do banIP."
 
@@ -598,13 +599,19 @@ msgstr "Atualizando o Temporizador..."
 msgid "Remove an existing job"
 msgstr "Exclua uma tarefa já existente"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Reiniciar"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -618,23 +625,23 @@ msgstr "Executar Flags"
 msgid "Run Information"
 msgstr "Informações de Execução"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr "O tipo do conjunto de IPs SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr "Opções de registro SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr "Destino SRC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr "O tipo do conjunto de IPs SRC+DST"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr "A quantidade de registros SSH"
 
@@ -655,7 +662,7 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr "Selecione as interfaces de rede relevantes manualmente."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
@@ -663,11 +670,11 @@ msgstr ""
 "Envie e-mails de notificação relacionados ao banIP. É necessário a "
 "instalação e configuração do pacote adicional 'msmtp'."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr "Endereço do remetente para os e-mails de notificação do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr "Prioridade do serviço"
 
@@ -675,50 +682,50 @@ msgstr "Prioridade do serviço"
 msgid "Set a new banIP job"
 msgstr "Definir nova tarefa banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 "Define o tipo DST individual por conjunto de IPs para bloquear somente "
 "pacotes de saída."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 "Define o tipo SRC individual por conjunto de IPs para bloquear somente "
 "pacotes de entrada."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 "Define o tipo SRC+DST individual por conjunto de IPs para bloquear pacotes "
 "de entrada e saída."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 "Define as opções do registro DST especiais. Por exemplo: para definir uma "
 "taxa limite."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 "Define as opções especiais do registro SRC . Por exemplo: para definir uma "
 "taxa limite."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr "Define o tempo limite da lista negra dos conjuntos de IPs."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr "Define o destino do firewall para todas as regras relacionadas ao DST."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr "Define o destino do firewall para todas as regras relacionadas ao SRC."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
@@ -726,11 +733,11 @@ msgstr ""
 "Define o padrão do tipo do conjunto global dos IPs, para bloquear os pacotes "
 "da entrada (SRC) e/ou da saída (DST)."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr "Define o tempo limite do conjunto dos IPs maclist."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr "Define o tempo limite da lista branca do conjunto de IPs."
 
@@ -738,16 +745,16 @@ msgstr "Define o tempo limite da lista branca do conjunto de IPs."
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 "O tamanho da fila de download para o processamento dos downloads em paralelo."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr "Fontes (Informações)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 "Opções especiais de configuração para o utilitário de download selecionado."
@@ -772,12 +779,12 @@ msgstr "Condição Geral / Versão"
 msgid "Suspend"
 msgstr "Suspender"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 "Pasta de destino para arquivos de relatório relacionados ao conjunto de IPs."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr "O diretório de destino para os backups compactados da lista de origem."
 
@@ -803,7 +810,7 @@ msgstr "A parte das horas (obg., intervalo: 0-23)"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "A parte dos minutos (obg., intervalo: 0-59)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -873,11 +880,11 @@ msgstr ""
 "Para manter as suas listas banIP atualizadas, você precisa configurar uma "
 "tarefa de atualização automática para estas listas."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr "Tópico para e-mails de notificação do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
@@ -891,17 +898,17 @@ msgstr "Tipo"
 msgid "Unable to save changes: %s"
 msgstr "Impossível salvar as modificações: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr "Redirecionar WAN"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr "Entrada WAN"
 
@@ -909,7 +916,11 @@ msgstr "Entrada WAN"
 msgid "Whitelist IP/CIDR"
 msgstr "Lista branca IP/CIDR"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr "Tempo limite da lista branca"
 

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 "Întârziere suplimentară declanșare in secunde înainte de începerea "
@@ -105,7 +105,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -113,34 +113,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Director copie de siguranţă"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -188,39 +188,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -230,39 +230,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Utilitar descărcare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -293,7 +293,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -317,7 +317,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -325,7 +325,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -333,11 +333,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -374,13 +374,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -388,23 +388,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Ultima rulare"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -416,15 +416,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -451,11 +451,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -465,7 +465,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -513,18 +513,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -535,11 +535,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -547,7 +547,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -568,12 +568,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -588,23 +594,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -623,17 +629,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -641,50 +647,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -692,15 +698,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -722,11 +728,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -752,7 +758,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -801,11 +807,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
@@ -819,17 +825,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -837,7 +843,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 час"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 часов"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 часа"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 часа"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 минут"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 часов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr "Активные источники"
 msgid "Active Subnets"
 msgstr "Активные подсети"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr "Дополнительная задержка срабатывания правил banIP в секундах."
 
@@ -103,7 +103,7 @@ msgstr "Расширенные настройки электронной поч�
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr "Автоматический черный список"
 
@@ -111,34 +111,34 @@ msgstr "Автоматический черный список"
 msgid "Auto Detection"
 msgstr "Автоопределение"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "Автоматический белый список"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Папка для резервных копий"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "Расположение временных файлов"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr "Тайм-аут черного списка"
 
@@ -186,39 +186,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr "Страны"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -228,39 +228,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Параметры загрузки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Очередь загрузки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Утилита для загрузки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "Уведомление по электронной почте"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "Адрес получателя"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "Адрес отправителя"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "Тема"
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Включить подробное формирование отчёта на случай возникновения ошибок."
 
@@ -315,7 +315,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Существующие задания"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr "Дополнительные источники"
 
@@ -323,7 +323,7 @@ msgstr "Дополнительные источники"
 msgid "General Settings"
 msgstr "Общие настройки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,11 +331,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr "Предоставить доступ LuCI к приложению banIP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr "Высокий приоритет"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr "Наивысший приоритет"
 
@@ -372,13 +372,13 @@ msgstr "Поддержка IPv6"
 msgid "Information"
 msgstr "Информация"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -386,23 +386,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Последний запуск"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr "Наименьший приоритет"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr "Меньший приоритет"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -414,16 +414,16 @@ msgstr "Номер строки для удаления"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 "Список поддерживаемых предварительно настроенных утилит для загрузки списков."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -450,11 +450,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr "Нет результатов запроса!"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -512,18 +512,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -534,11 +534,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Query"
 msgstr "Запрос"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -567,13 +567,19 @@ msgstr "Обновить таймер..."
 msgid "Remove an existing job"
 msgstr "Удалить существующее задание"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "Папка для отчётов"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Перезапустить"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -587,23 +593,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -622,17 +628,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -640,50 +646,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -691,15 +697,15 @@ msgstr ""
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr "Источники (информация)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr "Специальные опции конфигурации для выбранной утилиты загрузки."
 
@@ -721,11 +727,11 @@ msgstr "Статус / Версия"
 msgid "Suspend"
 msgstr "Приостановить"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -751,7 +757,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -800,11 +806,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
@@ -818,17 +824,17 @@ msgstr "Тип"
 msgid "Unable to save changes: %s"
 msgstr "Невозможно сохранить изменения: %s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -836,7 +842,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/sk/banip.po
+++ b/applications/luci-app-banip/po/sk/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.0-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Záložný priečinok"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Nástroj na sťahovanie"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr "Aktiva källor"
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr "Avancerade e-post-inställingar"
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "Tempkatalogbas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "Ladda ner parametrar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "Nedladdningskö"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "Avsändaradress för e-post"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "E-postämne"
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Aktivera utförlig avlusningsloggning i händelse av behandlingsfel."
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Befintliga jobb"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "Generella inställningar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Kördes senast"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr "Inga frågeresultat!"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Överblick"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr "Förnya stoppuret..."
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "Rapportkatalog"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr "Förflaggor"
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/templates/banip.pot
+++ b/applications/luci-app-banip/po/templates/banip.pot
@@ -1,42 +1,42 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -64,7 +64,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -77,7 +77,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -93,7 +93,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -101,34 +101,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -176,39 +176,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -218,39 +218,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -281,7 +281,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -313,7 +313,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -321,11 +321,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -362,13 +362,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -376,23 +376,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -404,15 +404,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -420,7 +420,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -439,11 +439,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -453,7 +453,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -473,7 +473,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -501,18 +501,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -523,11 +523,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -556,12 +556,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -576,23 +582,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -611,17 +617,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -629,50 +635,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -680,15 +686,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -710,11 +716,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -740,7 +746,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -789,11 +795,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -807,17 +813,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -825,7 +831,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr "Etkin Kaynaklar"
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr "Ek Ayarlar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr "Gelişmiş E-Posta Ayarları"
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Yedekleme Dizini"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "Temel Geçici Dizin"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "İndirme Parametreleri"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "İndirme Kuyruğu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "İndirme Aracı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "E-Posta Bildirimi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "E-Posta Profili"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "E-Posta Alıcı Adresi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "E-Posta Gönderen Adresi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "E-Posta Konusu"
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Herhangi bir işleme hatası durumunda ayrıntılı hata ayıklama günlüğünü "
@@ -316,7 +316,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr "Mevcut iş(ler)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "Genel Ayarlar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -332,11 +332,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -373,13 +373,13 @@ msgstr ""
 msgid "Information"
 msgstr "Bilgi"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -387,23 +387,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "Son çalışma zamanı"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -415,15 +415,15 @@ msgstr "Kaldırılacak satırın numarası"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -431,7 +431,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -450,11 +450,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -464,7 +464,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr "Sorgu sonuçları yok!"
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -512,18 +512,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -534,11 +534,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -567,13 +567,19 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "Yeniden başlat"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -587,23 +593,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -622,17 +628,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -640,50 +646,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -691,15 +697,15 @@ msgstr ""
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -721,11 +727,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -751,7 +757,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -800,11 +806,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -818,17 +824,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -836,7 +842,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -11,42 +11,42 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -74,7 +74,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -111,34 +111,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -186,39 +186,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -228,39 +228,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -315,7 +315,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -323,7 +323,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "Загальні налаштування"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -331,11 +331,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -372,13 +372,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -386,23 +386,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -414,15 +414,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -430,7 +430,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -449,11 +449,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -483,7 +483,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -511,18 +511,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -533,11 +533,11 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -566,12 +566,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -586,23 +592,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -621,17 +627,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -639,50 +645,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -690,15 +696,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -720,11 +726,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -750,7 +756,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -799,11 +805,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr ""
 
@@ -817,17 +823,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -835,7 +841,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr ""
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr ""
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr ""
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "Thư mục sao lưu"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr ""
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,12 +565,18 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
@@ -816,18 +822,18 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 #, fuzzy
 msgid "Verbose Debug Logging"
 msgstr "Nhật ký gỡ lỗi khởi động"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -835,7 +841,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/sec（默认）"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 小时"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 小时"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 小时"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 小时"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 分钟"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 小时"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr "平均取样数"
 
@@ -73,7 +73,7 @@ msgstr "活动源"
 msgid "Active Subnets"
 msgstr "活动子网"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr "额外的与非 banIP 相关的 IPSets，例如：用于报告和查询。"
@@ -86,7 +86,7 @@ msgstr "将此 IP/CIDR 添加到您的本地白名单。"
 msgid "Additional Settings"
 msgstr "额外设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr "banIP 处理开始之前的额外触发延迟（以秒为单位）。"
 
@@ -102,7 +102,7 @@ msgstr "高级设置 - 邮箱"
 msgid "Advanced Log Settings"
 msgstr "高级设置 - 日志"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr "自动 黑名单"
 
@@ -110,34 +110,34 @@ msgstr "自动 黑名单"
 msgid "Auto Detection"
 msgstr "自动检测"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr "自动 白名单"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr "运行时自动将可疑 IP 从日志转移到 banIP 黑名单。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr "运行时自动将上行链路 IP 转移到 banIP 白名单。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "备份目录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr "基础临时目录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr "用于所有与 banIP 相关运行时操作的基础临时目录。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr "超时黑名单"
 
@@ -164,9 +164,9 @@ msgid ""
 "master/net/banip/files/README.md\" target=\"_blank\" rel=\"noreferrer "
 "noopener\" >check the online documentation</a>"
 msgstr ""
-"通过 IPSet 拦截 IP 地址/子网的 banIP 包的配置。更多信息请<a href=\"https://github.com/openwrt/"
-"packages/blob/master/net/banip/files/README.md\" target=\"_blank\" rel="
-"\"noreferrer noopener\" >查看在线文档</a>"
+"通过 IPSet 拦截 IP 地址/子网的 banIP 包的配置。更多信息请<a href=\"https://"
+"github.com/openwrt/packages/blob/master/net/banip/files/README.md\" target="
+"\"_blank\" rel=\"noreferrer noopener\" >查看在线文档</a>"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:124
 msgid "Count ACC"
@@ -188,39 +188,39 @@ msgstr "MAC 统计"
 msgid "Count SUM"
 msgstr "SUM 统计"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr "地区"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr "DST IPSet 类型"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr "DST 日志选项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr "DST 目标"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr "banIP 默认使用的链是 “forwarding_lan_rule”"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr "banIP 默认使用的链是 “forwarding_wan_rule”"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr "banIP 默认使用的链是 “input_lan_rule”"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr "banIP 默认使用的链是 “input_wan_rule”"
 
@@ -230,39 +230,39 @@ msgid ""
 "automatically."
 msgstr "自动检测相关的网络接口、设备、子网和协议。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr "下载参数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr "下载队列"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "下载工具"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr "电子邮件操作"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr "电子邮件通知"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr "电子邮件概要"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr "电子邮件收件人地址"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
@@ -293,7 +293,7 @@ msgstr "启用 SRC 记录"
 msgid "Enable the banIP service."
 msgstr "启用 banIP 服务。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在出现任何处理错误时启用详细的调试日志。"
 
@@ -317,7 +317,7 @@ msgstr "条目详情"
 msgid "Existing job(s)"
 msgstr "现有任务"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr "附加源"
 
@@ -325,7 +325,7 @@ msgstr "附加源"
 msgid "General Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr "全局 IPSet 类型"
 
@@ -333,11 +333,11 @@ msgstr "全局 IPSet 类型"
 msgid "Grant access to LuCI app banIP"
 msgstr "授予访问 LuCI 应用 banIP 的权限"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr "较高优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr "最高优先级"
 
@@ -374,13 +374,13 @@ msgstr "IPv6 支持"
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr "局域网转发"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr "局域网入站"
 
@@ -388,23 +388,23 @@ msgstr "局域网入站"
 msgid "Last Run"
 msgstr "最后运行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr "最低优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr "较低优先级"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr "限制仅特定 banIP 操作会触发电子邮件发送。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr "将日志监视器限制为特定的日志项。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr "将选择限制在特定的本地源。"
 
@@ -416,15 +416,15 @@ msgstr "要移除的行号"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr "触发 banIP 启动的可用网络接口列表。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "支持和完全预配置的下载实用程序列表。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr "本地源"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr "日志限制"
 
@@ -432,7 +432,7 @@ msgstr "日志限制"
 msgid "Log Monitor"
 msgstr "日志监视器"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr "日志项"
 
@@ -449,13 +449,15 @@ msgstr "记录可疑的传入数据包 - 通常是被丢弃的。"
 msgid ""
 "Log suspicious outgoing packets - usually rejected. Logging such packets may "
 "cause an increase in latency due to it requiring additional system resources."
-msgstr "记录可疑的传出数据包 - 通常是被拒绝的。由于需要额外的系统资源，记录这样的数据包可能会导致延迟增加。"
+msgstr ""
+"记录可疑的传出数据包 - 通常是被拒绝的。由于需要额外的系统资源，记录这样的数据"
+"包可能会导致延迟增加。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr "LuCI 日志计数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr "MAC 列表超时"
 
@@ -465,7 +467,7 @@ msgid ""
 "effect."
 msgstr "MAC 列表更改已经保存。刷新您的 banIP 列表以使更改生效。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr "NGINX 日志计数"
 
@@ -485,7 +487,7 @@ msgstr "无查询结果！"
 msgid "No banIP related logs yet!"
 msgstr "尚无 banIP 相关的日志！"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr "正常优先级（默认）"
 
@@ -513,18 +515,18 @@ msgstr "全部 IPSet 条目数"
 msgid "Number of all entries"
 msgstr "全部条目数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr "在被封禁前，日志中同一 IP 登录 LuCI 失败的记录次数。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr "在被封禁前，日志中同一 IP 请求 nginx 失败的记录次数。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -535,11 +537,11 @@ msgstr "在被封禁前，日志中同一 IP 登录 SSH 失败的记录次数。
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr "仅解析最后声明的可疑事件的日志条目数量。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr "“msmtp”所用的 banIP 电子邮件通知配置。"
 
@@ -547,7 +549,7 @@ msgstr "“msmtp”所用的 banIP 电子邮件通知配置。"
 msgid "Query"
 msgstr "查询"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr "banIP 通知电子邮件的接收者地址。"
 
@@ -568,13 +570,19 @@ msgstr "定时恢复中..."
 msgid "Remove an existing job"
 msgstr "移除一个现有任务"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr "报告目录"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "重启"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -588,23 +596,23 @@ msgstr "运行标记"
 msgid "Run Information"
 msgstr "运行信息"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr "SRC IPSet 类型"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr "SRC 日志选项"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr "SRC 目标"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr "SRC+DST IPSet 类型"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr "SSH 日志计数"
 
@@ -623,17 +631,17 @@ msgstr "搜索特定 IP、CIDR 或 MAC 地址的活动的 banIP 相关 IPSet。"
 msgid "Select the relevant network interfaces manually."
 msgstr "手动选择相关的网络接口。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr "发送 banIP 相关的通知邮件。这需要安装和设置额外的“msmtp”包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr "banIP 通知邮件的发送地址。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr "服务优先级"
 
@@ -641,50 +649,50 @@ msgstr "服务优先级"
 msgid "Set a new banIP job"
 msgstr "配置一个新的 banIP 任务"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr "为每一 IPSet 设置单独的 DST 类型来仅拦截传出数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr "为每一 IPSet 设置单独的 SRC 类型来仅拦截传入数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr "为每一 IPSet 设置单独的 SRC+DST 类型来拦截传入和传出数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr "设定特殊的 DST 日志选项，如设置一个限制率。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr "设置特殊的 SRC 日志选项，如设置一个限制率。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr "设置黑名单 IPSet 超时。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr "设置所有 DST 相关规则的防火墙目标。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr "设置所有 SRC 相关规则的防火墙目标。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr "设置全局 IPSet 类型默认值，以拦截传入（SRC）和/或传出（DST）数据包。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr "设置 MAC 列表 IPSet 超时。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr "设置白名单 IPSet 超时。"
 
@@ -692,15 +700,15 @@ msgstr "设置白名单 IPSet 超时。"
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr "用于并行下载处理的下载队列大小。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr "源（信息）"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr "所选下载工具的特殊配置选项。"
 
@@ -722,11 +730,11 @@ msgstr "状态 / 版本"
 msgid "Suspend"
 msgstr "暂停"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr "IPSet 相关的报告文件的目标目录。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr "压缩的源列表备份的目标目录。"
 
@@ -752,11 +760,13 @@ msgstr "小时（必须。取值范围：0-23）"
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr "分钟（可选。取值范围：0-59）"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
-msgstr "所选的优先级将用于 banIP 后台处理。此更改需要重新启动整个 banIP 服务才能生效。"
+msgstr ""
+"所选的优先级将用于 banIP 后台处理。此更改需要重新启动整个 banIP 服务才能生"
+"效。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/logread.js:28
 msgid "The syslog output, pre-filtered for banIP related messages only."
@@ -769,8 +779,9 @@ msgid ""
 "or domain name per line. Comments introduced with '#' are allowed - "
 "wildcards and regex are not."
 msgstr ""
-"这是本地 banIP 黑名单，用于始终拒绝某些 IP/CIDR 地址。<br /> <em><b>请注意：</b></em>每行仅添加一个 IPv4 "
-"地址、IPv6 地址或域名。注释以“＃”开头。不允许使用通配符和正则表达式。"
+"这是本地 banIP 黑名单，用于始终拒绝某些 IP/CIDR 地址。<br /> <em><b>请注意："
+"</b></em>每行仅添加一个 IPv4 地址、IPv6 地址或域名。注释以“＃”开头。不允许使"
+"用通配符和正则表达式。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/maclist.js:23
 msgid ""
@@ -778,8 +789,9 @@ msgid ""
 "<em><b>Please note:</b></em> add only one MAC address per line. Comments "
 "introduced with '#' are allowed - domains, wildcards and regex are not."
 msgstr ""
-"这是本地 banIP MAC 列表，用于始终允许某些 MAC 地址。<br /> "
-"<em><b>请注意：</b></em>每行只添加一个MAC地址。注释以“＃”开头。不允许使用域名、通配符和正则表达式。"
+"这是本地 banIP MAC 列表，用于始终允许某些 MAC 地址。<br /> <em><b>请注意：</"
+"b></em>每行只添加一个MAC地址。注释以“＃”开头。不允许使用域名、通配符和正则表"
+"达式。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/whitelist.js:23
 msgid ""
@@ -788,8 +800,9 @@ msgid ""
 "or domain name per line. Comments introduced with '#' are allowed - "
 "wildcards and regex are not."
 msgstr ""
-"这是本地 banIP 白名单，用于始终允许某些 IP/CIDR 地址。<br /> <em><b>请注意：</b></em>每行仅添加一个 IPv4 "
-"地址、IPv6 地址或域名。注释以“＃”开头。不允许使用通配符和正则表达式。"
+"这是本地 banIP 白名单，用于始终允许某些 IP/CIDR 地址。<br /> <em><b>请注意："
+"</b></em>每行仅添加一个 IPv4 地址、IPv6 地址或域名。注释以“＃”开头。不允许使"
+"用通配符和正则表达式。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
 msgid ""
@@ -807,11 +820,11 @@ msgid ""
 "job for these lists."
 msgstr "为了使您的 banIP 列表保持最新，您应该为这些列表设置一个自动更新任务。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr "banIP 通知邮件的主题。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "触发延时"
 
@@ -825,17 +838,17 @@ msgstr "类型"
 msgid "Unable to save changes: %s"
 msgstr "无法保存更改：%s"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr "广域网转发"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr "广域网入站"
 
@@ -843,7 +856,11 @@ msgstr "广域网入站"
 msgid "Whitelist IP/CIDR"
 msgstr "白名单 IP/CIDR"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr "白名单超时"
 

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -10,42 +10,42 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:701
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:709
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:705
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:713
 msgid "-m limit --limit 2/sec (default)"
 msgstr "-m limit --limit 2/秒 (預設)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:483
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:492
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:501
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:487
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:496
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:505
 msgid "1 hour"
 msgstr "1 小時"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:489
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:498
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:507
 msgid "12 hours"
 msgstr "12 小時"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:508
+msgid "24 hours"
+msgstr "24 小時"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:486
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:495
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:504
-msgid "24 hours"
-msgstr "24 小時"
-
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:482
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:491
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:500
 msgid "30 minutes"
 msgstr "30 分鐘"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:484
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:493
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:502
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:488
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:497
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:506
 msgid "6 hours"
 msgstr "6 小時"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:780
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:784
 msgid "ASNs"
 msgstr "平均取樣數"
 
@@ -73,7 +73,7 @@ msgstr ""
 msgid "Active Subnets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid ""
 "Add additional, non-banIP related IPSets e.g. for reporting and queries."
 msgstr ""
@@ -86,7 +86,7 @@ msgstr ""
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Additional trigger delay in seconds before banIP processing begins."
 msgstr "附加觸發 banIP 行程開始延遲的秒數。"
 
@@ -102,7 +102,7 @@ msgstr ""
 msgid "Advanced Log Settings"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid "Auto Blacklist"
 msgstr ""
 
@@ -110,34 +110,34 @@ msgstr ""
 msgid "Auto Detection"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid "Auto Whitelist"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:801
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:805
 msgid ""
 "Automatically transfers suspicious IPs from the log to the banIP blacklist "
 "during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:804
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:808
 msgid ""
 "Automatically transfers uplink IPs to the banIP whitelist during runtime."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Backup Directory"
 msgstr "備份目錄"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:431
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
 msgid "Base Temp Directory used for all banIP related runtime operations."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Blacklist Timeout"
 msgstr ""
 
@@ -185,39 +185,39 @@ msgstr ""
 msgid "Count SUM"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:767
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:771
 msgid "Countries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "DST Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "DST Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "Default chain used by banIP is 'forwarding_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "Default chain used by banIP is 'forwarding_wan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "Default chain used by banIP is 'input_lan_rule'"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "Default chain used by banIP is 'input_wan_rule'"
 msgstr ""
 
@@ -227,39 +227,39 @@ msgid ""
 "automatically."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Download Parameters"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Download Queue"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "Download Utility"
 msgstr "下載工具"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "E-Mail Actions"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid "E-Mail Notification"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "E-Mail Topic"
 msgstr ""
 
@@ -290,7 +290,7 @@ msgstr ""
 msgid "Enable the banIP service."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Existing job(s)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:796
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:800
 msgid "Extra Sources"
 msgstr ""
 
@@ -322,7 +322,7 @@ msgstr ""
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid "Global IPSet Type"
 msgstr ""
 
@@ -330,11 +330,11 @@ msgstr ""
 msgid "Grant access to LuCI app banIP"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:409
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:413
 msgid "High Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:408
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
 msgid "Highest Priority"
 msgstr ""
 
@@ -371,13 +371,13 @@ msgstr "支援 IPv6"
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:580
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:628
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:584
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:632
 msgid "LAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:569
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:617
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:573
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:621
 msgid "LAN Input"
 msgstr ""
 
@@ -385,23 +385,23 @@ msgstr ""
 msgid "Last Run"
 msgstr "最後執行"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:412
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
 msgid "Least Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:411
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:415
 msgid "Less Priority"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:730
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:734
 msgid "Limit E-Mail trigger to certain banIP actions."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Limit the log monitor to certain log terms."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Limit the selection to certain local sources."
 msgstr ""
 
@@ -413,15 +413,15 @@ msgstr "要移除的行號"
 msgid "List of available network interfaces to trigger the banIP start."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:789
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Log Limit"
 msgstr ""
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Log Monitor"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:675
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:679
 msgid "Log Terms"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgid ""
 "cause an increase in latency due to it requiring additional system resources."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid "LuCI Log Count"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Maclist Timeout"
 msgstr ""
 
@@ -462,7 +462,7 @@ msgid ""
 "effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid "NGINX Log Count"
 msgstr ""
 
@@ -482,7 +482,7 @@ msgstr ""
 msgid "No banIP related logs yet!"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:414
 msgid "Normal Priority (default)"
 msgstr ""
 
@@ -510,18 +510,18 @@ msgstr ""
 msgid "Number of all entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:688
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:692
 msgid ""
 "Number of failed LuCI login repetitions of the same ip in the log before "
 "banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:693
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:697
 msgid ""
 "Number of failed nginx requests of the same ip in the log before banning."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid ""
 "Number of failed ssh login repetitions of the same ip in the log before "
 "banning."
@@ -532,11 +532,11 @@ msgstr ""
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:668
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:672
 msgid "Parse only the last stated number of log entries for suspicious events."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:729
 msgid "Profile used by 'msmtp' for banIP notification E-Mails."
 msgstr ""
 
@@ -544,7 +544,7 @@ msgstr ""
 msgid "Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:399
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
@@ -565,13 +565,19 @@ msgstr ""
 msgid "Remove an existing job"
 msgstr "移除一個現存工作"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Report Directory"
 msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:331
 msgid "Restart"
 msgstr "重新啟動"
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid ""
+"Restrict the internet access from/to a small number of secure websites/IPs "
+"and block access from/to the rest of the internet."
+msgstr ""
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -585,23 +591,23 @@ msgstr ""
 msgid "Run Information"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "SRC IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "SRC Log Options"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "SRC Target"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid "SRC+DST IPSet Type"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:683
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:687
 msgid "SSH Log Count"
 msgstr ""
 
@@ -620,17 +626,17 @@ msgstr ""
 msgid "Select the relevant network interfaces manually."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:395
 msgid ""
 "Send banIP related notification e-mails. This needs the installation and "
 "setup of the additional 'msmtp' package."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:717
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
 msgid "Sender address for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid "Service Priority"
 msgstr ""
 
@@ -638,50 +644,50 @@ msgstr ""
 msgid "Set a new banIP job"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:525
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:529
 msgid "Set individual DST type per IPset to block only outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:513
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:517
 msgid "Set individual SRC type per IPset to block only incoming packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:537
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:541
 msgid ""
 "Set individual SRC+DST type per IPset to block incoming and outgoing packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:706
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:710
 msgid "Set special DST log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:698
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:702
 msgid "Set special SRC log options, e.g. to set a limit rate."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:499
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:503
 msgid "Set the blacklist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:472
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:476
 msgid "Set the firewall target for all DST related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:467
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:471
 msgid "Set the firewall target for all SRC related rules."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:461
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:465
 msgid ""
 "Set the global IPset type default, to block incoming (SRC) and/or outgoing "
 "(DST) packets."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:481
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:485
 msgid "Set the maclist IPSet timeout."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Set the whitelist IPSet timeout."
 msgstr ""
 
@@ -689,15 +695,15 @@ msgstr ""
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:421
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:425
 msgid "Size of the download queue for download processing in parallel."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:744
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:748
 msgid "Sources (Info)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:451
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:455
 msgid "Special config options for the selected download utility."
 msgstr ""
 
@@ -719,11 +725,11 @@ msgstr ""
 msgid "Suspend"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:443
 msgid "Target directory for IPSet related report files."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:435
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:439
 msgid "Target directory for compressed source list backups."
 msgstr ""
 
@@ -749,7 +755,7 @@ msgstr ""
 msgid "The minutes portion (opt., range: 0-59)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:406
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:410
 msgid ""
 "The selected priority will be used for banIP background processing. This "
 "change requires a full banIP service restart to take effect."
@@ -798,11 +804,11 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:721
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:725
 msgid "Topic for banIP notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:416
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:420
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
@@ -816,17 +822,17 @@ msgstr ""
 msgid "Unable to save changes: %s"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:403
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:407
 msgid "Verbose Debug Logging"
 msgstr "詳細除錯日誌"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:602
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:650
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:606
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:654
 msgid "WAN Forward"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:591
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:639
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:595
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:643
 msgid "WAN Input"
 msgstr ""
 
@@ -834,7 +840,11 @@ msgstr ""
 msgid "Whitelist IP/CIDR"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:490
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:391
+msgid "Whitelist Only"
+msgstr ""
+
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:494
 msgid "Whitelist Timeout"
 msgstr ""
 


### PR DESCRIPTION
* support the new 'Whitelist Only' mode
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>