### PR TITLE
luci-base: minor fixes and improvments

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2203,10 +2203,8 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 
 			dom.append(createEl, [
 				E('div', {}, nameEl),
-				E('input', {
+				E('button', {
 					'class': 'cbi-button cbi-button-add',
-					'type': 'submit',
-					'value': btn_title || _('Add'),
 					'title': btn_title || _('Add'),
 					'click': ui.createHandlerFn(this, function(ev) {
 						if (nameEl.classList.contains('cbi-input-invalid'))
@@ -2215,7 +2213,7 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 						return this.handleAdd(ev, nameEl.value);
 					}),
 					'disabled': this.map.readonly || null
-				})
+				}, [ btn_title || _('Add') ])
 			]);
 
 			ui.addValidator(nameEl, 'uciname', true, 'blur', 'keyup');

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -2212,11 +2212,21 @@ var CBITypedSection = CBIAbstractSection.extend(/** @lends LuCI.form.TypedSectio
 
 						return this.handleAdd(ev, nameEl.value);
 					}),
-					'disabled': this.map.readonly || null
+					'disabled': true
 				}, [ btn_title || _('Add') ])
 			]);
 
-			ui.addValidator(nameEl, 'uciname', true, 'blur', 'keyup');
+			ui.addValidator(nameEl, 'uciname', true, function(v) {
+				var button = document.querySelector('.cbi-section-create > .cbi-button-add');
+				if (v !== '') {
+					button.disabled = false;
+					return true;
+				}
+				else {
+					button.disabled = true;
+					return _('Expecting: %s').format(_('non-empty value'));
+				}
+			}, 'blur', 'keyup');
 		}
 
 		return createEl;

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -603,7 +603,7 @@ var CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 						E('p', {}, [ _('An error occurred while saving the form:') ]),
 						E('p', {}, [ E('em', { 'style': 'white-space:pre' }, [ e.message ]) ]),
 						E('div', { 'class': 'right' }, [
-							E('button', { 'class': 'btn', 'click': ui.hideModal }, [ _('Dismiss') ])
+							E('button', { 'class': 'cbi-button', 'click': ui.hideModal }, [ _('Dismiss') ])
 						])
 					]);
 				}
@@ -2639,9 +2639,9 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 
 		if (this.sortable) {
 			dom.append(tdEl.lastElementChild, [
-				E('div', {
+				E('button', {
 					'title': _('Drag to reorder'),
-					'class': 'btn cbi-button drag-handle center',
+					'class': 'cbi-button drag-handle center',
 					'style': 'cursor:move',
 					'disabled': this.map.readonly || null
 				}, '☰')
@@ -2879,7 +2879,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 				nodes,
 				E('div', { 'class': 'right' }, [
 					E('button', {
-						'class': 'btn',
+						'class': 'cbi-button',
 						'click': ui.createHandlerFn(this, 'handleModalCancel', m)
 					}, [ _('Dismiss') ]), ' ',
 					E('button', {


### PR DESCRIPTION
- Change html tag `input` to `button` for adding a named section. Button is then rendert correct for luci-theme-openwrt-2020
- Call validation, because named section is always empty on page load. User must added a name for named sections.
- Remove `btn` css class and also rename them to `button`