### PR TITLE
luci-app-ddns: fix time error

### DIFF
--- a/applications/luci-app-ddns/root/usr/libexec/rpcd/luci.ddns
+++ b/applications/luci-app-ddns/root/usr/libexec/rpcd/luci.ddns
@@ -120,7 +120,7 @@ local methods = {
 					next_update = epoch2date(epoch + force_seconds + check_seconds)
 				end
 
-				if pid > 0 and ( last_update + force_seconds - uptime ) <= 0 then
+				if pid > 0 and ( last_update + force_seconds + check_seconds - uptime ) <= 0 then
 					next_update = "Verify"
 
 				-- run once

--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -614,17 +614,17 @@ String.prototype.format = function()
 						var tm = 0;
 						var ts = (param || 0);
 
-						if (ts > 60) {
+						if (ts > 59) {
 							tm = Math.floor(ts / 60);
 							ts = (ts % 60);
 						}
 
-						if (tm > 60) {
+						if (tm > 59) {
 							th = Math.floor(tm / 60);
 							tm = (tm % 60);
 						}
 
-						if (th > 24) {
+						if (th > 23) {
 							td = Math.floor(th / 24);
 							th = (th % 24);
 						}


### PR DESCRIPTION
luci-app-ddns:Fix the error that next_update sometimes display Verify

Fix time display error like this:
![1](https://user-images.githubusercontent.com/61473216/119333137-1bba4d80-bcbc-11eb-8d6a-a2cd664061de.png)

Running time should display 1h 0m 36s instead of 0h 60m 36s