### PR TITLE
Allow full 32-bit mark fields to be specified

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -77,7 +77,7 @@ return network.registerProtocol('wireguard', {
 		o = s.taboption('advanced', form.Value, 'fwmark', _('Firewall Mark'), _('Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, starting with <code>0x</code>.'));
 		o.optional = true;
 		o.validate = function(section_id, value) {
-			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,4}$/))
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,8}$/))
 				return _('Invalid hexadecimal value');
 
 			return true;


### PR DESCRIPTION
From man iptables-extensions: MARK "The mark field is 32 bits wide."

This change allows a full 32 bit mark field to be specified