### PR TITLE
luci-app-nlbwmon: Add translation context for Download/Upload terms

### DIFF
--- a/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
+++ b/applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js
@@ -583,11 +583,11 @@ return view.extend({
 		dom.content(tooltip, [
 			E('div', { 'class': 'head' }, [
 				E('div', { 'class': 'pie' }, [
-					E('label', _('Download')),
+					E('label', _('Download', 'Traffic counter')),
 					E('canvas', { 'id': 'bubble-pie1', 'width': 100, 'height': 100 })
 				]),
 				E('div', { 'class': 'pie' }, [
-					E('label', _('Upload')),
+					E('label', _('Upload', 'Traffic counter')),
 					E('canvas', { 'id': 'bubble-pie2', 'width': 100, 'height': 100 })
 				]),
 				E('div', { 'class': 'kpi' }, [

--- a/applications/luci-app-nlbwmon/po/ar/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ar/nlbwmon.po
@@ -221,6 +221,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "تنزيل"
 
@@ -505,6 +506,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "تحميل"
 

--- a/applications/luci-app-nlbwmon/po/bg/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/bg/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/bn_BD/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/bn_BD/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/ca/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ca/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/cs/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/cs/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Stáhnout"
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Nahrát"
 

--- a/applications/luci-app-nlbwmon/po/de/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/de/nlbwmon.po
@@ -240,6 +240,7 @@ msgid "Down. (Pkts.)"
 msgstr "Down. (Pkg.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Download"
 
@@ -543,6 +544,7 @@ msgid "Up. (Pkts.)"
 msgstr "Up. (Pkts.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Upload"
 

--- a/applications/luci-app-nlbwmon/po/el/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/el/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/en/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/en/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/es/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/es/nlbwmon.po
@@ -246,6 +246,7 @@ msgid "Down. (Pkts.)"
 msgstr "Desc. (Paqs.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Descargar"
 
@@ -552,6 +553,7 @@ msgid "Up. (Pkts.)"
 msgstr "Sub. (Paq.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Cargar"
 

--- a/applications/luci-app-nlbwmon/po/fi/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/fi/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Lataa"
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Lähetä"
 

--- a/applications/luci-app-nlbwmon/po/fr/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/fr/nlbwmon.po
@@ -231,6 +231,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Télécharger"
 
@@ -515,6 +516,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Téléverser"
 

--- a/applications/luci-app-nlbwmon/po/he/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/he/nlbwmon.po
@@ -221,6 +221,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -505,6 +506,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/hi/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/hi/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/hu/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/hu/nlbwmon.po
@@ -238,6 +238,7 @@ msgid "Down. (Pkts.)"
 msgstr "Le. (csom.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Letöltés"
 
@@ -545,6 +546,7 @@ msgid "Up. (Pkts.)"
 msgstr "Fel. (csom.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Feltöltés"
 

--- a/applications/luci-app-nlbwmon/po/it/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/it/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Download"
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Upload"
 

--- a/applications/luci-app-nlbwmon/po/ja/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ja/nlbwmon.po
@@ -232,6 +232,7 @@ msgid "Down. (Pkts.)"
 msgstr "ダウンロード（パケット）"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "ダウンロード"
 
@@ -531,6 +532,7 @@ msgid "Up. (Pkts.)"
 msgstr "アップロード（パケット）"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "アップロード"
 

--- a/applications/luci-app-nlbwmon/po/ko/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ko/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/mr/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/mr/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "डाउनलोड"
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/ms/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ms/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/nb_NO/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/nb_NO/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Last ned"
 
@@ -505,6 +506,7 @@ msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
 #, fuzzy
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Last opp"
 

--- a/applications/luci-app-nlbwmon/po/pl/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/pl/nlbwmon.po
@@ -233,6 +233,7 @@ msgid "Down. (Pkts.)"
 msgstr "Pobieranie (Pakiety)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Pobieranie"
 
@@ -536,6 +537,7 @@ msgid "Up. (Pkts.)"
 msgstr "Wysyłanie (Pakiety)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Wysyłanie"
 

--- a/applications/luci-app-nlbwmon/po/pt/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/pt/nlbwmon.po
@@ -236,6 +236,7 @@ msgid "Down. (Pkts.)"
 msgstr "Desc. (Pcts.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Descarregar"
 
@@ -541,6 +542,7 @@ msgid "Up. (Pkts.)"
 msgstr "Acima. (Pcts.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Enviar"
 

--- a/applications/luci-app-nlbwmon/po/pt_BR/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/pt_BR/nlbwmon.po
@@ -243,6 +243,7 @@ msgid "Down. (Pkts.)"
 msgstr "Down. (Pcts.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Download"
 
@@ -549,6 +550,7 @@ msgid "Up. (Pkts.)"
 msgstr "Up. (Pcts.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Envio"
 

--- a/applications/luci-app-nlbwmon/po/ro/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ro/nlbwmon.po
@@ -221,6 +221,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -505,6 +506,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/ru/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/ru/nlbwmon.po
@@ -241,8 +241,9 @@ msgid "Down. (Pkts.)"
 msgstr "Скач. (пакеты)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
-msgstr "Скачать"
+msgstr "Скачано"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:837
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:883
@@ -541,8 +542,9 @@ msgid "Up. (Pkts.)"
 msgstr "Загр. (пакеты)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
-msgstr "Загрузить"
+msgstr "Загружено"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:839
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:885

--- a/applications/luci-app-nlbwmon/po/sk/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/sk/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Odovzdať"
 

--- a/applications/luci-app-nlbwmon/po/sv/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/sv/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Nedladdning"
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/templates/nlbwmon.pot
+++ b/applications/luci-app-nlbwmon/po/templates/nlbwmon.pot
@@ -211,6 +211,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -495,6 +496,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/tr/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/tr/nlbwmon.po
@@ -234,6 +234,7 @@ msgid "Down. (Pkts.)"
 msgstr "İndr. (Pktlr.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "İndir"
 
@@ -537,6 +538,7 @@ msgid "Up. (Pkts.)"
 msgstr "Yükl. (Pktlr.)"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Yükleme"
 

--- a/applications/luci-app-nlbwmon/po/uk/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/uk/nlbwmon.po
@@ -221,6 +221,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "Завантажити"
 
@@ -505,6 +506,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "Відвантажити"
 

--- a/applications/luci-app-nlbwmon/po/vi/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/vi/nlbwmon.po
@@ -220,6 +220,7 @@ msgid "Down. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr ""
 
@@ -504,6 +505,7 @@ msgid "Up. (Pkts.)"
 msgstr ""
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr ""
 

--- a/applications/luci-app-nlbwmon/po/zh_Hans/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/zh_Hans/nlbwmon.po
@@ -229,6 +229,7 @@ msgid "Down. (Pkts.)"
 msgstr "下载量（包）"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "下载"
 
@@ -517,6 +518,7 @@ msgid "Up. (Pkts.)"
 msgstr "上传量（包）"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "上传"
 

--- a/applications/luci-app-nlbwmon/po/zh_Hant/nlbwmon.po
+++ b/applications/luci-app-nlbwmon/po/zh_Hant/nlbwmon.po
@@ -229,6 +229,7 @@ msgid "Down. (Pkts.)"
 msgstr "下載量（封包）"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:586
+msgctxt "Traffic counter"
 msgid "Download"
 msgstr "下載"
 
@@ -517,6 +518,7 @@ msgid "Up. (Pkts.)"
 msgstr "上傳量（封包）"
 
 #: applications/luci-app-nlbwmon/htdocs/luci-static/resources/view/nlbw/display.js:590
+msgctxt "Traffic counter"
 msgid "Upload"
 msgstr "上傳"
 


### PR DESCRIPTION
Added a translation context for the terms 'Download' and 'Upload'
used in this application. The reason is that these terms are
translated differently in Russian depending on the context.

If the terms are used in the sense of an action (download file
or upload file) then the translations should be as follows:
- Download = скачать
- Upload   = загрузить

But if they are used in the context of a traffic counter (like
in this application) the correct translations are:
- Download = скачано
- Upload   = загружено

A translation context has been added to all affected PO files
to avoid breaking existing translations. The Russian translation
in PO file is fixed to comply with the used context.

Signed-off-by: Anton Kikin <a.kikin@tano-systems.com>