### PR TITLE
luci-mod-status: check if center_chan1 is defined

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -196,7 +196,7 @@ return view.extend({
 
 			scanCache[local_wifi.bssid].data = local_wifi;
 
-			if (chan_analysis.offset_tbl[local_wifi.channel] != null) {
+			if (chan_analysis.offset_tbl[local_wifi.channel] != null && local_wifi.center_chan1) {
 				var center_channels = [local_wifi.center_chan1],
 				    chan_width_text = local_wifi.htmode.replace(/(V)*HT/,''),
 				    chan_width = parseInt(chan_width_text)/10;


### PR DESCRIPTION
While using channel analysis I noticed an exception. It turned out that center_chan1 is not returned in scan results for a "local_wifi" I use dual band card Compex WLE900VX. This causes that channels chart is not generated. 
Fix it by checking if center_chan1 is  defined. 

![exc](https://user-images.githubusercontent.com/4362399/117154624-5404f500-adbc-11eb-84be-0e1fe300f975.png)
