### PR TITLE
luci-mod-network: depend on luci-proto-ipv6 (fixes "wan6")

### DIFF
--- a/modules/luci-mod-network/Makefile
+++ b/modules/luci-mod-network/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI Network Administration
-LUCI_DEPENDS:=+luci-base +libiwinfo-lua +rpcd-mod-iwinfo
+LUCI_DEPENDS:=+luci-base +libiwinfo-lua +rpcd-mod-iwinfo +IPV6:luci-proto-ipv6
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
Maintainer: @jow- @hnyman

OpenWrt sets up a wan6 interface by default. Without the "proto-ipv6" this interface is reported "broken / unsupported protocol" in LuCI and can't be edited therefore.
Adding this dependency, fixes the Interface-listing. This dependency will (as in a708378) only be relevant when IPV6-feature is enabled at all.

Tested on: ramips-mt7621
This affects also openwrt-21.02