### PR TITLE
luci-theme-material: fix JS error from ES6 method in IE

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
+++ b/themes/luci-theme-material/htdocs/luci-static/material/js/script.js
@@ -68,7 +68,7 @@ document.addEventListener('luci-loaded', function(ev) {
 				var that = $(this);
 				var href = that.attr("href");
 
-				if (href.endsWith(nodeUrl) || href.indexOf('/' + nodeUrl + '/') != -1) {
+				if (href.substring(href.length - nodeUrl.length, href.length) === nodeUrl || href.indexOf('/' + nodeUrl + '/') != -1) {
 					ulNode.click();
 					ulNode.next(".slide-menu").stop(true, true);
 					lastNode = that.parent();


### PR DESCRIPTION
The JS `String.prototype.endsWith()` method is not supported in Internet Explorer, which results in the interface not loading after logging in.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#browser_compatibility

Signed-off-by: geoff <geoff@invizbox.com>