### PR TITLE
luci-app-statistics: fix broken apcups support

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/apcups.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/apcups.js
@@ -11,7 +11,7 @@ return baseclass.extend({
 
 		o = s.option(form.Flag, 'enable', _('Enable this plugin'));
 
-		o = s.option(form.DynamicList, 'Host', _('Monitor host'));
+		o = s.option(form.Value, 'Host', _('Monitor host'));
 		o.default = 'localhost';
 		o.datatype = 'host';
 		o.depends('enable', '1');
@@ -23,11 +23,6 @@ return baseclass.extend({
 	},
 
 	configSummary: function(section) {
-		var hosts = L.toArray(section.Host);
-		if (hosts.length)
-			return N_(hosts.length,
-				'Monitoring APC UPS at host %s, port %d',
-				'Monitoring APC UPS at hosts %s, port %d'
-			).format(hosts.join(', '), section.Port || 3551);
+		return 'Monitoring APC UPS at host %s, port %d'.format(section.Host || 'localhost', section.Port || 3551);
 	}
 });


### PR DESCRIPTION
### Description:
A previous commit arbitrarily changed the apcups parameter "Host" into a list, and broke collectd config generation by /usr/bin/stat-genconfig:
```
  /usr/bin/lua: /usr/bin/stat-genconfig:254: attempt to call method  'find' (a nil value) stack traceback:
        /usr/bin/stat-genconfig:254: in function '_string'
        /usr/bin/stat-genconfig:74: in function 'config_generic'
        /usr/bin/stat-genconfig:45: in function 'section'
        /usr/bin/stat-genconfig:321: in main chunk
        [C]: ?
```
Restore "Host" to be a simple option.

Fixes: e7d22dce50b4 ("luci-app-statistics: convert collectd configuration
to client side views")
Reported-by: Gabe Rodriguez <lifehacksback@gmail.com>
Signed-off-by: Tony Ambardar <itugrok@yahoo.com>

### Testing:
Tested on a recent 21.02 snapshot, using EA6350v3/ipq4019, live patching the changed file.

### Distribution:

@thagabe reported the problem on IRC.
Config generation for collectd was broken in e7d22dce50b4 by @jow- .

**_This PR needs application to both **master** and **21.02** branches. Maintainers, please tag appropriately._**
