### PR TITLE
luci-base:Fix time display error

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -614,17 +614,17 @@ String.prototype.format = function()
 						var tm = 0;
 						var ts = (param || 0);
 
-						if (ts > 60) {
+						if (ts > 59) {
 							tm = Math.floor(ts / 60);
 							ts = (ts % 60);
 						}
 
-						if (tm > 60) {
+						if (tm > 59) {
 							th = Math.floor(tm / 60);
 							tm = (tm % 60);
 						}
 
-						if (th > 24) {
+						if (th > 23) {
 							td = Math.floor(th / 24);
 							th = (th % 24);
 						}


### PR DESCRIPTION
Fix time display error like this:
![119333137-1bba4d80-bcbc-11eb-8d6a-a2cd664061de](https://user-images.githubusercontent.com/61473216/124549156-5984c700-de61-11eb-8a51-7a8b6b2bfd1f.png)
Running time should display 1h 0m 36s instead of 0h 60m 36s