### PR TITLE
luci-app-advanced-reboot: add board config for Linksys EA7500-V1

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.0.1-1
+PKG_VERSION:=1.0.1-2
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea7500v1.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea7500v1.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "EA7500v1",
+	"boardNames": [ "linksys,ea7500-v1" ],
+	"partition1MTD": "mtd13",
+	"partition2MTD": "mtd15",
+	"labelOffset": 32,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
EA7500-v1 works the same as the other Linksys models except
the name is different. Verified with 21-02 and master.

Signed-off-by: David Adair <djabhead@aol.com>