### PR TITLE
luci-app-nlbwmon: fix url and clean up the ui buttons

### DIFF
--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/backup.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/backup.js
@@ -52,12 +52,14 @@ return view.extend({
 			E('h5', [ _('Restore Database Backup') ]),
 			E('p', [
 				E('button', {
+					'class': 'cbi-button',
 					'click': ui.createHandlerFn(this, 'handleArchiveUpload')
 				}, [ _('Restore') ])
 			]),
 			E('h5', [ _('Download Database Backup') ]),
 			E('p', [
 				E('button', {
+					'class': 'cbi-button',
 					'click': ui.createHandlerFn(this, 'handleArchiveDownload', hostname)
 				}, [ _('Generate Backup') ])
 			])

--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/config.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/config.js
@@ -73,7 +73,7 @@ return view.extend({
 		o.value('absolute', _('Fixed interval'));
 
 		o = s.taboption('general', form.DummyValue, '_warning', _('Warning'));
-		o.default = _('Changing the accounting interval type will invalidate existing databases!<br /><strong><a href="%s">Download backup</a></strong>.').format(L.url('admin/nlbw/backup'));
+		o.default = _('Changing the accounting interval type will invalidate existing databases!<br /><strong><a href="%s">Download backup</a></strong>.').format(L.url('admin/services/nlbw/backup'));
 		o.rawhtml = true;
 		if (/^[0-9]{4}-[0-9]{2}-[0-9]{2}\/[0-9]+$/.test(uci.get_first('nlbwmon', 'nlbwmon', 'database_interval')))
 			o.depends('_period', 'relative');

--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
@@ -945,30 +945,42 @@ return view.extend({
 				]),
 
 				E('div', { 'class': 'cbi-section', 'data-tab': 'export', 'data-tab-title': _('Export') }, [
-					E('ul', [
-						E('li', [
-							E('a', {
-								'href': '#',
-								'click': ui.createHandlerFn(this, 'handleDownload', 'csv', 'mac', '-rx,-tx')
-							}, [ _('CSV, grouped by MAC') ])
+					E('div', { 'class': 'cbi-section-node cbi-sction-node-tabbed' }, [
+						E('div', { 'class': 'cbi-value' }, [
+							E('label', { 'class': 'cbi-value-title' }, _('Grouped by MAC (CSV)')),
+							E('div', { 'class': 'cbi-value-field' }, [
+								E('button', {
+									'class': 'cbi-button',
+									'click': ui.createHandlerFn(this, 'handleDownload', 'csv', 'mac', '-rx,-tx')
+								}, [ _('Export') ])
+							])
 						]),
-						E('li', [
-							E('a', {
-								'href': '#',
-								'click': ui.createHandlerFn(this, 'handleDownload', 'csv', 'ip', '-rx,-tx')
-							}, [ _('CSV, grouped by IP') ])
+						E('div', { 'class': 'cbi-value' }, [
+							E('label', { 'class': 'cbi-value-title' }, _('Grouped by IP (CSV)')),
+							E('div', { 'class': 'cbi-value-field' }, [
+								E('button', {
+									'class': 'cbi-button',
+									'click': ui.createHandlerFn(this, 'handleDownload', 'csv', 'ip', '-rx,-tx')
+								}, [ _('Export') ])
+							])
 						]),
-						E('li', [
-							E('a', {
-								'href': '#',
-								'click': ui.createHandlerFn(this, 'handleDownload', 'csv', 'layer7', '-rx,-tx')
-							}, [ _('CSV, grouped by protocol') ])
+						E('div', { 'class': 'cbi-value' }, [
+							E('label', { 'class': 'cbi-value-title' }, _('Grouped by protocol (CSV)')),
+							E('div', { 'class': 'cbi-value-field' }, [
+								E('button', {
+									'class': 'cbi-button',
+									'click': ui.createHandlerFn(this, 'handleDownload', 'csv', 'layer7', '-rx,-tx')
+								}, [ _('Export') ])
+							])
 						]),
-						E('li', [
-							E('a', {
-								'href': '#',
-								'click': ui.createHandlerFn(this, 'handleDownload', 'json', null, null)
-							}, [ _('JSON dump') ])
+						E('div', { 'class': 'cbi-value' }, [
+							E('label', { 'class': 'cbi-value-title' }, _('Dump (JSON)')),
+							E('div', { 'class': 'cbi-value-field' }, [
+								E('button', {
+									'class': 'cbi-button',
+									'click': ui.createHandlerFn(this, 'handleDownload', 'json', null, null)
+								}, [ _('Export') ])
+							])
 						])
 					])
 				])

--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
@@ -361,8 +361,8 @@ return view.extend({
 
 		cbi_update_table('#host-data', rows, E('em', [
 			_('No data recorded yet.'), ' ',
-			E('a', {
-				'href': '#',
+			E('button', {
+				'class': 'cbi-button',
 				'click': ui.createHandlerFn(this, 'handleCommit')
 			}, _('Force reload…'))
 		]));
@@ -421,8 +421,8 @@ return view.extend({
 
 		cbi_update_table('#layer7-data', rows, E('em', [
 			_('No data recorded yet.'), ' ',
-			E('a', {
-				'href': '#',
+			E('button', {
+				'class': 'cbi-button',
 				'click': ui.createHandlerFn(this, 'handleCommit')
 			}, _('Force reload…'))
 		]));
@@ -528,8 +528,8 @@ return view.extend({
 
 		cbi_update_table('#ipv6-data', rows, E('em', [
 			_('No data recorded yet.'), ' ',
-			E('a', {
-				'href': '#',
+			E('button', {
+				'class': 'cbi-button',
 				'click': ui.createHandlerFn(this, 'handleCommit')
 			}, _('Force reload…'))
 		]));

--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
@@ -421,7 +421,10 @@ return view.extend({
 
 		cbi_update_table('#layer7-data', rows, E('em', [
 			_('No data recorded yet.'), ' ',
-			E('a', { 'href': L.url('admin/nlbw/commit') }, _('Force reload…'))
+			E('a', {
+				'href': '#',
+				'click': ui.createHandlerFn(this, 'handleCommit')
+			}, _('Force reload…'))
 		]));
 
 		this.pie('layer7-rx-pie', rxData);
@@ -525,7 +528,10 @@ return view.extend({
 
 		cbi_update_table('#ipv6-data', rows, E('em', [
 			_('No data recorded yet.'), ' ',
-			E('a', { 'href': L.url('admin/nlbw/commit') }, _('Force reload…'))
+			E('a', {
+				'href': '#',
+				'click': ui.createHandlerFn(this, 'handleCommit')
+			}, _('Force reload…'))
 		]));
 
 		var shareData = [], hostsData = [];

--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
@@ -359,13 +359,7 @@ return view.extend({
 			conn_total += rec.conns;
 		}
 
-		cbi_update_table('#host-data', rows, E('em', [
-			_('No data recorded yet.'), ' ',
-			E('button', {
-				'class': 'cbi-button',
-				'click': ui.createHandlerFn(this, 'handleCommit')
-			}, _('Force reload…'))
-		]));
+		cbi_update_table('#host-data', rows, E('em', _('No data recorded yet.')));
 
 		this.pie('traf-pie', trafData);
 		this.pie('conn-pie', connData);
@@ -419,13 +413,7 @@ return view.extend({
 			}
 		}
 
-		cbi_update_table('#layer7-data', rows, E('em', [
-			_('No data recorded yet.'), ' ',
-			E('button', {
-				'class': 'cbi-button',
-				'click': ui.createHandlerFn(this, 'handleCommit')
-			}, _('Force reload…'))
-		]));
+		cbi_update_table('#layer7-data', rows, E('em', 	_('No data recorded yet.')));
 
 		this.pie('layer7-rx-pie', rxData);
 		this.pie('layer7-tx-pie', txData);
@@ -526,13 +514,7 @@ return view.extend({
 			]);
 		}
 
-		cbi_update_table('#ipv6-data', rows, E('em', [
-			_('No data recorded yet.'), ' ',
-			E('button', {
-				'class': 'cbi-button',
-				'click': ui.createHandlerFn(this, 'handleCommit')
-			}, _('Force reload…'))
-		]));
+		cbi_update_table('#ipv6-data', rows, E('em', _('No data recorded yet.')));
 
 		var shareData = [], hostsData = [];
 
@@ -862,6 +844,13 @@ return view.extend({
 								E('em', { 'class': 'spinning' }, [ _('Collecting data...') ])
 							])
 						])
+					]),
+					E('div', { 'class': 'right' }, [
+						E('button', {
+							'class': 'cbi-button',
+							'click': ui.createHandlerFn(this, 'handleCommit')
+							}, _('Force reload…')
+						)
 					])
 				]),
 
@@ -901,6 +890,13 @@ return view.extend({
 								E('em', { 'class': 'spinning' }, [ _('Collecting data...') ])
 							])
 						])
+					]),
+					E('div', { 'class': 'right' }, [
+						E('button', {
+							'class': 'cbi-button',
+							'click': ui.createHandlerFn(this, 'handleCommit')
+							}, _('Force reload…')
+						)
 					])
 				]),
 
@@ -941,6 +937,13 @@ return view.extend({
 								E('em', { 'class': 'spinning' }, [ _('Collecting data...') ])
 							])
 						])
+					]),
+					E('div', { 'class': 'right' }, [
+						E('button', {
+							'class': 'cbi-button',
+							'click': ui.createHandlerFn(this, 'handleCommit')
+							}, _('Force reload…')
+						)
 					])
 				]),
 


### PR DESCRIPTION
When moving this application to the service section, the links were forgotten to be changed.

@jow- Since I messed up, it's up to me to deal with it on my own. 
But in the process I noticed that the change in display.js wasn't right in the first place, was it?

If I had not moved the application, then it should have looked like this.
```

- E('a', { 'href': L.url('admin/nlbw/commit') }, _('Force reload…'))
+ E('a', { 'href': L.url('admin/nlbw/update') }, _('Force reload…'))

```



  