### PR TITLE
Fix fwmark validation to allow 32 bit values

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -97,7 +97,7 @@ return network.registerProtocol('wireguard', {
 		o = s.taboption('advanced', form.Value, 'fwmark', _('Firewall Mark'), _('Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, starting with <code>0x</code>.'));
 		o.optional = true;
 		o.validate = function(section_id, value) {
-			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,4}$/))
+			if (value.length > 0 && !value.match(/^0x[a-fA-F0-9]{1,8}$/))
 				return _('Invalid hexadecimal value');
 
 			return true;


### PR DESCRIPTION
The iptables mark field is 32 bits wide, which is 4 bytes and so 8 hex characters.  Fix the fwmark validation to allow 8 characters in the hex string.