### PR TITLE
luci-app-banip: switch IP query provider

### DIFF
--- a/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js
+++ b/applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js
@@ -142,8 +142,7 @@ return view.extend({
 				]);
 				for (var i = 0; i < content.ipsets[key].member_acc.length; i++) {
 					if (key != 'maclist' && key.substr(0,9) != 'whitelist') {
-						urlprefix = content.ipsets[key].member_acc[i].member.includes('/') ? 'prefix/' : 'ip/';
-						member = '<a href="https://api.bgpview.io/' + urlprefix + encodeURIComponent(content.ipsets[key].member_acc[i].member) + '" target="_blank" rel="noreferrer noopener" title="IP/CIDR Lookup" >' + content.ipsets[key].member_acc[i].member + '</a>';
+						member = '<a href="https://ipwhois.app/json/' + encodeURIComponent(content.ipsets[key].member_acc[i].member) + '" target="_blank" rel="noreferrer noopener" title="IP/CIDR Lookup" >' + content.ipsets[key].member_acc[i].member + '</a>';
 						button = E('button', {
 							'class': 'btn cbi-button cbi-button-apply',
 							'style': 'word-break: inherit',

--- a/applications/luci-app-banip/po/ar/banip.po
+++ b/applications/luci-app-banip/po/ar/banip.po
@@ -347,7 +347,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -487,27 +487,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr "استعلام"
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "نعش الذاكرة"
@@ -790,13 +790,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -857,7 +857,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "القائمة البيضاء ..."
 

--- a/applications/luci-app-banip/po/bg/banip.po
+++ b/applications/luci-app-banip/po/bg/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/bn_BD/banip.po
+++ b/applications/luci-app-banip/po/bn_BD/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/ca/banip.po
+++ b/applications/luci-app-banip/po/ca/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr "Consulta"
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Actualitza"
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/cs/banip.po
+++ b/applications/luci-app-banip/po/cs/banip.po
@@ -346,7 +346,7 @@ msgstr "Informace o IPSet"
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Aktualizovat"
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/de/banip.po
+++ b/applications/luci-app-banip/po/de/banip.po
@@ -363,7 +363,7 @@ msgstr "IPSet-Information"
 msgid "IPSet Query"
 msgstr "IPSet Suche"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr "IPSet Suche..."
 
@@ -372,7 +372,7 @@ msgstr "IPSet Suche..."
 msgid "IPSet Report"
 msgstr "IPSet Report"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr "IPSet Details"
 
@@ -505,27 +505,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr "Abfrage"
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Aktualisieren"
@@ -808,13 +808,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -875,7 +875,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "Positivliste..."
 

--- a/applications/luci-app-banip/po/el/banip.po
+++ b/applications/luci-app-banip/po/el/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/en/banip.po
+++ b/applications/luci-app-banip/po/en/banip.po
@@ -340,7 +340,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -349,7 +349,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -480,27 +480,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -782,13 +782,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -849,7 +849,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/es/banip.po
+++ b/applications/luci-app-banip/po/es/banip.po
@@ -369,7 +369,7 @@ msgstr "Información de IPSet"
 msgid "IPSet Query"
 msgstr "Consulta IPSet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr "Consulta IPSet..."
 
@@ -378,7 +378,7 @@ msgstr "Consulta IPSet..."
 msgid "IPSet Report"
 msgstr "Informe IPSet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr "Detalles del IPSet"
 
@@ -517,27 +517,27 @@ msgstr "¡Aún no hay registros relacionados con banIP!"
 msgid "Normal Priority (default)"
 msgstr "Prioridad normal (predeterminado)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr "Número de entradas CIDR"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr "Número de entradas de IP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr "Número de entradas MAC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr "Número de entradas accedidas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr "Número de todos los IPSets"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr "Número de todas las entradas"
 
@@ -590,7 +590,7 @@ msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 "Dirección del receptor de los correos electrónicos de notificación de banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Refrescar"
@@ -878,7 +878,7 @@ msgstr ""
 "comentarios introducidos con '#' están permitidos; los comodines y las "
 "expresiones regulares no."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
@@ -886,7 +886,7 @@ msgstr ""
 "Esta pestaña muestra el último informe IPSet generado, presione el botón "
 "'Actualizar' para obtener uno actual."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr "Marca de tiempo"
 
@@ -951,7 +951,7 @@ msgstr ""
 "Se han guardado los cambios de la lista blanca. Actualice sus listas de "
 "banIP para que los cambios surtan efecto."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "Lista blanca..."
 

--- a/applications/luci-app-banip/po/fi/banip.po
+++ b/applications/luci-app-banip/po/fi/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Päivitä"
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/fr/banip.po
+++ b/applications/luci-app-banip/po/fr/banip.po
@@ -350,7 +350,7 @@ msgstr "Informations IPSet"
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -359,7 +359,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -420,8 +420,8 @@ msgstr ""
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:447
 msgid "List of supported and fully pre-configured download utilities."
 msgstr ""
-"Liste des utilitaires de téléchargement pris en charge et entièrement "
-"pré-configurés."
+"Liste des utilitaires de téléchargement pris en charge et entièrement pré-"
+"configurés."
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:793
 msgid "Local Sources"
@@ -492,27 +492,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -554,7 +554,7 @@ msgstr "Requête"
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Actualiser"
@@ -798,13 +798,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "Liste Blanche..."
 

--- a/applications/luci-app-banip/po/he/banip.po
+++ b/applications/luci-app-banip/po/he/banip.po
@@ -347,7 +347,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -487,27 +487,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -789,13 +789,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/hi/banip.po
+++ b/applications/luci-app-banip/po/hi/banip.po
@@ -340,7 +340,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -349,7 +349,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -480,27 +480,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -782,13 +782,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -849,7 +849,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/hu/banip.po
+++ b/applications/luci-app-banip/po/hu/banip.po
@@ -348,7 +348,7 @@ msgstr "IPSet információk"
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -357,7 +357,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -488,27 +488,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Frissítés"
@@ -792,13 +792,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -859,7 +859,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/it/banip.po
+++ b/applications/luci-app-banip/po/it/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Ricaricare"
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/ja/banip.po
+++ b/applications/luci-app-banip/po/ja/banip.po
@@ -346,7 +346,7 @@ msgstr "IPSet 情報"
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr "IPSet 詳細"
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr "通常の優先度 (デフォルト)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr "CIDR エントリ 数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr "IP エントリ 数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr "MAC エントリ 数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr "アクセスされたエントリ数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr "全エントリ数"
 
@@ -548,7 +548,7 @@ msgstr "検索"
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "リフレッシュ"
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr "タイムスタンプ"
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "ホワイトリスト..."
 

--- a/applications/luci-app-banip/po/ko/banip.po
+++ b/applications/luci-app-banip/po/ko/banip.po
@@ -347,7 +347,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -487,27 +487,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -789,13 +789,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/mr/banip.po
+++ b/applications/luci-app-banip/po/mr/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/ms/banip.po
+++ b/applications/luci-app-banip/po/ms/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/nb_NO/banip.po
+++ b/applications/luci-app-banip/po/nb_NO/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr "Spørring"
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Gjenoppfrisk"
@@ -789,13 +789,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "Hvitliste …"
 

--- a/applications/luci-app-banip/po/nl/banip.po
+++ b/applications/luci-app-banip/po/nl/banip.po
@@ -348,7 +348,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -357,7 +357,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -488,27 +488,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -790,13 +790,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -857,7 +857,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/pl/banip.po
+++ b/applications/luci-app-banip/po/pl/banip.po
@@ -366,7 +366,7 @@ msgstr "Informacje IPSet"
 msgid "IPSet Query"
 msgstr "Zapytanie IPSet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr "Zapytanie IPSet ..."
 
@@ -375,7 +375,7 @@ msgstr "Zapytanie IPSet ..."
 msgid "IPSet Report"
 msgstr "Raport IPSet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr "Szczegóły IPSet"
 
@@ -513,27 +513,27 @@ msgstr "Brak dzienników związanych z banIP!"
 msgid "Normal Priority (default)"
 msgstr "Normalny priorytet (domyślny)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr "Liczba wpisów CIDR"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr "Liczba wpisów IP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr "Liczba wpisów MAC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr "Liczba wpisów, do które uzyskały dostęp"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr "Liczba wszystkich zestawów IP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr "Liczba wszystkich wpisów"
 
@@ -583,7 +583,7 @@ msgstr "Zapytanie"
 msgid "Receiver address for banIP notification e-mails."
 msgstr "Adres odbiorcy wiadomości e-mail z powiadomieniem BanIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Odśwież"
@@ -856,7 +856,7 @@ msgstr ""
 "IPv6 lub nazwę domeny na wiersz. Komentarze wprowadzone z \"#\" są dozwolone "
 "- symbole wieloznaczne i wyrażenia regularnego nie są."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
@@ -864,7 +864,7 @@ msgstr ""
 "Ta zakładka pokazuje ostatni wygenerowany raport IPSet, naciśnij przycisk "
 "'Odśwież', aby uzyskać aktualny raport."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr "Sygnatura czasowa"
 
@@ -929,7 +929,7 @@ msgstr ""
 "Zmiany na białej liście zostały zapisane. Odśwież listę banIP, aby zmiany "
 "zostały wprowadzone."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "Biała lista ..."
 

--- a/applications/luci-app-banip/po/pt/banip.po
+++ b/applications/luci-app-banip/po/pt/banip.po
@@ -356,7 +356,7 @@ msgstr "Informações IPSet"
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -365,7 +365,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -498,27 +498,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -560,7 +560,7 @@ msgstr "Consulta"
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Atualizar"
@@ -803,13 +803,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -870,7 +870,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 

--- a/applications/luci-app-banip/po/pt_BR/banip.po
+++ b/applications/luci-app-banip/po/pt_BR/banip.po
@@ -366,7 +366,7 @@ msgstr "Informações IPSet"
 msgid "IPSet Query"
 msgstr "Consulta IPSet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr "Consulta IPSet..."
 
@@ -375,7 +375,7 @@ msgstr "Consulta IPSet..."
 msgid "IPSet Report"
 msgstr "Relatório IPSet"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr "Detalhes do IPSet"
 
@@ -512,27 +512,27 @@ msgstr "Ainda não há nenhum registro relacionado ao banIP!"
 msgid "Normal Priority (default)"
 msgstr "Prioridade Normal (padrão)"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr "A quantidade das entradas CIDR"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr "A quantidade das entradas IP"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr "A quantidade das entradas MAC"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr "A quantidade das entradas que foram acessadas"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr "A quantidade de todos os IPSets"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr "A quantidade de todas as entradas"
 
@@ -582,7 +582,7 @@ msgstr "Consulta"
 msgid "Receiver address for banIP notification e-mails."
 msgstr "O endereço do destinatário para os e-mails de notificação do banIP."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Atualizar"
@@ -862,7 +862,7 @@ msgstr ""
 "endereço IPv4, endereço IPv6 ou nome de domínio por linha. Comentários "
 "iniciados com '#' são permitidos - curingas e regex não."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
@@ -870,7 +870,7 @@ msgstr ""
 "Esta aba mostra o último Relatório gerado do Conjunto de IPs, pressione o "
 "botão 'Atualizar' para obter o atual."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr "Marca de Tempo"
 
@@ -935,7 +935,7 @@ msgstr ""
 "As alterações da lista branca foram salvas. Atualize a sua lista BanIP para "
 "que as alterações surtam efeito."
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 

--- a/applications/luci-app-banip/po/ro/banip.po
+++ b/applications/luci-app-banip/po/ro/banip.po
@@ -349,7 +349,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -358,7 +358,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -489,27 +489,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Reîmprospătare"
@@ -791,13 +791,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/ru/banip.po
+++ b/applications/luci-app-banip/po/ru/banip.po
@@ -347,7 +347,7 @@ msgstr "Информация об IPSet"
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -488,27 +488,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr "Запрос"
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Обновить"
@@ -790,13 +790,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -857,7 +857,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "Белый список..."
 

--- a/applications/luci-app-banip/po/sk/banip.po
+++ b/applications/luci-app-banip/po/sk/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/sv/banip.po
+++ b/applications/luci-app-banip/po/sv/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Uppdatera"
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/templates/banip.pot
+++ b/applications/luci-app-banip/po/templates/banip.pot
@@ -337,7 +337,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -477,27 +477,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -539,7 +539,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -779,13 +779,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -846,7 +846,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/tr/banip.po
+++ b/applications/luci-app-banip/po/tr/banip.po
@@ -348,7 +348,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -357,7 +357,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -488,27 +488,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Yenile"
@@ -790,13 +790,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -857,7 +857,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/uk/banip.po
+++ b/applications/luci-app-banip/po/uk/banip.po
@@ -347,7 +347,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -356,7 +356,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -487,27 +487,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "Оновити"
@@ -789,13 +789,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/vi/banip.po
+++ b/applications/luci-app-banip/po/vi/banip.po
@@ -346,7 +346,7 @@ msgstr ""
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr ""
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -856,7 +856,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 

--- a/applications/luci-app-banip/po/zh_Hans/banip.po
+++ b/applications/luci-app-banip/po/zh_Hans/banip.po
@@ -349,7 +349,7 @@ msgstr "IPSet 信息"
 msgid "IPSet Query"
 msgstr "IPSet 查询"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr "IPSet 查询..."
 
@@ -358,7 +358,7 @@ msgstr "IPSet 查询..."
 msgid "IPSet Report"
 msgstr "IPSet 报告"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr "IPSet 详情"
 
@@ -491,27 +491,27 @@ msgstr "尚无 banIP 相关的日志！"
 msgid "Normal Priority (default)"
 msgstr "正常优先级（默认）"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr "CIDR 条目数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr "IP 条目数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr "MAC 条目数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr "访问的条目数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr "全部 IPSet 条目数"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr "全部条目数"
 
@@ -553,7 +553,7 @@ msgstr "查询"
 msgid "Receiver address for banIP notification e-mails."
 msgstr "banIP 通知电子邮件的接收者地址。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "刷新"
@@ -582,7 +582,8 @@ msgstr "重启"
 msgid ""
 "Restrict the internet access from/to a small number of secure websites/IPs "
 "and block access from/to the rest of the internet."
-msgstr "限制来自/到少数安全网站/IP的互联网访问，拦截来自/到互联网其余部分的访问。"
+msgstr ""
+"限制来自/到少数安全网站/IP的互联网访问，拦截来自/到互联网其余部分的访问。"
 
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:60
 msgid "Result"
@@ -804,13 +805,13 @@ msgstr ""
 "</b></em>每行仅添加一个 IPv4 地址、IPv6 地址或域名。注释以“＃”开头。不允许使"
 "用通配符和正则表达式。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr "该选项卡显示了上一次生成的 IPSet 报告，点击“刷新”按钮可获得当前报告。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr "时间戳"
 
@@ -871,7 +872,7 @@ msgid ""
 "take effect."
 msgstr "白名单更改已经保存。刷新您的 banIP 列表以使更改生效。"
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr "白名单..."
 

--- a/applications/luci-app-banip/po/zh_Hant/banip.po
+++ b/applications/luci-app-banip/po/zh_Hant/banip.po
@@ -346,7 +346,7 @@ msgstr "IPSet信息"
 msgid "IPSet Query"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:213
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:212
 msgid "IPSet Query..."
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "IPSet Report"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:236
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:235
 msgid "IPSet details"
 msgstr ""
 
@@ -486,27 +486,27 @@ msgstr ""
 msgid "Normal Priority (default)"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:196
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:195
 msgid "Number of CIDR entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:192
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:191
 msgid "Number of IP entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:200
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:199
 msgid "Number of MAC entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:204
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:203
 msgid "Number of accessed entries"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:184
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:183
 msgid "Number of all IPSets"
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:188
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:187
 msgid "Number of all entries"
 msgstr ""
 
@@ -548,7 +548,7 @@ msgstr ""
 msgid "Receiver address for banIP notification e-mails."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:230
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:229
 #: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/overview.js:324
 msgid "Refresh"
 msgstr "重新整理"
@@ -788,13 +788,13 @@ msgid ""
 "wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:177
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:176
 msgid ""
 "This tab shows the last generated IPSet Report, press the 'Refresh' button "
 "to get a current one."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:180
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:179
 msgid "Timestamp"
 msgstr ""
 
@@ -855,7 +855,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:153
+#: applications/luci-app-banip/htdocs/luci-static/resources/view/banip/ipsetreport.js:152
 msgid "Whitelist..."
 msgstr ""
 


### PR DESCRIPTION
* switch to IPWHOIS.IO for IP report queries, the IP geolocation API is
  more accurate & faster

Signed-off-by: Dirk Brenken <dev@brenken.org>