### PR TITLE
luci-mod-network: do not remove enable_vlan from config

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js
@@ -180,8 +180,10 @@ return view.extend({
 			s = m.section(form.NamedSection, sid, 'switch', switch_title);
 			s.addremove = false;
 
-			if (feat.vlan_option)
-				s.option(form.Flag, feat.vlan_option, _('Enable VLAN functionality'));
+			if (feat.vlan_option) {
+				o = s.option(form.Flag, feat.vlan_option, _('Enable VLAN functionality'));
+				o.rmempty = false;
+			}
 
 			if (feat.learning_option) {
 				o = s.option(form.Flag, feat.learning_option, _('Enable learning and aging'));


### PR DESCRIPTION
There are many switch drivers where VLAN functionality is enabled by default.
In this situation, LuCI cannot be used to disable VLAN functionality,
because removing the line from configuration results in VLAN remaining enabled
by the driver.

When enable_vlan is set to 0 by default
by using functions in board.d,
and an unrelated change is made on the Switch webpage,
then the enable_vlan option gets deleted when changes are saved.

Therefore, the option needs to be preserved, whether set to 0 or 1.

Signed-off-by: Michael Pratt <mcpratt@pm.me>