### PR TITLE
luci-app-https-dns-proxy: add IPv6 addresses for cz.nic odvr

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua
@@ -2,5 +2,5 @@ return {
 	name = "odvr-nic-cz",
 	label = _("ODVR (nic.cz)"),
 	resolver_url = "https://odvr.nic.cz/doh",
-	bootstrap_dns = "193.17.47.1,185.43.135.1"
+	bootstrap_dns = "193.17.47.1,185.43.135.1,2001:148f:ffff::1,2001:148f:fffe::1"
 }


### PR DESCRIPTION
This PR adds IPv6 addresses for CZ.NIC ODVR.
It is based on info from https://www.nic.cz/odvr/

cc @stangri