### PR TITLE
Add validation to APN and PIN fields in luci-proto-3g, luci-proto-qmi, luci-proto-ncm and luci-proto-modemmanager

### DIFF
--- a/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
+++ b/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
@@ -92,7 +92,13 @@ return network.registerProtocol('3g', {
 		o.value('gprs_only', _('GPRS only'));
 		o.value('evdo', 'CDMA/EV-DO');
 
-		s.taboption('general', form.Value, 'apn', _('APN'));
+		o = s.taboption('general', form.Value, 'apn', _('APN'));
+		o.validate = function(section_id, value) { 
+    		    if (!/^[a-zA-Z0-9\-.]*[a-zA-Z0-9]$/.test(value))
+                        return _('Invalid APN provided');
+
+	            return true; 
+		};
 		s.taboption('general', form.Value, 'pincode', _('PIN'));
 		s.taboption('general', form.Value, 'username', _('PAP/CHAP username'));
 

--- a/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
+++ b/protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js
@@ -99,7 +99,9 @@ return network.registerProtocol('3g', {
 
 	            return true; 
 		};
-		s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o.datatype = 'and(uinteger,minlength(4),maxlength(8))';
+
 		s.taboption('general', form.Value, 'username', _('PAP/CHAP username'));
 
 		o = s.taboption('general', form.Value, 'password', _('PAP/CHAP password'));

--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -100,7 +100,7 @@ return network.registerProtocol('modemmanager', {
 		};
 
 		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
-		o.datatype = 'and(uinteger,maxlength(4))';
+		o.datatype = 'and(uinteger,minlength(4),maxlength(8))';
 
 		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));
 		o.value('both', _('PAP/CHAP (both)'));

--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -98,7 +98,9 @@ return network.registerProtocol('modemmanager', {
                         
 	            return true; 
 		};
-		s.taboption('general', form.Value, 'pincode', _('PIN'));
+
+		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o.datatype = 'and(uinteger,maxlength(4))';
 
 		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));
 		o.value('both', _('PAP/CHAP (both)'));

--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -91,7 +91,13 @@ return network.registerProtocol('modemmanager', {
 			}, this));
 		};
 
-		s.taboption('general', form.Value, 'apn', _('APN'));
+		o = s.taboption('general', form.Value, 'apn', _('APN'));
+		o.validate = function(section_id, value) { 
+    		    if (!/^[a-zA-Z0-9\-.]*[a-zA-Z0-9]$/.test(value))
+                        return _('Invalid APN provided');
+                        
+	            return true; 
+		};
 		s.taboption('general', form.Value, 'pincode', _('PIN'));
 
 		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));

--- a/protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js
+++ b/protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js
@@ -84,8 +84,15 @@ return network.registerProtocol('ncm', {
 		o.value('IPV4V6', _('IPv4+IPv6'));
 		o.value('IPV6', _('IPv6'));
 
-		s.taboption('general', form.Value, 'apn', _('APN'));
-		s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o = s.taboption('general', form.Value, 'apn', _('APN'));
+		o.validate = function(section_id, value) { 
+			if (!/^[a-zA-Z0-9\-.]*[a-zA-Z0-9]$/.test(value))
+					return _('Invalid APN provided');
+					
+			return true; 
+		};
+		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o.datatype = 'and(uinteger,maxlength(4))';
 		s.taboption('general', form.Value, 'username', _('PAP/CHAP username'));
 
 		o = s.taboption('general', form.Value, 'password', _('PAP/CHAP password'));

--- a/protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js
+++ b/protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js
@@ -92,7 +92,7 @@ return network.registerProtocol('ncm', {
 			return true; 
 		};
 		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
-		o.datatype = 'and(uinteger,maxlength(4))';
+		o.datatype = 'and(uinteger,minlength(4),maxlength(8))';
 		s.taboption('general', form.Value, 'username', _('PAP/CHAP username'));
 
 		o = s.taboption('general', form.Value, 'password', _('PAP/CHAP password'));

--- a/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
+++ b/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
@@ -72,7 +72,8 @@ return network.registerProtocol('qmi', {
 
 	            return true; 
 		};
-		s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
+		o.datatype = 'and(uinteger,minlength(4),maxlength(8))';
 
 		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));
 		o.value('both', 'PAP/CHAP');

--- a/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
+++ b/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
@@ -65,7 +65,13 @@ return network.registerProtocol('qmi', {
 			}, this));
 		};
 
-		s.taboption('general', form.Value, 'apn', _('APN'));
+		o = s.taboption('general', form.Value, 'apn', _('APN'));
+		o.validate = function(section_id, value) { 
+    		    if (!/^[a-zA-Z0-9\-.]*[a-zA-Z0-9]$/.test(value))
+                        return _('Invalid APN provided');
+
+	            return true; 
+		};
 		s.taboption('general', form.Value, 'pincode', _('PIN'));
 
 		o = s.taboption('general', form.ListValue, 'auth', _('Authentication Type'));


### PR DESCRIPTION
Validates APN fields in luci-proto-modemmanager, luci-proto-3g and luci-proto-qmi.  The APN is validated with a custom validator function instead of adding support to LuCI validation.js, as suggested.  While I'm at it I validated the PIN to a max of 4 digits for luci-proto-modemmanager.

The validation regex is based on [Chapter 9.1](https://www.etsi.org/deliver/etsi_ts/123000_123099/123003/08.08.00_60/ts_123003v080800p.pdf) of the 3GPP Spec, "Structure of APN" and the PIN length is based on [Chapter 5.2](https://www.etsi.org/deliver/etsi_ts/121100_121199/121111/08.00.01_60/ts_121111v080001p.pdf) "User Authentication".