### PR TITLE
luci-app-mwan3: update status page for no tracked interfaces

### DIFF
--- a/applications/luci-app-mwan3/luasrc/view/mwan/overview_status_interface.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/overview_status_interface.htm
@@ -99,7 +99,7 @@ XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "interface
 		display: inline-block;
 		margin: 1rem;
 		padding: 1rem;
-		width: 10rem;
+		width: 15rem;
 		float: left;
 		line-height: 125%;
 	}

--- a/applications/luci-app-mwan3/luasrc/view/mwan/overview_status_interface.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/overview_status_interface.htm
@@ -46,6 +46,20 @@ XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "interface
 							);
 							css = 'danger';
 							break;
+						case 'notracking':
+							state = '<%:No Tracking%>';
+							if ((status.interfaces[iface].uptime) > 0) {
+								time = String.format(
+									'<div><strong>Uptime:&nbsp;</strong>%s</div>',
+									secondsToString(status.interfaces[iface].uptime)
+								);
+								css = 'success';
+							}
+							else {
+								time = '<div>&nbsp;</div>'
+								css = 'warning';
+							}
+							break;
 						default:
 							state = '<%:Disabled%>';
 							time = '<div>&nbsp;</div>'

--- a/applications/luci-app-mwan3/luasrc/view/mwan/overview_status_interface.htm
+++ b/applications/luci-app-mwan3/luasrc/view/mwan/overview_status_interface.htm
@@ -33,7 +33,7 @@ XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "interface
 						case 'online':
 							state = '<%:Online%>';
 							time = String.format(
-								'<div><strong>Uptime:&nbsp;</strong>%s</div>',
+								'<div><strong><%:Uptime%>:&nbsp;</strong>%s</div>',
 								secondsToString(status.interfaces[iface].online)
 							);
 							css = 'success';
@@ -41,7 +41,7 @@ XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "interface
 						case 'offline':
 							state = '<%:Offline%>';
 							time = String.format(
-								'<div><strong>Downtime:&nbsp;</strong>%s</div>',
+								'<div><strong><%:Downtime%>:&nbsp;</strong>%s</div>',
 								secondsToString(status.interfaces[iface].offline)
 							);
 							css = 'danger';
@@ -50,7 +50,7 @@ XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "interface
 							state = '<%:No Tracking%>';
 							if ((status.interfaces[iface].uptime) > 0) {
 								time = String.format(
-									'<div><strong>Uptime:&nbsp;</strong>%s</div>',
+									'<div><strong><%:Uptime%>:&nbsp;</strong>%s</div>',
 									secondsToString(status.interfaces[iface].uptime)
 								);
 								css = 'success';
@@ -71,11 +71,11 @@ XHR.poll(-1, '<%=luci.dispatcher.build_url("admin", "status", "mwan", "interface
 						css
 					);
 					statusview += String.format(
-						'<div><strong>Interface:&nbsp;</strong>%s</div>',
+						'<div><strong><%:Interface%>:&nbsp;</strong>%s</div>',
 						iface
 					);
 					statusview += String.format(
-						'<div><strong>Status:&nbsp;</strong>%s</div>',
+						'<div><strong><%:Status%>:&nbsp;</strong>%s</div>',
 						state
 					);
 					if (time)


### PR DESCRIPTION
This is a followup pullrequest to show the correct status information if tracking is disabled for an mwan3 interface.