### PR TITLE
mod-network: label button "Delete" for devices

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1273,7 +1273,7 @@ return view.extend({
 			var trEl = this.super('renderRowActions', [ section_id, _('Configure…') ]),
 			    deleteBtn = trEl.querySelector('button:last-child');
 
-			deleteBtn.firstChild.data = _('Reset');
+			deleteBtn.firstChild.data = _('Delete');
 			deleteBtn.setAttribute('title', _('Remove related device settings from the configuration'));
 			deleteBtn.disabled = section_id.match(/^dev:/) ? true : null;
 


### PR DESCRIPTION
Maintainer: @jow-

Use proper label text "Delete" for button which "Remove related device settings".
Currently it buttons are labeled "Reset" ("Zurücksetzen) which is wrong, as they removing the device from the config.
![Screenshot_20210715_150238](https://user-images.githubusercontent.com/1755362/125792803-6032242d-de6d-4d80-822b-207ae24f9171.png)


This should be also cherry-picked to 21.02

