### PR TITLE
luci-app-attendedsysupgrade: add timeout and catch

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -66,13 +66,13 @@ function install_sysupgrade(url, keep, sha256) {
 						]);
 					} else {
 						displayStatus('warning spinning', E('p', _('Installing the sysupgrade. Do not unpower device!')));
-							L.resolveDefault(callUpgradeStart(keep), {}).then(response => {
-								if (keep) {
-									ui.awaitReconnect(window.location.host);
-								} else {
-									ui.awaitReconnect('192.168.1.1', 'openwrt.lan');
-								}
-							});
+						L.resolveDefault(callUpgradeStart(keep), {}).then(response => {
+							if (keep) {
+								ui.awaitReconnect(window.location.host);
+							} else {
+								ui.awaitReconnect('192.168.1.1', 'openwrt.lan');
+							}
+						});
 					}
 				});
 		});
@@ -228,7 +228,9 @@ function check_sysupgrade(server_url, current_version, target, board_name, packa
 	var advanced_mode = uci.get_first('attendedsysupgrade', 'client', 'advanced_mode') || 0;
 	var candidates = [];
 
-	fetch(server_url + "/api/latest")
+	request.get(server_url + "/api/latest", {
+			timeout: 8000
+		})
 		.then(response => response.json())
 		.then(response => {
 			if (current_version == "SNAPSHOT") {
@@ -320,6 +322,20 @@ function check_sysupgrade(server_url, current_version, target, board_name, packa
 					])
 				]);
 			}
+		})
+		.catch(error => {
+			ui.showModal(_('Error connecting to upgrade server'), [
+				E('p', {}, _('Could not reach API at "%s". Please try again later.'.format(server_url))),
+				E('pre', {}, error),
+				E('div', {
+					'class': 'right'
+				}, [
+					E('div', {
+						'class': 'btn',
+						'click': ui.hideModal
+					}, _('Close'))
+				])
+			]);
 		});
 }
 


### PR DESCRIPTION
If the upgrade server API does not respond, show an error message.
Fix #5222

While at it, minimal code linting

Signed-off-by: Paul Spooren <mail@aparcar.org>