### PR TITLE
luci-app-attendedsysupgrade: fix ACL definition

### DIFF
--- a/applications/luci-app-attendedsysupgrade/root/usr/share/rpcd/acl.d/luci-app-attendedsysupgrade.json
+++ b/applications/luci-app-attendedsysupgrade/root/usr/share/rpcd/acl.d/luci-app-attendedsysupgrade.json
@@ -2,16 +2,35 @@
 	"luci-app-attendedsysupgrade": {
 		"description": "Grant UCI access to LuCI app attendedsysupgrade",
 		"read": {
-			"uci": ["attendedsysupgrade"],
 			"ubus": {
-				"rpc-sys": ["upgrade_start", "packagelist"]
-			}
+				"rpc-sys": [
+					"upgrade_start",
+					"packagelist"
+				],
+				"system": [
+					"board",
+					"info"
+				],
+				"uci": [
+					"get"
+				]
+			},
+			"uci": [
+				"attendedsysupgrade"
+			]
 		},
 		"write": {
-			"uci": ["attendedsysupgrade"],
+			"cgi-io": [
+				"upload"
+			],
 			"ubus": {
-				"rpc-sys": ["upgrade_start"]
-			}
+				"uci": [
+					"set", "commit"
+				]
+			},
+			"uci": [
+				"attendedsysupgrade"
+			]
 		}
 	}
 }


### PR DESCRIPTION
Fix the ACL file which handles the permissions for the LuCI app.

Suggested-by: Jo-Philipp Wich <jo@mein.io>
Signed-off-by: Paul Spooren <mail@aparcar.org>