### PR TITLE
luci-base: fix request timeout docstring

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -655,7 +655,7 @@
 		 * Provides a password for HTTP basic authentication.
 		 *
 		 * @property {number} [timeout]
-		 * Specifies the request timeout in seconds.
+		 * Specifies the request timeout in milliseconds.
 		 *
 		 * @property {boolean} [credentials=false]
 		 * Whether to include credentials such as cookies in the request.


### PR DESCRIPTION
The `timeout` is defined in milliseconds, not seconds.

TIL: My server API does not respond within 8ms.

Signed-off-by: Paul Spooren <mail@aparcar.org>