### PR TITLE
luci-mod-network: interfaces: restructure DHCPv6 and IPv6 RA options

### DIFF
--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -5,6 +5,8 @@
 			"cgi-io": [ "exec" ],
 			"file": {
 				"/etc/iproute2/rt_tables": [ "read" ],
+				"/proc/sys/net/ipv6/conf/*/mtu": [ "read" ],
+				"/proc/sys/net/ipv6/conf/*/hop_limit": [ "read" ],
 				"/usr/libexec/luci-peeraddr": [ "exec" ],
 				"/usr/lib/opkg/info/netifd.control": [ "read" ]
 			},


### PR DESCRIPTION
 - Condense overly large IPv6 RA/DHCPv6 description texts and get rid of most embedded markup

 - Switch ra/ndp/dhcpv6 mode selections to rich dropdown lists and move extended choice
   descriptions next to the selection options

 - Drop ndproxy_static option which has been removed from odhcpd long ago

 - Add format validations to all text input fields

 - Add ability to configure master/relay modes for non-static interfaces (#2998)

 - Move extended RA configuration options into a new tab

 - Prevent enabling master mode on multiple interfaces

 - Prevent enabling ra/dhcpv6 server mode on non-static or master interfaces

 - Drop ra_management in favor to ra_flags option (#5083)

 - Add support for dns_service option

Signed-off-by: Jo-Philipp Wich <jo@mein.io>