### PR TITLE
luci-mod-status: fix description for luci-mod-status-channel_analysis

### DIFF
--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -57,7 +57,7 @@
 	},
 
 	"luci-mod-status-channel_analysis": {
-		"description": "Grant access to the system route status",
+		"description": "Grant access to wireless channel status",
 		"read": {
 			"ubus": {
 				"iwinfo": [ "info", "freqlist" ]


### PR DESCRIPTION
Update "modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json".
Fix incorrect description for "luci-mod-status-channel_analysis".

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>