### PR TITLE
luci-app-adblock: sync with adblock 4.1.3

### DIFF
--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js
@@ -412,7 +412,12 @@ return view.extend({
 		o.optional = true;
 		o.rmempty = true;
 
-		o = s.taboption('additional', form.Value, 'adb_fetchparm', _('Download Parameters'), _('Special config options for the selected download utility.'));
+		o = s.taboption('additional', form.Flag, 'adb_fetchinsecure', _('Download Insecure'), _('Don\'t check SSL server certificates during download.'));
+		o.default = 0
+		o.rmempty = true;
+
+		o = s.taboption('additional', form.Value, 'adb_fetchparm', _('Download Parameters'), _('Manually override the pre-configured download options for the selected download utility.'));
+		o.optional = true;
 		o.rmempty = true;
 
 		/*


### PR DESCRIPTION
* support the new 'adb_fetchinsecure' option

Signed-off-by: Dirk Brenken <dev@brenken.org>