### PR TITLE
luci.mk: don't run uci-defaults scripts ourself

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -206,8 +206,7 @@ endef
 
 ifndef Package/$(PKG_NAME)/postinst
 define Package/$(PKG_NAME)/postinst
-[ -n "$${IPKG_INSTROOT}" ] || {$(foreach script,$(LUCI_DEFAULTS),
-	(. /etc/uci-defaults/$(script)) && rm -f /etc/uci-defaults/$(script))
+[ -n "$${IPKG_INSTROOT}" ] || { \
 	rm -f /tmp/luci-indexcache
 	rm -rf /tmp/luci-modulecache/
 	killall -HUP rpcd 2>/dev/null


### PR DESCRIPTION
Do not run the uci-defaults scripts of a package in the package-postinst, but leave this for the default_postinst() of the OpenWrt base-files package.
Based on https://github.com/openwrt/luci/pull/1635#issuecomment-368266512 and a short test it worked as expected. 

Looks to me like this was added back in 2014 when OpenWrt did not start the uci-defaults automtically.