### PR TITLE
luci-base: batch DOM updates to prevent slowdown

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -752,7 +752,7 @@ function cbi_update_table(table, data, placeholder) {
 		});
 
 		if (Array.isArray(data)) {
-			var n = 0, rows = target.querySelectorAll('tr, .tr');
+			var n = 0, rows = target.querySelectorAll('tr, .tr'), trows = [];
 
 			data.forEach(function(row) {
 				var trow = E('tr', { 'class': 'tr' });
@@ -770,11 +770,15 @@ function cbi_update_table(table, data, placeholder) {
 
 				trow.classList.add('cbi-rowstyle-%d'.format((n++ % 2) ? 2 : 1));
 
-				if (rows[n])
-					target.replaceChild(trow, rows[n]);
-				else
-					target.appendChild(trow);
+				trows[n] = trow;
 			});
+
+			for(var i = 1; i < n; i++) {
+				if (rows[i])
+					target.replaceChild(trows[i], rows[i]);
+				else
+					target.appendChild(trows[i]);
+			}
 
 			while (rows[++n])
 				target.removeChild(rows[n]);


### PR DESCRIPTION
Currently, if there are a lot of rows in the Realtime Connections table, the page slows down to a crawl.

![image](https://user-images.githubusercontent.com/38528110/123879467-a04a5c80-d949-11eb-84b0-c63c64073262.png)

A major actor here is the _cbi_update_table_ function, which upsets the browser by making a lot of DOM updates with _slight pause in between_ when updating the table rows. Because of that pause between the updates, the browser tries to keep the view updated and does tons of useless style recalculations and this is what freezes the page. 

Before:

![image](https://user-images.githubusercontent.com/38528110/123880962-66c72080-d94c-11eb-813b-6ec9ef6a5d34.png)

Luckily this behavior can be fixed by batching the DOM updates.

After:

![image](https://user-images.githubusercontent.com/38528110/123880989-72b2e280-d94c-11eb-93f3-fd6790e7de30.png)

After this optimization the page can handle thousands of rows without breaking a sweat, whereas before it would choke with some hundreds of rows.