### PR TITLE
luci-app-statistics: fix read of hostname

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/collectd.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/collectd.js
@@ -52,7 +52,7 @@ return view.extend({
 		o.load = function() {
 			return fs.trimmed('/proc/sys/kernel/hostname').then(L.bind(function(name) {
 				this.placeholder = name;
-				return uci.get('collectd', 'statistics', 'hostname');
+				return uci.get('luci_statistics', 'collectd', 'Hostname');
 			}, this));
 		};
 


### PR DESCRIPTION
Existing javascript did not read a non-default statistics hostname due to
incorrect config ids.

Signed-off-by: Anderson McKinley coyoso@tuta.io