### PR TITLE
luci-mod-network: hint that the network-upgrade might triggered multiple times

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -345,6 +345,7 @@ return view.extend({
 		ui.showModal(_('Network bridge configuration migration'), [
 			E('p', _('The existing network configuration needs to be changed for LuCI to function properly.')),
 			E('p', _('Upon pressing "Continue", bridges configuration will be updated and the network will be restarted to apply the updated configuration.')),
+			E('p', _('Depending on your current configuration this update will be triggered multiple times.')),
 			E('div', { 'class': 'right' },
 				E('button', {
 					'class': 'btn cbi-button-action important',
@@ -379,6 +380,7 @@ return view.extend({
 		ui.showModal(_('Network ifname configuration migration'), [
 			E('p', _('The existing network configuration needs to be changed for LuCI to function properly.')),
 			E('p', _('Upon pressing "Continue", ifname options will get renamed and the network will be restarted to apply the updated configuration.')),
+			E('p', _('Depending on your current configuration this update will be triggered multiple times.')),
 			E('div', { 'class': 'right' },
 				E('button', {
 					'class': 'btn cbi-button-action important',


### PR DESCRIPTION
Based on the 2-step migration of the bridge- and interface-configuration (e7c9c63c657963daa1a0d57dcb0848d88e909c25) add a
hint that the "Network configuration migration" might get triggered multiple
times. This will not confuse the user with some thought of endless loop.

