### PR TITLE
[21.02] luci-app-https-dns-proxy: update to 2021-07-29-1

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=2021-01-17-2
+PKG_VERSION:=2021-07-29-1
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua
@@ -1,6 +1,0 @@
-return {
-	name = "Digitale-Gesellschaft",
-	label = _("Digitale Gesellschaft"),
-	resolver_url = "https://dns.digitale-gesellschaft.ch/dns-query",
-	bootstrap_dns = "185.95.218.42,185.95.218.43"
-}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/cn.rubyfish.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/cn.rubyfish.dns.lua
@@ -1,6 +1,0 @@
-return {
-	name = "rubyfish.cn",
-	label = _("rubyfish.cn"),
-	resolver_url = "https://dns.rubyfish.cn/dns-query",
-	bootstrap_dns = "118.89.110.78,47.96.179.163"
-}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.digitale-gesellschaft.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.digitale-gesellschaft.dns.lua
@@ -1,0 +1,7 @@
+return {
+	name = "Digitale-Gesellschaft",
+	label = _("Digitale Gesellschaft"),
+	resolver_url = "https://dns.digitale-gesellschaft.ch/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	http2_only = true
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.rubyfish.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.rubyfish.dns.lua
@@ -1,0 +1,7 @@
+return {
+	name = "rubyfish.cn",
+	label = _("rubyfish.cn"),
+	resolver_url = "https://dns.rubyfish.cn/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	http2_only = true
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.lua
@@ -4,5 +4,6 @@ return {
 	resolver_url = "https://cloudflare-dns.com/dns-query",
 	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001",
 	help_link = "https://one.one.one.one/family/",
-	help_link_text = "Cloudflare"
+	help_link_text = "Cloudflare",
+	default = true
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua
@@ -2,5 +2,5 @@ return {
 	name = "odvr-nic-cz",
 	label = _("ODVR (nic.cz)"),
 	resolver_url = "https://odvr.nic.cz/doh",
-	bootstrap_dns = "193.17.47.1,185.43.135.1"
+	bootstrap_dns = "193.17.47.1,185.43.135.1,2001:148f:ffff::1,2001:148f:fffe::1"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua
@@ -2,6 +2,5 @@ return {
 	name = "Google",
 	label = _("Google"),
 	resolver_url = "https://dns.google/dns-query",
-	bootstrap_dns = "8.8.8.8,8.8.4.4",
-	default = true
+	bootstrap_dns = "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua
@@ -2,7 +2,7 @@ return {
 	name = "LibreDNS (No Ads)",
 	label = _("LibreDNS (No Ads)"),
 	resolver_url = "https://doh.libredns.gr/ads",
-	bootstrap_dns = "116.202.176.26",
+	bootstrap_dns = "116.202.176.26,1.1.1.1",
 	help_link = "https://libredns.gr/",
 	help_link_text = "LibreDNS.gr"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua
@@ -2,7 +2,7 @@ return {
 	name = "LibreDNS",
 	label = _("LibreDNS"),
 	resolver_url = "https://doh.libredns.gr/dns-query",
-	bootstrap_dns = "116.202.176.26",
+	bootstrap_dns = "116.202.176.26,1.1.1.1",
 	help_link = "https://libredns.gr/",
 	help_link_text = "LibreDNS.gr"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.adblocker.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.adblocker.lua
@@ -1,0 +1,9 @@
+return {
+	name="mullvad-adblock",
+	label=_("Mullvad (AdBlock)"),
+	resolver_url="https://adblock.doh.mullvad.net/dns-query",
+	bootstrap_dns="1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link="https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/",
+	help_link_text="Mullvad.net",
+	http2_only = true
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.lua
@@ -1,0 +1,9 @@
+return {
+	name="mullvad",
+	label=_("Mullvad"),
+	resolver_url="https://doh.mullvad.net/dns-query",
+	bootstrap_dns="1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link="https://mullvad.net/en/help/dns-over-https-and-dns-over-tls/",
+	help_link_text="Mullvad.net",
+	http2_only = true
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua
@@ -2,7 +2,7 @@ return {
 	name = "CleanBrowsing-Adult",
 	label = _("CleanBrowsing (Adult Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/adult-filter/",
-	bootstrap_dns = "185.228.168.168",
+	bootstrap_dns = "185.228.168.168,1.1.1.1",
 	help_link = "https://cleanbrowsing.org/guides/dnsoverhttps",
 	help_link_text = "CleanBrowsing.org"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua
@@ -2,7 +2,7 @@ return {
 	name = "CleanBrowsing-Family",
 	label = _("CleanBrowsing (Family Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/family-filter/",
-	bootstrap_dns = "185.228.168.168",
+	bootstrap_dns = "185.228.168.168,1.1.1.1",
 	help_link = "https://cleanbrowsing.org/guides/dnsoverhttps",
 	help_link_text = "CleanBrowsing.org"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua
@@ -2,7 +2,7 @@ return {
 	name = "CleanBrowsing-Security",
 	label = _("CleanBrowsing (Security Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/security-filter/",
-	bootstrap_dns = "185.228.168.168",
+	bootstrap_dns = "185.228.168.168,1.1.1.1",
 	help_link = "https://cleanbrowsing.org/guides/dnsoverhttps",
 	help_link_text = "CleanBrowsing.org"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/sb.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/sb.dns.lua
@@ -2,5 +2,6 @@ return {
 	name = "DNS.SB",
 	label = _("DNS.SB"),
 	resolver_url = "https://doh.dns.sb/dns-query",
-	bootstrap_dns = "185.222.222.222,185.184.222.222"
+	bootstrap_dns = "185.222.222.222,185.184.222.222",
+	http2_only = true
 }

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,11 +1,11 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:91
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:92
 msgid "%s DoH at %s:%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:72
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:73
 msgid "%s is not installed or not found"
 msgstr ""
 
@@ -57,7 +57,7 @@ msgstr ""
 msgid "Cloudflare (Security Protection)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:117
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:122
 msgid "Configuration"
 msgstr ""
 
@@ -65,11 +65,11 @@ msgstr ""
 msgid "DNS HTTPS Proxy"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:105
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:110
 msgid "DNS HTTPS Proxy Settings"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/sb.dns.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/sb.dns.lua:3
 msgid "DNS.SB"
 msgstr ""
 
@@ -85,11 +85,11 @@ msgstr ""
 msgid "DNSPod.cn Public DNS"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:184
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:195
 msgid "DSCP Codepoint"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/ch.digitale-gesellschaft.dns.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.digitale-gesellschaft.dns.lua:3
 msgid "Digitale Gesellschaft"
 msgstr ""
 
@@ -97,7 +97,7 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:125
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:130
 msgid "Do not update configs"
 msgstr ""
 
@@ -105,19 +105,19 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:28
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:29
 msgid "For more information on different options check"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:127
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:132
 msgid "Force Router DNS"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:129
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:134
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:127
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:132
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
@@ -133,18 +133,18 @@ msgstr ""
 msgid "IDNet.net (UK)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:118
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:123
 msgid ""
 "If update option is selected, the 'DNS forwardings' section of %sDHCP and DNS"
 "%s will be automatically updated to use selected DoH providers (%smore "
 "information%s)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:133
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:138
 msgid "Instances"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:128
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:133
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
@@ -156,16 +156,24 @@ msgstr ""
 msgid "LibreDNS (No Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:167
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:178
 msgid "Listen Address"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:180
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:191
 msgid "Listen Port"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/js.htm:52
 msgid "Loading"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.lua:3
+msgid "Mullvad"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.adblocker.lua:3
+msgid "Mullvad (AdBlock)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua:3
@@ -184,7 +192,7 @@ msgstr ""
 msgid "OpenDNS (Family Shield)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:188
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:199
 msgid "Proxy Server"
 msgstr ""
 
@@ -212,19 +220,19 @@ msgstr ""
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:140
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:145
 msgid "Resolver"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:113
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:118
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:109
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:114
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:107
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:112
 msgid "Service Status [%s %s]"
 msgstr ""
 
@@ -236,34 +244,34 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:98
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:99
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:64
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:65
 msgid "Unknown Provider"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:122
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:127
 msgid "Update %s config"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:118
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:123
 msgid "Update DNSMASQ Config on Start/Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:119
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:124
 msgid "Update all configs"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:49
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:50
 msgid "and"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:100
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:101
 msgid "disabled"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers.disabled/cn.rubyfish.dns.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.rubyfish.dns.lua:3
 msgid "rubyfish.cn"
 msgstr ""


### PR DESCRIPTION
* add HTTP/2-only supporting providers: Mullvad, Digitale-Gesellschaft, dns.sb and Rubyfish.cn
* switch default provider from Google to Cloudflare
* add IPv6 addresses for bootstrap resolvers for Google DNS
* add secondary bootstrap resolver (Cloudflare's) to all providers with a single bootstrap resolver
* modify model/cbi file to show HTTP/2-only providers (and help texts) on HTTP/2-supporting systems

Signed-off-by: Stan Grishin <stangri@melmac.net>