### PR TITLE
luci-app-frpc: allow hostname in server address

### DIFF
--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -16,7 +16,7 @@ var startupConf = [
 ];
 
 var commonConf = [
-	[form.Value, 'server_addr', _('Server address'), _('ServerAddr specifies the address of the server to connect to.<br>By default, this value is "0.0.0.0".'), {datatype: 'ipaddr'}],
+	[form.Value, 'server_addr', _('Server address'), _('ServerAddr specifies the address of the server to connect to.<br>By default, this value is "0.0.0.0".'), {datatype: 'host'}],
 	[form.Value, 'server_port', _('Server port'), _('ServerPort specifies the port to connect to the server on.<br>By default, this value is 7000.'), {datatype: 'port'}],
 	[form.Value, 'http_proxy', _('HTTP proxy'), _('HttpProxy specifies a proxy address to connect to the server through. If this value is "", the server will be connected to directly.<br>By default, this value is read from the "http_proxy" environment variable.')],
 	[form.ListValue, 'log_level', _('Log level'), _('LogLevel specifies the minimum log level. Valid values are "trace", "debug", "info", "warn", and "error".<br>By default, this value is "info".'), {values: ['trace', 'debug', 'info', 'warn', 'error']}],


### PR DESCRIPTION
Sometimes, our frp server cannot use a static ip address.
So perhaps we should allow people to use hostname in server address.