### PR TITLE
luci-proto-modemmanager: validate APN and PIN

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -98,7 +98,9 @@ return network.registerProtocol('modemmanager', {
                         
 	            return true; 
 		};
-		s.taboption('general', form.Value, 'pincode', _('PIN'));
+
+		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o.datatype = 'and(uinteger,maxlength(4))';
 
 		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));
 		o.value('both', _('PAP/CHAP (both)'));

--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -91,7 +91,13 @@ return network.registerProtocol('modemmanager', {
 			}, this));
 		};
 
-		s.taboption('general', form.Value, 'apn', _('APN'));
+		o = s.taboption('general', form.Value, 'apn', _('APN'));
+		o.validate = function(section_id, value) { 
+    		    if (!/^[a-zA-Z0-9\-.]*[a-zA-Z0-9]$/.test(value))
+                        return _('Invalid APN provided');
+                        
+	            return true; 
+		};
 		s.taboption('general', form.Value, 'pincode', _('PIN'));
 
 		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));


### PR DESCRIPTION
The APN is validated with a custom validator function instead of adding support to LuCI validation.js, as suggested.