### PR TITLE
luci-base: rename Dismiss button to Close in UCI-apply changes overview

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4063,7 +4063,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 						E('button', {
 							'class': 'btn',
 							'click': UI.prototype.hideModal
-						}, [ _('Dismiss') ]), ' ',
+						}, [ _('Close') ]), ' ',
 						E('button', {
 							'class': 'cbi-button cbi-button-positive important',
 							'click': L.bind(this.apply, this, true)


### PR DESCRIPTION
Change the ~german translation for "Dismiss" to "Abbrechen"~  "Dismiss" button to "Close" to differentiate with "Revert". Currently both are translated to "Verwerfen". This is confusing at least in the uci-apply dialog, which shows "Verwerfen" - "Speichern & Anwenden" - "Verwerfen".

![Screenshot_20210501_003914](https://user-images.githubusercontent.com/1755362/116762308-49440c00-aa1a-11eb-86e6-1ba4fee3b93c.png)
