### PR TITLE
luci-mod-network: clarify device settings "Delete" button

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1273,7 +1273,7 @@ return view.extend({
 			var trEl = this.super('renderRowActions', [ section_id, _('Configure…') ]),
 			    deleteBtn = trEl.querySelector('button:last-child');
 
-			deleteBtn.firstChild.data = _('Reset');
+			deleteBtn.firstChild.data = _('Unconfigure');
 			deleteBtn.setAttribute('title', _('Remove related device settings from the configuration'));
 			deleteBtn.disabled = section_id.match(/^dev:/) ? true : null;
 


### PR DESCRIPTION
Use proper label text "Unconfigure" for button which "Remove related device settings". This seems to describe best what it's doing. Current "Reset" is misleading and "Delete" (#5090, #5092) are technically not correct.

Also this one should be cherry-picked to openwrt-21.02