### PR TITLE
modules: minor styling fixes

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2203,9 +2203,8 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 
 			dom.append(createEl, [
 				E('div', {}, nameEl),
-				E('input', {
+				E('button', {
 					'class': 'cbi-button cbi-button-add',
-					'type': 'submit',
 					'value': btn_title || _('Add'),
 					'title': btn_title || _('Add'),
 					'click': ui.createHandlerFn(this, function(ev) {
@@ -2215,7 +2214,7 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 						return this.handleAdd(ev, nameEl.value);
 					}),
 					'disabled': this.map.readonly || null
-				})
+				}, [ btn_title || _('Add') ])
 			]);
 
 			ui.addValidator(nameEl, 'uciname', true, 'blur', 'keyup');


### PR DESCRIPTION
During testing I notice some styling issue with the luci-theme-openwrt-2020.
Due missing of the btn class in form.js the button in xintd looks strange. I have added to all `cbi-button` css class the `btn` css class in from.js. We have already discussed the topic in other issues. I don't know the btn css class. But it looks like it's necessary.

### Before change:
![Screenshot_2021-06-16 st-dev-07 - Xinetd - LuCI](https://user-images.githubusercontent.com/553091/122240489-1cf92780-cec2-11eb-803d-651cfb4920bc.png)



### After the change:
![Screenshot_2021-06-16 st-dev-07 - Xinetd - LuCI](https://user-images.githubusercontent.com/553091/122240121-cf7cba80-cec1-11eb-8117-d8485ccc7cb7.png)

### Before change:
Due using div for instead of table element the wlan channel analysis looks strange.
![Screenshot_2021-06-16 st-dev-07 - Channel Analysis - LuCI](https://user-images.githubusercontent.com/553091/122239582-58472680-cec1-11eb-92e1-18314ca9e8ee.png)

### After the change:
![Screenshot_2021-06-16 st-dev-07 - Channel Analysis - LuCI](https://user-images.githubusercontent.com/553091/122240764-503bb680-cec2-11eb-9f6a-68edf492004d.png)

