### PR TITLE
luci-app-acl: some fixes

### DIFF
--- a/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
+++ b/applications/luci-app-acl/htdocs/luci-static/resources/view/system/acl.js
@@ -146,6 +146,9 @@ var cbiACLSelect = form.Value.extend({
 	},
 
 	write: function(section_id, value) {
+		uci.unset('rpcd', section_id, 'read');
+		uci.unset('rpcd', section_id, 'write');
+
 		if (L.isObject(value) && Array.isArray(value.read))
 			uci.set('rpcd', section_id, 'read', value.read);
 


### PR DESCRIPTION
This P/R does make two changes

1. luci-app-acl: fix translation function call. The second argument in the translation function makes no sense.
2. luci-app-acl: unset read and write before acl set.  If the setting in the view is set to `denied`, only the read list option is deleted. This is not correct. The write list option must also be deleted. To ensure that the correct configuration is saved, the write and read list options are always deleted beforehand and then rewritten.

**Configuration that is being changed:**
```
config login
        option username 'test'
        option timeout '300'
        option password '$1$$whuMjZj.HMFoaTaZRRtkO0'
        list read 'luci-app-acme'
        list read 'luci-app-commands'
        list read 'luci-app-ddns'
        list read 'luci-base'
        list read 'unauthenticated'
        list write 'luci-app-acme'
        list write 'luci-app-commands'
        list write 'luci-app-ddns'
```
**Before acl.js change to denied (wrong):**
![Screenshot_2021-06-30 st-dev-07 - ACL Settings - LuCI(1)](https://user-images.githubusercontent.com/553091/123974004-8f86fe80-d9bc-11eb-8368-330ac7dc5f84.png)
```
config login
        option username 'test'
        option timeout '300'
        option password '$1$$whuMjZj.HMFoaTaZRRtkO0'
        list write 'luci-app-acme'
        list write 'luci-app-commands'
        list write 'luci-app-ddns'
        list read 'luci-base'
        list read 'unauthenticated'
```
**After acl.js change to denied (correct):**
![Screenshot_2021-06-30 st-dev-07 - ACL Settings - LuCI](https://user-images.githubusercontent.com/553091/123973613-3323df00-d9bc-11eb-8b48-2360b2aa8f8b.png)
```
config login
        option username 'test'
        option timeout '300'
        option password '$1$$whuMjZj.HMFoaTaZRRtkO0'
        list read 'luci-base'
        list read 'unauthenticated'
```