### PR TITLE
luci-base: prevent empty field for adding new entry

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -367,6 +367,17 @@ function cbi_validate_form(form, errmsg)
 	return true;
 }
 
+function cbi_validate_named_section_add(input)
+{
+	var button = input.parentNode.parentNode.querySelector('.cbi-button-add');
+	if (input.value !== '') {
+		button.disabled = false;
+	}
+	else {
+		button.disabled = true;
+	}
+}
+
 function cbi_validate_reset(form)
 {
 	window.setTimeout(

--- a/modules/luci-compat/luasrc/view/cbi/tblsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tblsection.htm
@@ -192,9 +192,9 @@ end
 					<div class="cbi-section-error"><%:Invalid%></div>
 				<%- end %>
 				<div>
-					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" data-type="uciname" data-optional="true" />
+					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>.<%=section%>" data-type="uciname" data-optional="true" onkeyup="cbi_validate_named_section_add(this)"/>
 				</div>
-				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" />
+				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" disabled="" />
 			<% end %>
 		</div>
 		<%- end %>

--- a/modules/luci-compat/luasrc/view/cbi/tsection.htm
+++ b/modules/luci-compat/luasrc/view/cbi/tsection.htm
@@ -42,9 +42,9 @@
 					<div class="cbi-section-error"><%:Invalid%></div>
 				<%- end %>
 				<div>
-					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." data-type="uciname" data-optional="true" />
+					<input type="text" class="cbi-section-create-name" id="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." name="cbi.cts.<%=self.config%>.<%=self.sectiontype%>." data-type="uciname" data-optional="true" onkeyup="cbi_validate_named_section_add(this)"/>
 				</div>
-				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" />
+				<input class="btn cbi-button cbi-button-add" type="submit" onclick="this.form.cbi_state='add-section'; return true" value="<%:Add%>" title="<%:Add%>" disabled=""/>
 			<%- end %>
 		</div>
 		<%- end %>


### PR DESCRIPTION
Currently it is not checked whether a valid string was entered in the input field when adding a named section.
This commit validates if the input field is empty or not.
If the input field is not empty, then the Add button is displayed.

refs https://github.com/openwrt/luci/pull/5154