### PR TITLE
luci-mod-status: status/routing support for pbr

### DIFF
--- a/modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json
@@ -11,27 +11,27 @@
 		}
 	},
 
-	"admin/status/iptables": {
-		"title": "Firewall",
-		"order": 2,
-		"action": {
-			"type": "view",
-			"path": "status/iptables"
-		},
-		"depends": {
-			"acl": [ "luci-mod-status-firewall" ]
-		}
-	},
-
 	"admin/status/routes": {
-		"title": "Routes",
-		"order": 3,
+		"title": "Routing",
+		"order": 2,
 		"action": {
 			"type": "view",
 			"path": "status/routes"
 		},
 		"depends": {
 			"acl": [ "luci-mod-status-routes" ]
+		}
+	},
+
+	"admin/status/iptables": {
+		"title": "Firewall",
+		"order": 3,
+		"action": {
+			"type": "view",
+			"path": "status/iptables"
+		},
+		"depends": {
+			"acl": [ "luci-mod-status-firewall" ]
 		}
 	},
 

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -44,11 +44,12 @@
 	},
 
 	"luci-mod-status-routes": {
-		"description": "Grant access to the system route status",
+		"description": "Grant access to routing status",
 		"read": {
 			"file": {
 				"/sbin/ip -[46] neigh show": [ "exec" ],
-				"/sbin/ip -[46] route show table all": [ "exec" ]
+				"/sbin/ip -[46] route show table all": [ "exec" ],
+				"/sbin/ip -[46] rule show": [ "exec" ]
 			},
 			"ubus": {
 				"file": [ "exec" ]


### PR DESCRIPTION
Provide comprehensive status information for routing.
Rename the "Status > Routes" page to "Status > Routing".
Unify sorting for the "Status" and "Network" menus.
Add tabs for IPv4 and IPv6 and reorganize the contents.
Display routing rules and their priorities for each protocol.

Policy-based routing is an increasingly popular problem.
Netifd natively supports policy-based routing:
* The interface-specific options "ip4table" and "ip6table".
* The routing rules using the "rule" and "rule6" sections.
LuCI is missing the information about routing rules.

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>