### PR TITLE
themes: Call striptags() on hostname to prevent XSS

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -41,7 +41,7 @@
 		<header>
 			<div class="fill">
 				<div class="container">
-					<a class="brand" href="/"><%=boardinfo.hostname or "?"%></a>
+					<a class="brand" href="/"><%=striptags(boardinfo.hostname or "?")%></a>
 					<ul class="nav" id="topmenu" style="display:none"></ul>
 					<div id="indicators" class="pull-right"></div>
 				</div>

--- a/themes/luci-theme-material/luasrc/view/themes/material/header.htm
+++ b/themes/luci-theme-material/luasrc/view/themes/material/header.htm
@@ -190,7 +190,7 @@
 		<div class="container">
 			<span class="showSide"></span>
 			<a id="logo" href="<% if luci.dispatcher.context.authsession then %><%=url('admin/status/overview')%><% else %>#<% end %>"><img src="<%=media%>/brand.png" alt="OpenWrt"></a>
-			<a class="brand" href="#"><%=boardinfo.hostname or "?"%></a>
+			<a class="brand" href="#"><%=striptags(boardinfo.hostname or "?")%></a>
 			<div class="status" id="indicators">
 				<span id="xhr_poll_status" style="display:none" onclick="XHR.running() ? XHR.halt() : XHR.run()">
 					<span class="label success" id="xhr_poll_status_on"><span class="mobile-hide"><%:Auto Refresh%></span> <%:on%></span>

--- a/themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm
+++ b/themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm
@@ -43,7 +43,7 @@
 <div id="menubar">
 	<h2 class="navigation"><a id="navigation" name="navigation"><%:Navigation%></a></h2>
 
-	<span class="hostname"><a href="/"><%=(boardinfo.hostname or "?")%></a></span>
+	<span class="hostname"><a href="/"><%=striptags(boardinfo.hostname or "?")%></a></span>
 	<span class="distversion"><%=ver.distversion%></span>
 	<span id="indicators"></span>
 </div>

--- a/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
+++ b/themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm
@@ -50,7 +50,7 @@
 <h2 class="navigation"><a id="navigation" name="navigation"><%:Navigation%></a></h2>
 
 <div class="hostinfo">
-	<%=(boardinfo.hostname or "?")%> | <%=ver.distversion%> |
+	<%=striptags(boardinfo.hostname or "?")%> | <%=ver.distversion%> |
 	<%:Load%>: <%="%.2f" % (loadinfo[1] / 65535.0)%> <%="%.2f" % (loadinfo[2] / 65535.0)%> <%="%.2f" % (loadinfo[3] / 65535.0)%>
 </div>
 


### PR DESCRIPTION
This calls striptags() on the hostname to prevent any XSS over the
hostname. This should fix CVE-2021-33425 as far as I understood it.

If someone adds some Javascript into `system.@system[0].hostname` it would
have been directly added to the page, this prevents the problem.

This can only be exploited by someone being able to modify the uci
configuration, normally a user with such privileges could also just
modify the webpage.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>