### PR TITLE
luci-app-travelmate: sync with travelmate 2.0.5

### DIFF
--- a/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js
+++ b/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js
@@ -10,30 +10,32 @@
 /*
 	button handling
 */
-async function handleAction(ev) {
+function handleAction(ev) {
+	var ifaceValue;
 	if (ev === 'restart') {
-		fs.exec_direct('/etc/init.d/travelmate', [ev])
+		ifaceValue = String(uci.get('travelmate', 'global', 'trm_iface') || 'trm_wwan');
+		return fs.exec('/sbin/ifup', [ifaceValue])
+			.then(fs.exec('/etc/init.d/travelmate', ['restart']))
 	}
 	if (ev === 'setup') {
-		var ifaceValue = String(uci.get('travelmate', 'global', 'trm_iface') || '');
+		ifaceValue = String(uci.get('travelmate', 'global', 'trm_iface') || '');
 		L.ui.showModal(_('Interface Wizard'), [
 			E('p', _('To use Travelmate, you have to set up an uplink interface once. This wizard creates an IPv4- and an IPv6 alias network interface with all required network- and firewall settings.')),
 			E('div', { 'class': 'left', 'style': 'display:flex; flex-direction:column' }, [
 				E('label', { 'class': 'cbi-input-text', 'style': 'padding-top:.5em' }, [
-				E('input', { 'class': 'cbi-input-text', 'id': 'iface', 'placeholder': 'trm_wwan', 'value': ifaceValue, 'maxlength': '15', 'spellcheck': 'false' }, [
-				]),
-				'\xa0\xa0\xa0',
-				_('The uplink interface name')
-				]),
-				E('label', { 'class': 'cbi-input-text', 'style': 'padding-top:.5em' }, [
-				E('input', { 'class': 'cbi-input-text', 'id': 'zone', 'placeholder': 'wan', 'maxlength': '15', 'spellcheck': 'false' }),
-				'\xa0\xa0\xa0',
-				_('The firewall zone name')
+					E('input', { 'class': 'cbi-input-text', 'id': 'iface', 'placeholder': 'trm_wwan', 'value': ifaceValue, 'maxlength': '15', 'spellcheck': 'false' }),
+					'\xa0\xa0\xa0',
+					_('The uplink interface name')
 				]),
 				E('label', { 'class': 'cbi-input-text', 'style': 'padding-top:.5em' }, [
-				E('input', { 'class': 'cbi-input-text', 'id': 'metric', 'placeholder': '100', 'maxlength': '3', 'spellcheck': 'false' }),
-				'\xa0\xa0\xa0',
-				_('The interface metric')
+					E('input', { 'class': 'cbi-input-text', 'id': 'zone', 'placeholder': 'wan', 'maxlength': '15', 'spellcheck': 'false' }),
+					'\xa0\xa0\xa0',
+					_('The firewall zone name')
+				]),
+				E('label', { 'class': 'cbi-input-text', 'style': 'padding-top:.5em' }, [
+					E('input', { 'class': 'cbi-input-text', 'id': 'metric', 'placeholder': '100', 'maxlength': '3', 'spellcheck': 'false' }),
+					'\xa0\xa0\xa0',
+					_('The interface metric')
 				])
 			]),
 			E('div', { 'class': 'right' }, [
@@ -44,18 +46,18 @@ async function handleAction(ev) {
 				' ',
 				E('button', {
 					'class': 'cbi-button cbi-button-positive important',
-					'click': ui.createHandlerFn(this, function(ev) {
+					'click': ui.createHandlerFn(this, function (ev) {
 						var iface = document.getElementById('iface').value || 'trm_wwan',
-						zone = document.getElementById('zone').value || 'wan',
-						metric = document.getElementById('metric').value || '100';
-						L.resolveDefault(fs.exec_direct('/etc/init.d/travelmate', ['setup', iface, zone, metric]))
-						.then(function(res) {
-							if (res) {
-								ui.addNotification(null, E('p', res.trim() + '.'), 'error');
-							} else {
-								ui.addNotification(null, E('p', _('The uplink interface has been updated.')), 'info');
-							}
-						});
+							zone = document.getElementById('zone').value || 'wan',
+							metric = document.getElementById('metric').value || '100';
+						L.resolveDefault(fs.exec('/etc/init.d/travelmate', ['setup', iface, zone, metric]))
+							.then(function (res) {
+								if (res) {
+									ui.addNotification(null, E('p', res.trim() + '.'), 'error');
+								} else {
+									ui.addNotification(null, E('p', _('The uplink interface has been updated.')), 'info');
+								}
+							});
 						L.hideModal();
 					})
 				}, _('Save'))
@@ -67,28 +69,28 @@ async function handleAction(ev) {
 	if (ev === 'qrcode') {
 		return Promise.all([
 			uci.load('wireless')
-		]).then(function() {
+		]).then(function () {
 			var w_sid, w_device, w_ssid, w_enc, w_key, w_hidden, result,
-			w_sections = uci.sections('wireless', 'wifi-iface'),
-			optionsAP  = [E('option', { value: '' }, [_('-- AP Selection --')])];
+				w_sections = uci.sections('wireless', 'wifi-iface'),
+				optionsAP = [E('option', { value: '' }, [_('-- AP Selection --')])];
 			for (var i = 0; i < w_sections.length; i++) {
 				if (w_sections[i].mode === 'ap' && w_sections[i].disabled !== '1') {
-					w_sid    = i;
+					w_sid = i;
 					w_device = w_sections[i].device;
-					w_ssid   = w_sections[i].ssid;
+					w_ssid = w_sections[i].ssid;
 					optionsAP.push(E('option', { value: w_sid }, w_device + ', ' + w_ssid));
 				}
 			}
 			var selectAP = E('select', {
 				id: 'selectID',
 				class: 'cbi-input-select',
-				change: function(ev) {
+				change: function (ev) {
 					result = document.getElementById('qrcode');
 					if (document.getElementById("selectID").value) {
-						w_sid    = document.getElementById("selectID").value;
-						w_ssid   = w_sections[w_sid].ssid;
-						w_enc    = w_sections[w_sid].encryption;
-						w_key    = w_sections[w_sid].key;
+						w_sid = document.getElementById("selectID").value;
+						w_ssid = w_sections[w_sid].ssid;
+						w_enc = w_sections[w_sid].encryption;
+						w_key = w_sections[w_sid].key;
 						w_hidden = (w_sections[w_sid].hidden == 1 ? 'true' : 'false');
 						if (w_enc.startsWith('psk')) {
 							w_enc = 'WPA';
@@ -97,17 +99,17 @@ async function handleAction(ev) {
 							w_enc = 'nopass';
 							w_key = 'nokey';
 						}
-						L.resolveDefault(fs.exec_direct('/usr/bin/qrencode', ['--inline', '--8bit', '--type=SVG', '--output=-', 'WIFI:S:' + w_ssid + ';T:' + w_enc + ';P:' + w_key + ';H:' + w_hidden + ';']), null).then(function(res) {
+						L.resolveDefault(fs.exec_direct('/usr/bin/qrencode', ['--inline', '--8bit', '--type=SVG', '--output=-', 'WIFI:S:' + w_ssid + ';T:' + w_enc + ';P:' + w_key + ';H:' + w_hidden + ';']), null).then(function (res) {
 							if (res) {
 								result.innerHTML = res.trim();
 							}
 							else {
-								result.innerHTML = _('The QR-Code could not be generated!');
+								result.textContent = _('The QR-Code could not be generated!');
 							}
 						});
 					}
 					else {
-						result.innerHTML = '';
+						result.textContent = '';
 					}
 				}
 			}, optionsAP);
@@ -135,13 +137,13 @@ async function handleAction(ev) {
 }
 
 return view.extend({
-	load: function() {
+	load: function () {
 		return Promise.all([
 			uci.load('travelmate')
 		]);
 	},
 
-	render: function(result) {
+	render: function (result) {
 		var m, s, o;
 
 		m = new form.Map('travelmate', 'Travelmate', _('Configuration of the travelmate package to enable travel router functionality. \
@@ -151,11 +153,11 @@ return view.extend({
 		/*
 			poll runtime information
 		*/
-		pollData: poll.add(function() {
-			return L.resolveDefault(fs.stat('/tmp/trm_runtime.json'), null).then(function(res) {
+		pollData: poll.add(function () {
+			return L.resolveDefault(fs.stat('/tmp/trm_runtime.json'), null).then(function (res) {
 				var status = document.getElementById('status');
 				if (res) {
-					L.resolveDefault(fs.read_direct('/tmp/trm_runtime.json'), null).then(function(res) {
+					L.resolveDefault(fs.read_direct('/tmp/trm_runtime.json'), null).then(function (res) {
 						if (res) {
 							var info = JSON.parse(res);
 							if (status && info) {
@@ -206,12 +208,6 @@ return view.extend({
 						}
 					});
 				}
-				else {
-					if (status && status.classList.contains("spinning")) {
-						status.textContent = '-';
-						status.classList.remove("spinning");
-					}
-				}
 			});
 		}, 1);
 
@@ -219,53 +215,68 @@ return view.extend({
 			runtime information and buttons
 		*/
 		s = m.section(form.NamedSection, 'global');
-		s.render = L.bind(function(view, section_id) {
+		s.render = L.bind(function (view, section_id) {
 			return E('div', { 'class': 'cbi-section' }, [
-				E('h3', _('Information')), 
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Status / Version')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'status', 'style': 'font-weight: bold;margin-bottom:5px;color:#37c' },'-')]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Station ID')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'station_id', 'style': 'font-weight: bold;margin-bottom:5px;color:#37c' },'-')]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Station MAC')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'station_mac', 'style': 'font-weight: bold;margin-bottom:5px;color:#37c' },'-')]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Station Interface')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'station_interface', 'style': 'font-weight: bold;margin-bottom:5px;color:#37c' },'-')]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('WPA Flags')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'wpa_flags', 'style': 'font-weight: bold;margin-bottom:5px;color:#37c' },'-')]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Run Flags')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'run_flags', 'style': 'font-weight: bold;margin-bottom:5px;color:#37c' },'-')]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Ext. Hooks')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'ext_hooks', 'style': 'font-weight: bold;margin-bottom:5px;color:#37c' },'-')]),
-				E('div', { 'class': 'cbi-value', 'style': 'margin-bottom:5px' }, [
-				E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Last Run')),
-				E('div', { 'class': 'cbi-value-field', 'id': 'run', 'style': 'font-weight: bold;margin-bottom:5px;color:#37c' },'-')]),
+				E('h3', _('Information')),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Status / Version')),
+					E('div', { 'class': 'cbi-value-field spinning', 'id': 'status', 'style': 'color:#37c' }, '\xa0')
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Station ID')),
+					E('div', { 'class': 'cbi-value-field', 'id': 'station_id', 'style': 'color:#37c' }, '-')
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Station MAC')),
+					E('div', { 'class': 'cbi-value-field', 'id': 'station_mac', 'style': 'color:#37c' }, '-')
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Station Interface')),
+					E('div', { 'class': 'cbi-value-field', 'id': 'station_interface', 'style': 'color:#37c' }, '-')
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('WPA Flags')),
+					E('div', { 'class': 'cbi-value-field', 'id': 'wpa_flags', 'style': 'color:#37c' }, '-')
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Run Flags')),
+					E('div', { 'class': 'cbi-value-field', 'id': 'run_flags', 'style': 'color:#37c' }, '-')
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Ext. Hooks')),
+					E('div', { 'class': 'cbi-value-field', 'id': 'ext_hooks', 'style': 'color:#37c' }, '-')
+				]),
+				E('div', { 'class': 'cbi-value' }, [
+					E('label', { 'class': 'cbi-value-title', 'style': 'padding-top:0rem' }, _('Last Run')),
+					E('div', { 'class': 'cbi-value-field', 'id': 'run', 'style': 'color:#37c' }, '-')
+				]),
 				E('div', { class: 'right' }, [
 					E('button', {
 						'class': 'cbi-button cbi-button-apply',
 						'id': 'btn_suspend',
-						'click': ui.createHandlerFn(this, function() {
-							L.resolveDefault(fs.stat('/usr/bin/qrencode'), null).then(function(res) {
+						'click': ui.createHandlerFn(this, function () {
+							L.resolveDefault(fs.stat('/usr/bin/qrencode'), null).then(function (res) {
 								if (res) {
 									return handleAction('qrcode');
 								}
 								return ui.addNotification(null, E('p', _('Please install the separate \'qrencode\' package.')), 'info');
 							})
 						})
-					}, [ _('AP QR-Codes...') ]),
+					}, [_('AP QR-Codes...')]),
 					'\xa0',
 					E('button', {
-						'class': 'cbi-button cbi-button-reset',
-						'click': ui.createHandlerFn(this, function() {
+						'class': 'cbi-button cbi-button-negative',
+						'click': ui.createHandlerFn(this, function () {
+							return handleAction('restart');
+						})
+					}, [_('Restart Interface')]),
+					'\xa0',
+					E('button', {
+						'class': 'cbi-button cbi-button-negative',
+						'click': ui.createHandlerFn(this, function () {
 							return handleAction('setup');
 						})
-					}, [ _('Interface Wizard...') ])
+					}, [_('Interface Wizard...')])
 				])
 			]);
 		}, o, this);
@@ -276,9 +287,8 @@ return view.extend({
 		*/
 		s = m.section(form.NamedSection, 'global', 'travelmate', _('Settings'));
 		s.addremove = false;
-		s.tab('general',  _('General Settings'));
+		s.tab('general', _('General Settings'));
 		s.tab('additional', _('Additional Settings'));
-		s.tab('adv_vpn', _('VPN Settings'), _('Please note: VPN connections require the separate setup of the <em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>'));
 		s.tab('adv_email', _('E-Mail Settings'), _('Please note: E-Mail notifications require the separate setup of the <em>mstmp</em> package.<br /><p>&#xa0;</p>'));
 
 		/*
@@ -290,8 +300,11 @@ return view.extend({
 		o = s.taboption('general', form.Flag, 'trm_debug', _('Verbose Debug Logging'), _('Enable verbose debug logging in case of any processing errors.'));
 		o.rmempty = false;
 
-		o = s.taboption('general', form.Value, 'trm_radio', _('Radio Selection'), _('Restrict travelmate to a single radio or change the overall scanning order (e.g. \'radio1 radio0\').'));
-		o.placeholder = 'radio0';
+		o = s.taboption('general', form.Value, 'trm_radio', _('Radio Selection'), _('Restrict travelmate to a single radio or change the overall scanning order.'));
+		o.value('radio0', _('use the first radio only (radio0)'));
+		o.value('radio1', _('use the second radio only (radio1)'));
+		o.value('radio0 radio1', _('use both radios, normal sort order (radio0 radio1)'));
+		o.value('radio1 radio0', _('use both radios, reverse sort order (radio1 radio0)'));
 		o.rmempty = true;
 
 		o = s.taboption('general', form.Flag, 'trm_captive', _('Captive Portal Detection'), _('Check the internet availability, handle captive portal redirections and keep the uplink connection \'alive\'.'));
@@ -307,13 +320,19 @@ return view.extend({
 		o.default = 1;
 		o.rmempty = false;
 
+		o = s.taboption('general', form.Flag, 'trm_randomize', _('Randomize MAC Addresses'), _('Generate a random unicast MAC address for each uplink connection.'));
+		o.default = 0;
+		o.rmempty = false;
+
 		o = s.taboption('general', form.Flag, 'trm_autoadd', _('AutoAdd Open Uplinks'), _('Automatically add open uplinks like hotel captive portals to your wireless config.'));
 		o.default = 0;
 		o.rmempty = false;
 
-		o = s.taboption('general', form.Flag, 'trm_randomize', _('Randomize MAC Addresses'), _('Generate a random unicast MAC address for each uplink connection.'));
-		o.default = 0;
-		o.rmempty = false;
+		o = s.taboption('general', form.Value, 'trm_maxautoadd', _('Limit AutoAdd'), _('Limit the maximum number of automatically added open uplinks. To disable this limitation set it to \'0\'.'));
+		o.depends('trm_autoadd', '1');
+		o.placeholder = '5';
+		o.datatype = 'range(0,30)';
+		o.rmempty = true;
 
 		/*
 			additional settings tab
@@ -349,19 +368,20 @@ return view.extend({
 		o.rmempty = true;
 
 		o = s.taboption('additional', form.ListValue, 'trm_captiveurl', _('Captive Portal URL'), _('The selected URL will be used for connectivity- and captive portal checks.'));
-		o.value('http://captive.apple.com', 'Apple (default)');
+		o.value('http://detectportal.firefox.com', 'Firefox (default)');
 		o.value('http://connectivity-check.ubuntu.com', 'Ubuntu');
+		o.value('http://captive.apple.com', 'Apple');
 		o.value('http://connectivitycheck.android.com/generate_204', 'Google');
 		o.value('http://www.msftncsi.com/ncsi.txt', 'Microsoft');
 		o.optional = true;
 		o.rmempty = true;
 
 		o = s.taboption('additional', form.ListValue, 'trm_useragent', _('User Agent'), _('The selected user agent will be used for connectivity- and captive portal checks.'));
-		o.value('Mozilla/5.0 (X11; Linux x86_64; rv:80.0) Gecko/20100101 Firefox/80.0', 'Firefox (default)');
-		o.value('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36', 'Chromium');
-		o.value('Mozilla/5.0 (iPhone; CPU iPhone OS 13_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/85.0.4183.92 Mobile/15E148 Safari/604.1', 'Safari');
-		o.value('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 Safari/537.36 Edg/85.0.564.44', 'Edge');
-		o.value('Mozilla/5.0 (Linux; Android 10; SM-G970F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36 OPR/59.1.2926.54067', 'Opera');
+		o.value('Mozilla/5.0 (X11; Linux x86_64; rv:90.0) Gecko/20100101 Firefox/90.0', 'Firefox (default)');
+		o.value('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36', 'Chromium');
+		o.value('Mozilla/5.0 (Macintosh; Intel Mac OS X 11_5_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Safari/605.1.15', 'Safari');
+		o.value('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36 Edg/92.0.902.55', 'Edge');
+		o.value('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.131 Safari/537.36 OPR/77.0.4054.277', 'Opera');
 		o.optional = true;
 		o.rmempty = true;
 
@@ -372,30 +392,6 @@ return view.extend({
 		o.value('10', 'Less Priority');
 		o.value('19', 'Least Priority');
 		o.optional = true;
-		o.rmempty = true;
-
-		/*
-			advanced vpn settings tab
-		*/
-		o = s.taboption('adv_vpn', form.Flag, 'trm_vpn', _('VPN Hook'), _('Automatically handle VPN (re-) connections.'));
-		o.rmempty = false;
-
-		o = s.taboption('adv_vpn', form.ListValue, 'trm_vpnservice', _('VPN Service'));
-		o.depends('trm_vpn', '1');
-		o.value('wireguard');
-		o.value('openvpn');
-		o.rmempty = true;
-
-		o = s.taboption('adv_vpn', widgets.NetworkSelect, 'trm_vpniface', _('VPN Interface'), _('The logical vpn network interface, e.g. \'wg0\' or \'tun0\'.'));
-		o.depends('trm_vpn', '1');
-		o.unspecified = false;
-		o.nocreate = true;
-		o.rmempty = true;
-
-		o = s.taboption('adv_vpn', widgets.DeviceSelect, 'trm_landevice', _('LAN Device'), _('The lan network device, e.g. \'br-lan\'.'));
-		o.depends('trm_vpn', '1');
-		o.unspecified = false;
-		o.nocreate = true;
 		o.rmempty = true;
 
 		/*

--- a/applications/luci-app-travelmate/po/ar/travelmate.po
+++ b/applications/luci-app-travelmate/po/ar/travelmate.po
@@ -11,101 +11,108 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.5.1\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "المصادقة"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "قناة"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -115,149 +122,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "احذف هذه الشبكة"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "جهاز"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "إلغاء"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "اسحب لإعادة ترتيب"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "ملف تعريف البريد الإلكتروني"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "عنوان مستقبل البريد الإلكتروني"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "عنوان مرسل البريد الإلكتروني"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "موضوع البريد الإلكتروني"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "طريقة EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "تحرير"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "قم بتحرير هذه الشبكة"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "تمكين التسجيل المطول لتصحيح الأخطاء في حالة وجود أي أخطاء في المعالجة."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "مفعل"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "التشفير"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "الاعدادات العامة"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -265,69 +268,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "معلومة"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "آخر تشغيل"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "عرض السجل"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -335,15 +348,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -351,236 +368,237 @@ msgstr ""
 msgid "Overview"
 msgstr "نظرة عامة"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "كلمة المرور"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "كلمة مرور المفتاح الخاص"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "المسار إلى CA-Certificate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "مسار شهادة العميل"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "المسار إلى المفتاح الخاص"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "تشغيل الإشارات"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "إحفض"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "إعدادات"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "الحالة / الإصدار"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -590,22 +608,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -613,49 +637,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "تأخير الزناد"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "تسجيل مطول للتصحيح"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -663,101 +691,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -765,20 +793,39 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "لا شيء"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Delete this network"
+#~ msgstr "احذف هذه الشبكة"
 
 #~ msgid "Action"
 #~ msgstr "إجراء"

--- a/applications/luci-app-travelmate/po/bg/travelmate.po
+++ b/applications/luci-app-travelmate/po/bg/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Откажи"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Запази"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,17 +792,33 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""

--- a/applications/luci-app-travelmate/po/bn_BD/travelmate.po
+++ b/applications/luci-app-travelmate/po/bn_BD/travelmate.po
@@ -4,101 +4,108 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -108,149 +115,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -258,69 +261,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -328,15 +341,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -344,236 +361,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -583,22 +601,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -606,49 +630,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -656,101 +684,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -758,17 +786,33 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""

--- a/applications/luci-app-travelmate/po/ca/travelmate.po
+++ b/applications/luci-app-travelmate/po/ca/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.1\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Autenticació"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Script d’inici de sessió automàtic"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "Detecció de portals captius"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "Límit de connexions"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Dispositiu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Adreça del destinatari de correu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Edita"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Xifratge"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Paràmetres generals"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Darrera execució"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Visió de conjunt"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Contrasenya"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Contrasenya de la clau privada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Camí cap al certificat CA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Camí cap al certificat de client"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Camí cap a la clau privada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (amagat)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Desar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Paràmetres"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Enregistrament detallat de depuració"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,19 +792,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"

--- a/applications/luci-app-travelmate/po/cs/travelmate.po
+++ b/applications/luci-app-travelmate/po/cs/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- výběr přístupového bodu --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "QR kódy AP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Další nastavení"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Ověřování se"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Kanál"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Zařízení"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "E-mailový profil"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Adresa odesílatele e-mailu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Téma e-mailu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Metoda EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Upravit"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Zapnuto"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Šifrování"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Obecná nastavení"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Informace"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Poslední spuštění"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Zobrazení protokolu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Přehled"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Heslo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Heslo privátního klíče"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Cesta k certifikátu CA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Cesta k certifikátu klienta"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Cesta k privátnímu klíči"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Odstranit"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Uložit"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Prodleva spuštění"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,19 +792,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"
@@ -826,9 +870,6 @@ msgstr ""
 #~ "you."
 #~ msgstr ""
 #~ "Volby pro další doplnění pro případ, že výchozí hodnoty nejsou vhodné."
-
-#~ msgid "Remove"
-#~ msgstr "Odstranit"
 
 #~ msgid "Restart"
 #~ msgstr "Restart"

--- a/applications/luci-app-travelmate/po/de/travelmate.po
+++ b/applications/luci-app-travelmate/po/de/travelmate.po
@@ -10,45 +10,49 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- AP-Auswahl --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "AP QR-Codes..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "Uplink hinzufügen %q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "Uplink hinzufügen..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr "Zusätzliche Trigger-Verzögerung in Sekunden, bevor Travelmate startet."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Authentifizierung"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Auto-Login-Skript"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr "Automatisch offene Uplinks hinzufügen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
@@ -57,7 +61,7 @@ msgstr ""
 "nach fehlgeschlagenen Anmeldeversuchen. <br /> Die Standardeinstellung '0' "
 "deaktiviert diese Funktion."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
@@ -65,7 +69,7 @@ msgstr ""
 "Füge der Netzwerk-Konfiguration automatisch offene Uplinks wie Hotel-"
 "HotSpots hinzu."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
@@ -74,39 +78,42 @@ msgstr ""
 "zeitgesteuerte Verbindungen. <br /> Die Standardeinstellung '0' deaktiviert "
 "diese Funktion."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "Automatisch den Auf- und Abbau von VPN-Verbindungen regeln."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr "Puffergröße in Bytes, um die Scan-Resultate aufzubereiten."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr "CHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "Captive-Portal-Erkennung"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr "Captive-Portal-URL"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Kanal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
@@ -114,7 +121,7 @@ msgstr ""
 "Überprüfen Sie die Internetverfügbarkeit, bearbeiten Sie Captive-Portal-"
 "Umleitungen und halten Sie die Uplink-Verbindung \"am Leben\"."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -124,135 +131,131 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr "Verbindungsende"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr "Verbindungsende-Ablauf"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "Verbindungslimit"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr "Verbindungsstart"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr "Verbindungsstart-Ablauf"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "Löschen"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Dieses Netzwerk löschen"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Gerät"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "Gerätename"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Verwerfen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Ziehen zur Neuanordnung"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr "E-Mail-Hook"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "E-Mail-Profil"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "E-Mail Empfängeradresse"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "E-Mail Absenderadresse"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr "E-Mail-Einstellungen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "E-Mail-Thema"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr "EAP-GTC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "EAP-Methode"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr "EAP-TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Dieses Netzwerk bearbeiten"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr "Travelmate-Service aktivieren."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Aktiviere das ausführliche Anwendungs-Logging bei Verarbeitungsfehlern."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Verschlüsselung"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr "Ext. Hooks"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
@@ -260,16 +263,16 @@ msgstr ""
 "Externe Skriptreferenz, die für automatisierte Captive-Portal-Anmeldungen "
 "aufgerufen wird."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "SCHNELL"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 "Generieren Sie für jede Uplink-Verbindung eine zufällige Unicast-MAC-Adresse."
@@ -278,65 +281,75 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr "Zugriff auf LuCI App Travelmate gewähren"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 "Wie lange Travelmate auf eine erfolgreiche WLAN-Uplink-Verbindung warten "
 "sollte."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "Identifizieren"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "BSSID ignorieren"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Informationen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr "Name der Schnittstelle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "Zeitüberschreitung der Schnittstelle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "Schnittstellenassistent"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr "Schnittstellen-Assistent ..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr "LAN-Gerät"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Letzter Durchgang"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Protokollansicht"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
@@ -344,7 +357,7 @@ msgstr ""
 "Mindestschwelle für die Signalqualität in Prozent für bedingte Uplink-"
 "Verbindungen/Unterbrechungen."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "Netzfehlerprüfung"
 
@@ -352,15 +365,19 @@ msgstr "Netzfehlerprüfung"
 msgid "No travelmate related logs yet!"
 msgstr "Es existieren noch keine Travelmate-bezogenen Protokolle!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "Gesamt-Timeout"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "Gesamtzeitlimit für Wiederholungen in Sekunden."
 
@@ -368,7 +385,7 @@ msgstr "Gesamtzeitlimit für Wiederholungen in Sekunden."
 msgid "Overview"
 msgstr "Übersicht"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
@@ -379,46 +396,46 @@ msgstr ""
 "per drag &#38; drop ablegen und nach neuen suchen. Der aktuell verwendete "
 "Uplink wird blau hervorgehoben."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Passwort"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Passwort des privaten Schlüssels"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Pfad zum CA-Zertifikat"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Pfad zum Client-Zertifikat"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Pfad zum Privaten Schlüssel"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr "Bitte installieren Sie das separate 'qrencode'-Paket."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
@@ -426,19 +443,11 @@ msgstr ""
 "Bitte beachten Sie: Für E-Mail-Benachrichtigungen muss das Paket <em>mstmp</"
 "em> separat eingerichtet werden.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-"Bitte beachten Sie: Für VPN-Verbindungen muss das Paket <em>Wireguard</em> "
-"oder <em>OpenVPN</em> separat eingerichtet werden.<br /><p>&#xa0;</p>"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "ProActive-Uplink-Switch"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
@@ -446,29 +455,37 @@ msgstr ""
 "Trotz einer bereits bestehenden Verbindung proaktiv scannen und zu einem "
 "Uplink mit höherer Priorität wechseln."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 "Profil, das von 'msmtp' zur Benachrichtigung von Travelmate-E-Mails "
 "verwendet wird."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr "QR-Code Übersicht"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "Funkmodulauswahl"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "MAC-Adressen randomisieren"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr "Empfängeradresse für Travelmate-Benachrichtigungs-E-Mails."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Entfernen"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
@@ -476,76 +493,77 @@ msgstr ""
 "Legen Sie den QR-Code des ausgewählten Access Points vor, um die WLAN-"
 "Anmeldeinformationen bequem auf Ihre Mobilgeräte zu übertragen."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "Scan wiederholen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
-"Beschränken Sie Travelmate auf ein einzelnes Funkmodul oder ändern Sie die "
-"gesamte Scanreihenfolge (z. B. 'radio1 radio0')."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "Wiederholungslimit für eine Verbindung zu einem Uplink."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "Laufzeit-Flags"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (versteckt)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Speichern"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "Scan-Puffergröße"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr "Weiterscannen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr "Skriptargumente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr "Absenderadresse für Travelmate-Benachrichtigungs-E-Mails."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 "Sendet nach jeder erfolgreichen Uplink-Verbindung Benachrichtigungs-E-Mails."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "Servicepriorität"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "Signalqualitätsschwelle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
@@ -553,72 +571,68 @@ msgstr ""
 "Durch Leerzeichen getrennte Liste zusätzlicher Argumente, die an das "
 "automatische Anmeldeskript übergeben werden, z.B. Benutzername und Kennwort"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr "Starten des drahtlosen Scans am '"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "Stations-ID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "Stationsschnittstelle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "Stations-MAC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Status / Version"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "Stärke"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "Der QR-Code konnte nicht generiert werden!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "Der Name der Firewall-Zone"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr "Die Schnittstellenmetrik"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr "Das LAN-Netzwerkgerät, z.B. 'br-lan'."
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr "Die logische VPN-Netzwerkschnittstelle, z.B. 'wg0' oder 'tun0'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 "Die ausgewählte URL wird für Konnektivitäts- und Captive-Portal-Prüfungen "
 "verwendet."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr "Die ausgewählte Priorität wird für Travelmate-Prozesse verwendet."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -632,15 +646,21 @@ msgstr ""
 "Die Syslog-Ausgabe, die nur für Travelmate-bezogene Nachrichten vorgefiltert "
 "ist."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr "Die Uplink-Schnittstelle wurde aktualisiert."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr "Der Name der Uplink-Schnittstelle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
@@ -651,7 +671,7 @@ msgstr ""
 "Alias-Netzwerkschnittstelle mit allen erforderlichen Netzwerk- und Firewall-"
 "Einstellungen."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr "Thema für Travelmate-Benachrichtigungs-E-Mails."
 
@@ -659,49 +679,53 @@ msgstr "Thema für Travelmate-Benachrichtigungs-E-Mails."
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr "Travelmate-Einstellungen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "Fehlende Internetverfügbarkeit als Fehler behandeln."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Verzögerung der Trigger-Bedingung"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "User-Agent"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr "VPN-Hook"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "VPN-Schnittstelle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "VPN-Dienst"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr "VPN-Einstellungen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Ausführliche Debug-Protokollierung"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr "WPA Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr "WPA Ent. (TKIP)"
 
@@ -709,101 +733,101 @@ msgstr "WPA Ent. (TKIP)"
 msgid "WPA Flags"
 msgstr "WPA-Flags"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr "WPA Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr "WPA Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr "WPA Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr "WPA/WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr "WPA/WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr "WPA/WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr "WPA/WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr "WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr "WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr "WPA2 Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr "WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr "WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr "WPA2/WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr "WPA2/WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr "WPA2/WPA3 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr "WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr "WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr "WPA3 OWE (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr "WPA3 Pers. (SAE)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "Drahtloser Scan"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr "Drahtlose Einstellungen"
 
@@ -811,20 +835,65 @@ msgstr "Drahtlose Einstellungen"
 msgid "Wireless Stations"
 msgstr "Drahtlose Stationen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr "auth=MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "auth=PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "kein"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "Automatisch den Auf- und Abbau von VPN-Verbindungen regeln."
+
+#~ msgid "Del"
+#~ msgstr "Löschen"
+
+#~ msgid "Delete this network"
+#~ msgstr "Dieses Netzwerk löschen"
+
+#~ msgid "LAN Device"
+#~ msgstr "LAN-Gerät"
+
+#~ msgid ""
+#~ "Please note: VPN connections require the separate setup of the "
+#~ "<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Bitte beachten Sie: Für VPN-Verbindungen muss das Paket <em>Wireguard</"
+#~ "em> oder <em>OpenVPN</em> separat eingerichtet werden.<br /><p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Restrict travelmate to a single radio or change the overall scanning "
+#~ "order (e.g. 'radio1 radio0')."
+#~ msgstr ""
+#~ "Beschränken Sie Travelmate auf ein einzelnes Funkmodul oder ändern Sie "
+#~ "die gesamte Scanreihenfolge (z. B. 'radio1 radio0')."
+
+#~ msgid "The lan network device, e.g. 'br-lan'."
+#~ msgstr "Das LAN-Netzwerkgerät, z.B. 'br-lan'."
 
 #~ msgid ""
 #~ "Configuration of the travelmate package to to enable travel router "
@@ -919,9 +988,6 @@ msgstr "kein"
 #~ msgstr ""
 #~ "Optionen für weitere Optimierungen, falls die Standardeinstellungen nicht "
 #~ "für Sie geeignet sind."
-
-#~ msgid "Remove"
-#~ msgstr "Entfernen"
 
 #~ msgid "Restart"
 #~ msgstr "Neustart"

--- a/applications/luci-app-travelmate/po/el/travelmate.po
+++ b/applications/luci-app-travelmate/po/el/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Επιπρόσθετες ρυθμίσεις"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Συσκευή"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Ενεργοποιήθηκε"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Γενικές ρυθμίσεις"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,19 +792,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Advanced"

--- a/applications/luci-app-travelmate/po/en/travelmate.po
+++ b/applications/luci-app-travelmate/po/en/travelmate.po
@@ -4,101 +4,108 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -108,149 +115,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -258,69 +261,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -328,15 +341,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -344,236 +361,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -583,22 +601,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -606,49 +630,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -656,101 +684,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -758,17 +786,33 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""

--- a/applications/luci-app-travelmate/po/es/travelmate.po
+++ b/applications/luci-app-travelmate/po/es/travelmate.po
@@ -13,47 +13,51 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- Selección de AP --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "Códigos QR del AP..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "Agregar enlace ascendente %q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "Agregar enlace ascendente..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Configuración adicional"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 "Demora adicional del disparador en segundos antes de que comience el "
 "procesamiento de travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Autenticación"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Script de inicio de sesión automático"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr "Auto agregar enlaces ascendentes abiertos"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
@@ -62,7 +66,7 @@ msgstr ""
 "minutos, p.e. después de intentos fallidos de inicio de sesión.<br/> El "
 "valor predeterminado de '0' desactiva esta función."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
@@ -70,7 +74,7 @@ msgstr ""
 "Agregue automáticamente enlaces ascendentes abiertos como portales cautivos "
 "de hotel a su configuración inalámbrica."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
@@ -79,40 +83,43 @@ msgstr ""
 "minutos, p.e. para conexiones temporizadas.<br/> El valor predeterminado de "
 "'0' desactiva esta función."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "Maneja automáticamente las (rec-) conexiones VPN."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 "Tamaño del búfer en bytes para preparar resultados de escaneo cercanos."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr "CHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "Detección de portal cautivo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr "URL del portal cautivo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Canal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
@@ -120,7 +127,7 @@ msgstr ""
 "Verifique la disponibilidad de Internet, maneje las redirecciones de los "
 "portales cautivos y mantenga la conexión de enlace ascendente 'viva'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -137,136 +144,132 @@ msgstr ""
 "\"Asistente de interfaz\" para realizar los ajustes necesarios de red y "
 "firewall."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr "Fin de conexión"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr "Caducidad de fin de conexión"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "Límite de conexión"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr "Inicio de conexión"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr "Vencimiento de inicio de conexión"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "Elim."
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Eliminar esta red"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Dispositivo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "Nombre del dispositivo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Arrastrar para reordenar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr "Gancho de correo electrónico"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "Perfil de correo electrónico"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Dirección del destinatario de correo electrónico"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Dirección del remitente de correo electrónico"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr "Configuraciones del correo electrónico"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Tema del correo electrónico"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr "EAP-GTC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr "EAP-TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Editar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Editar esta red"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr "Activar el servicio TravelMate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activar el registro de depuración detallado en caso de errores de "
 "procesamiento."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Activado"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Encriptación"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr "Manos ext."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
@@ -274,16 +277,16 @@ msgstr ""
 "Referencia de script externo que se llamará para inicios de sesión cautivos "
 "automatizados del portal."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "RÁPIDO"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Configuración general"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 "Genere una dirección MAC de unidifusión aleatoria para cada conexión de "
@@ -293,65 +296,75 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr "Otorgar acceso a la aplicación Travelmate de LuCI"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 "Cuánto tiempo debe esperar travelmate para una conexión de enlace wlan sea "
 "exitosa."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "Identificar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "Ignorar BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Información"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr "Nombre de interfaz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "Tiempo de espera de la interfaz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "Asistente de interfaz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr "Asistente de interfaz..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr "Dispositivo LAN"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Último inicio"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Vista de registro"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
@@ -359,7 +372,7 @@ msgstr ""
 "Umbral de calidad de señal mínimo como porcentaje para conexiones (dis-) de "
 "enlace condicional."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "Comprobación de error neto"
 
@@ -367,15 +380,19 @@ msgstr "Comprobación de error neto"
 msgid "No travelmate related logs yet!"
 msgstr "¡Aún no hay registros relacionados con Travelmate!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "Tiempo de espera total"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "Tiempo de espera de reintento global en segundos."
 
@@ -383,7 +400,7 @@ msgstr "Tiempo de espera de reintento global en segundos."
 msgid "Overview"
 msgstr "Visión general"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
@@ -394,46 +411,46 @@ msgstr ""
 "existentes arrastrando y soltando y buscando nuevos. El enlace ascendente "
 "utilizado actualmente se resalta en azul."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Contraseña"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Contraseña de clave privada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Ruta al certificado CA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Ruta al certificado del cliente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Ruta a la clave privada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr "Instale el paquete 'qrencode' por separado."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
@@ -441,19 +458,11 @@ msgstr ""
 "Tenga en cuenta: las notificaciones por correo electrónico requieren la "
 "configuración por separado del paquete <em>mstmp</em>.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-"Tenga en cuenta: las conexiones VPN requieren la configuración por separado "
-"del paquete <em>Wireguard</em> u <em>OpenVPN</em>.<br /><p>&#xa0;</p>"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "Interruptor de enlace proactivo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
@@ -461,31 +470,39 @@ msgstr ""
 "Escanee de forma proactiva y cambie a un enlace de mayor prioridad, a pesar "
 "de una conexión ya existente."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 "Perfil utilizado por 'msmtp' para los correos electrónicos de notificación "
 "de travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr "Descripción general del código QR"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "Selección de radio"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "Aleatorizar direcciones MAC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 "Dirección del destinatario de los correos electrónicos de notificación de "
 "travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Eliminar"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
@@ -493,79 +510,80 @@ msgstr ""
 "Genere el código QR del AP seleccionado para transferir cómodamente las "
 "credenciales WLAN a sus dispositivos móviles."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "Repetir escaneo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
-"Restrinja Travelmate a una sola radio o cambie el orden de exploración "
-"general (p.e., 'radio1 radio0')."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "Vuelva a intentar el límite para conectarse a un enlace ."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "Ejecutar banderas"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (oculto)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "Tamaño del búfer de escaneo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr "Escanear en"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr "Argumentos de script"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 "Dirección del remitente para los correos electrónicos de notificación de "
 "Travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 "Envía notificaciones por correo electrónico después de cada conexión de "
 "enlace ascendente exitosa."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "Prioridad de servicio"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "Umbral de calidad de señal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
@@ -574,73 +592,69 @@ msgstr ""
 "de comandos de inicio de sesión automático, es decir, nombre de usuario y "
 "contraseña"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr "Iniciando escaneo inalámbrico en '"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "ID de estación"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "Interfaz de estación"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "MAC de la estación"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Estado/Versión"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "Intensidad"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "¡No se pudo generar el código QR!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "El nombre de la zona de firewall"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr "La métrica de la interfaz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr "El dispositivo de red lan, p.ej. 'br-lan'."
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr "La interfaz de red lógica vpn, p.ej. 'wg0' o 'tun0'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 "La URL seleccionada se utilizará para las comprobaciones de conectividad y "
 "del portal cautivo."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 "La prioridad seleccionada se utilizará para los procesos de Travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -654,15 +668,21 @@ msgstr ""
 "La salida de syslog, prefiltrada solo para mensajes relacionados con "
 "travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr "La interfaz de enlace ascendente se ha actualizado."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr "El nombre de la interfaz de enlace ascendente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
@@ -672,7 +692,7 @@ msgstr ""
 "una vez. Este asistente crea una interfaz de red de alias IPv4 e IPv6 con "
 "todas las configuraciones de red y cortafuegos requeridas."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr "Tema para correos electrónicos de notificación de compañeros de viaje."
 
@@ -680,49 +700,53 @@ msgstr "Tema para correos electrónicos de notificación de compañeros de viaje
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr "Configuración de Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "Trate la falta de disponibilidad de Internet como un error."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Retraso de disparo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "Agente de usuario"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr "Gancho VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "Interfaz VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "Servicio VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr "Configuración de VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Registro de depuración detallado"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr "Encriptación WPA (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr "Encriptación WPA (TKIP)"
 
@@ -730,101 +754,101 @@ msgstr "Encriptación WPA (TKIP)"
 msgid "WPA Flags"
 msgstr "Banderas WPA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr "WPA personal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr "WPA personal (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr "WPA personal (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr "Encriptación WPA/WPA2 (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr "Encriptación WPA/WPA2 (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr "Encriptación WPA/WPA2 (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr "WPA/WPA2 personal (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr "Encriptación WPA2 (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr "Encriptación WPA2 (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr "WPA2 personal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr "WPA2 personal (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr "WPA2 personal (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr "Encriptación WPA2/WPA3"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr "WPA2/WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr "WPA2/WPA3 personal (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr "Encriptación WPA3"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr "WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr "WPA3 OWE (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr "WPA3 personal (SAE)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "Escanear red Wi-Fi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr "Configuración Wi-Fi"
 
@@ -832,20 +856,66 @@ msgstr "Configuración Wi-Fi"
 msgid "Wireless Stations"
 msgstr "Estaciones Wi-Fi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr "auth=MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "auth=PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "ninguno"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "Maneja automáticamente las (rec-) conexiones VPN."
+
+#~ msgid "Del"
+#~ msgstr "Elim."
+
+#~ msgid "Delete this network"
+#~ msgstr "Eliminar esta red"
+
+#~ msgid "LAN Device"
+#~ msgstr "Dispositivo LAN"
+
+#~ msgid ""
+#~ "Please note: VPN connections require the separate setup of the "
+#~ "<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Tenga en cuenta: las conexiones VPN requieren la configuración por "
+#~ "separado del paquete <em>Wireguard</em> u <em>OpenVPN</em>.<br /><p>&#xa0;"
+#~ "</p>"
+
+#~ msgid ""
+#~ "Restrict travelmate to a single radio or change the overall scanning "
+#~ "order (e.g. 'radio1 radio0')."
+#~ msgstr ""
+#~ "Restrinja Travelmate a una sola radio o cambie el orden de exploración "
+#~ "general (p.e., 'radio1 radio0')."
+
+#~ msgid "The lan network device, e.g. 'br-lan'."
+#~ msgstr "El dispositivo de red lan, p.ej. 'br-lan'."
 
 #~ msgid ""
 #~ "Configuration of the travelmate package to to enable travel router "
@@ -1035,9 +1105,6 @@ msgstr "ninguno"
 
 #~ msgid "Radio Selection / Order"
 #~ msgstr "Selección de Radio / Orden"
-
-#~ msgid "Remove"
-#~ msgstr "Eliminar"
 
 #~ msgid "Remove this Uplink"
 #~ msgstr "Eliminar este enlace ascendente"

--- a/applications/luci-app-travelmate/po/fi/travelmate.po
+++ b/applications/luci-app-travelmate/po/fi/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Todennus"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Kanava"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Poista tämä verkko"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Laite"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Hylkää"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Vedä järjestääksesi uudelleen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "EAP-menetelmä"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Muokkaa tätä verkkoa"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Salaus"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Yleisasetukset"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Tietoja"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Viimeksi ajettu"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Yleiskatsaus"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Salasana"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Yksityisen avaimen salasana"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Polku CA-varmenteeseen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Polku asiakasvarmenteeseen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Polku yksityiseen avaimeen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Poista"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Tallenna"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Asetukset"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,20 +792,39 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "ei mitään"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Delete this network"
+#~ msgstr "Poista tämä verkko"
 
 #~ msgid "Action"
 #~ msgstr "Toiminta"
@@ -814,9 +861,6 @@ msgstr "ei mitään"
 
 #~ msgid "Move up"
 #~ msgstr "Siirrä ylös"
-
-#~ msgid "Remove"
-#~ msgstr "Poista"
 
 #~ msgid "Restart"
 #~ msgstr "Käynnistä uudelleen"

--- a/applications/luci-app-travelmate/po/fr/travelmate.po
+++ b/applications/luci-app-travelmate/po/fr/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- Sélection AP --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Paramètres supplémentaires"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Authentification"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Canal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,151 +121,147 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Supprimer ce réseau"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Appareil"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Effacer"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Faites glisser pour réorganiser"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "E-mail du profil"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Adresse e-mail du destinataire"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Adresse e-mail de l'expéditeur"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Objet de l'e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Éditer"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Éditer ce réseau"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Activez la journalisation de débogage verbeuse en cas d'erreurs de "
 "traitement."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Activé"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Chiffrement"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -266,69 +269,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Dernière exécution"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Vue du journal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -336,15 +349,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -352,236 +369,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Aperçu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Mot de passe"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Mot de passe de la clé privée"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Chemin du certificat CA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Chemin du certificat-client"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Chemin de la clé privée"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Désinstaller"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "Drapeaux d'exécution"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Enregistrer"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Paramètres"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Statut / Version"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -591,22 +609,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -614,49 +638,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Délai de déclenchement"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Logs en mode verbeux"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -664,101 +692,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -766,20 +794,39 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "aucun"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Delete this network"
+#~ msgstr "Supprimer ce réseau"
 
 #~ msgid "Action"
 #~ msgstr "Action"
@@ -830,9 +877,6 @@ msgstr "aucun"
 #~ msgstr ""
 #~ "Options permettant d'apporter des modifications supplémentaires au cas où "
 #~ "les valeurs par défaut ne vous conviendraient pas."
-
-#~ msgid "Remove"
-#~ msgstr "Désinstaller"
 
 #~ msgid "Restart"
 #~ msgstr "Redémarrer"

--- a/applications/luci-app-travelmate/po/he/travelmate.po
+++ b/applications/luci-app-travelmate/po/he/travelmate.po
@@ -11,101 +11,108 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -115,149 +122,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "מכשיר"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "התעלמות"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -265,69 +268,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -335,15 +348,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -351,236 +368,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "הגדרות"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -590,22 +608,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -613,49 +637,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -663,101 +691,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -765,17 +793,33 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""

--- a/applications/luci-app-travelmate/po/hi/travelmate.po
+++ b/applications/luci-app-travelmate/po/hi/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,17 +792,33 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""

--- a/applications/luci-app-travelmate/po/hu/travelmate.po
+++ b/applications/luci-app-travelmate/po/hu/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Hitelesítés"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Eszköz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "EAP módszer"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Szerkesztés"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Titkosítás"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Általános Beállítások"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Utolsó futás"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Áttekintés"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Jelszó"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Személyes kulcs jelszava"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Útvonal a CA-tanúsítványhoz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Útvonal az ügyféltanúsítványhoz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Útvonal a személyes kulcshoz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Eltávolítás"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Mentés"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Beállítások"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Aktiváló késleltetése"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,19 +792,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"
@@ -827,9 +871,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Beállítások a további finomhangoláshoz abban az esetben, ha az "
 #~ "alapértelmezett értékek nem felelnek meg Önnek."
-
-#~ msgid "Remove"
-#~ msgstr "Eltávolítás"
 
 #~ msgid "Restart"
 #~ msgstr "Újraindítás"

--- a/applications/luci-app-travelmate/po/it/travelmate.po
+++ b/applications/luci-app-travelmate/po/it/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Impostazioni aggiuntive"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Autenticazione"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Canale"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,150 +121,146 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Dispositivo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "Profilo e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Indirizzo e-mail destinatario"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Indirizzo e-mail mittente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Oggetto e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Metodo EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Modifica"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Abilita log di debug verboso in caso di qualsiasi errore di elaborazione."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Criptazione"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Impostazioni Generali"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -265,69 +268,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -335,15 +348,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -351,236 +368,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Password"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Rimuovi"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Salva"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -590,22 +608,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -613,49 +637,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -663,101 +691,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -765,19 +793,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"
@@ -803,6 +847,3 @@ msgstr ""
 
 #~ msgid "Loading"
 #~ msgstr "Caricamento"
-
-#~ msgid "Remove"
-#~ msgstr "Rimuovi"

--- a/applications/luci-app-travelmate/po/ja/travelmate.po
+++ b/applications/luci-app-travelmate/po/ja/travelmate.po
@@ -13,51 +13,55 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "追加設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr "Travelmate の処理が開始されるまでの、追加の遅延時間（秒）です。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "認証"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "自動ログイン スクリプト"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
@@ -65,51 +69,54 @@ msgstr ""
 "ホテルのキャプティブ ポータルのような、オープンなアップリンクを自動的に無線設"
 "定に追加します。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr "スキャン結果を準備するためのバッファー サイズ (byte) です。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "キャプティブポータル検知"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "チャンネル"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -119,134 +126,130 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "接続制限"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "このネットワークを削除"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "デバイス"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "閉じる"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "ドラッグして並び替え"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "Eメールプロファイル"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Eメール受信アドレス"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Eメール送信者アドレス"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Eメールトピック"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "EAPメソッド"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "編集"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "このネットワークを編集"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "エラーが発生した際に詳細なデバッグロギングを有効にします。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "有効"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "暗号化"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
@@ -254,16 +257,16 @@ msgstr ""
 "キャプティブ ポータルへの自動ログインのために呼び出される、外部スクリプトへの"
 "参照です。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -271,63 +274,73 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr "Travelmate が無線アップリンクへの接続成功を待つ時間です。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "BSSID の無視"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "情報"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "インターフェース タイムアウト"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "インターフェース ウィザード"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "最終実行"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "ログビュー"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
@@ -335,7 +348,7 @@ msgstr ""
 "条件付きアップリンク接続（または切断）のための、シグナル品質閾値の下限（%）で"
 "す。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "ネット エラーチェック"
 
@@ -343,15 +356,19 @@ msgstr "ネット エラーチェック"
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "実行間隔"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "全体的な再試行タイムアウト（秒）です。"
 
@@ -359,69 +376,63 @@ msgstr "全体的な再試行タイムアウト（秒）です。"
 msgid "Overview"
 msgstr "概要"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "パスワード"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "秘密鍵のパスワード"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "CA証明書のパス"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "クライアント証明書のパス"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "秘密鍵のパス"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "積極的なアップリンク切替"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
@@ -429,168 +440,175 @@ msgstr ""
 "既存の接続に関わらず、より優先度の高いアップリンクへの積極的なスキャンと切り"
 "替えを行います。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "削除"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "アップリンクへの接続を試行する回数です。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "実行フラグ"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID（ステルス）"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "スキャンバッファー サイズ"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "サービス優先度"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "シグナル品質閾値"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "ステーション インターフェース"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "ステータス / バージョン"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -602,22 +620,28 @@ msgstr ""
 "このフォームには、システムログ内の Travelmate に関するメッセージのみが表示さ"
 "れます。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -625,49 +649,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "インターネット可用性が無い場合をエラーとして扱います。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "トリガ遅延"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "詳細なデバッグ ログ"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -675,101 +703,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "無線スキャン"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -777,20 +805,39 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr "無線ステーション"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "なし"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Delete this network"
+#~ msgstr "このネットワークを削除"
 
 #~ msgid "AP on"
 #~ msgstr "AP の場所:"
@@ -943,9 +990,6 @@ msgstr "なし"
 
 #~ msgid "Radio Selection / Order"
 #~ msgstr "無線の選択 / 順番"
-
-#~ msgid "Remove"
-#~ msgstr "削除"
 
 #~ msgid "Remove this Uplink"
 #~ msgstr "このアップリンクを削除"

--- a/applications/luci-app-travelmate/po/ko/travelmate.po
+++ b/applications/luci-app-travelmate/po/ko/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "활성화"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "기본 설정"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,20 +792,36 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "없음"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
 
 #~ msgid "Action"
 #~ msgstr "액션"

--- a/applications/luci-app-travelmate/po/mr/travelmate.po
+++ b/applications/luci-app-travelmate/po/mr/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.3-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "डिव्हाइस"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "डिसमिस करा"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr "आढावा"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "संकेतशब्द"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,19 +792,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Loading"

--- a/applications/luci-app-travelmate/po/ms/travelmate.po
+++ b/applications/luci-app-travelmate/po/ms/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,19 +792,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"

--- a/applications/luci-app-travelmate/po/nb_NO/travelmate.po
+++ b/applications/luci-app-travelmate/po/nb_NO/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Ytterligere innstillinger"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Kanal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Enhet"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "E-postsenderadresse"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "E-postemne"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Påskrudd"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Generelle innstillinger"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Info"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Sist kjørt"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Loggvisning"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,237 +367,238 @@ msgstr ""
 msgid "Overview"
 msgstr "Oversikt"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Passord"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 #, fuzzy
 msgid "Run Flags"
 msgstr "Kjøringsflagg"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Lagre"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Status/versjon"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -590,22 +608,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -613,49 +637,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Utløserforsinkelse"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -663,101 +691,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -765,19 +793,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"

--- a/applications/luci-app-travelmate/po/pl/travelmate.po
+++ b/applications/luci-app-travelmate/po/pl/travelmate.po
@@ -11,47 +11,51 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.8-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- Wybór AP --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "Kody QR AP..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "Dodaj Uplink %q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "Dodaj Uplink..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Dodatkowe ustawienia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 "Dodatkowe opóźnienie wyzwalacza w sekundach zanim travelmate zacznie "
 "przetwarzać."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Uwierzytelnienie"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Automatyczny skrypt logowania"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr "Automatycznie dodawaj otwarte łącza uplink"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
@@ -59,7 +63,7 @@ msgstr ""
 "Automatyczne (ponowne) włączenie uplink po <em>n</em> minutach, np. po "
 "nieudanych próbach logowania.<br /> Domyślna wartość '0' wyłącza tę funkcję."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
@@ -67,7 +71,7 @@ msgstr ""
 "Automatycznie dodawaj otwarte łącza zwrotne takie jak strony logowania w "
 "sieci w hotelu do swojej bezprzewodowej konfiguracji."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
@@ -75,40 +79,43 @@ msgstr ""
 "Automatycznie wyłącza łącze uplink po <em>n</em> minutach, np. dla połączeń "
 "czasowych.<br /> Domyślna wartość '0' wyłącza tę funkcję."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "Automatyczna obsługa połączeń VPN."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 "Rozmiar bufora w bajtach do przygotowania rezultatu skanowania okolicy."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr "CHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "Wykrywanie logowania w sieci"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr "Adres URL portalu przechwytującego"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Kanał"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
@@ -116,7 +123,7 @@ msgstr ""
 "Sprawdź dostępność internetu, obsługuj przekierowania do portalu "
 "przechwytującego i utrzymuj połączenie uplink 'aktywne'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -132,136 +139,132 @@ msgstr ""
 "<em>Uwaga: </em> przy pierwszym uruchomieniu wywołaj raz 'Kreatora "
 "interfejsu', aby dokonać niezbędnych ustawień sieci i zapory."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr "Koniec połączenia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr "Wygaśnięcie zakończenia połączenia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "Limit połączenia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr "Rozpoczęcie połączenia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr "Wygaśnięcie zakończenia połączenia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "Usuń"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Usuń tą sieć"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Urządzenie"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "Nazwa urządzenia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Odrzuć"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Przeciągnij, aby zmienić kolejność"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr "E-Mail Hook"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "Profil e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Adres e-mail odbiorcy"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Adres e-mail nadawcy"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr "Ustawienia e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Temat e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr "EAP-GTC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Metoda protokołu rozszerzonego uwierzytelniania (EAP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr "EAP-TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Edytuj"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Edytuj tę sieć"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr "Włącz usługę Travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Włącz rejestrowanie debugowania w przypadku wystąpienia błędów w "
 "przetwarzaniu."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Włączone"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Szyfrowanie"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr "Zewnętrzne Hooks'y"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
@@ -269,16 +272,16 @@ msgstr ""
 "Nawiązanie do zewnętrznego skryptu który będzie użyty do automatycznego "
 "logowania w sieci."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "FAST"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr "Wygeneruj losowy adres MAC unicast dla każdego połączenia uplink."
 
@@ -286,64 +289,74 @@ msgstr "Wygeneruj losowy adres MAC unicast dla każdego połączenia uplink."
 msgid "Grant access to LuCI app travelmate"
 msgstr "Przyznaj dostęp LuCI do aplikacji Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 "Jak długo travelmate powinien czekać na udane połączenie bezprzewodowe."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "Identyfikuj"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "Ignoruj BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Informacje"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr "Nazwa interfejsu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "Limit czasu interfejsu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "Kreator interfejsu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr "Kreator interfejsu..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr "Urządzenie LAN"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Ostatnie uruchomienie"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Widok dziennika"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
@@ -351,7 +364,7 @@ msgstr ""
 "Minimalny próg jakości sygnału jako wartość procentowa dla warunkowych "
 "(ujemnych) połączeń."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "Kontrola błędów sieci"
 
@@ -359,15 +372,19 @@ msgstr "Kontrola błędów sieci"
 msgid "No travelmate related logs yet!"
 msgstr "Brak powiązanych dzienników travelmate!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "Ogólny limit czasu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "Ogólny limit czasu powtarzania w sekundach."
 
@@ -375,7 +392,7 @@ msgstr "Ogólny limit czasu powtarzania w sekundach."
 msgid "Overview"
 msgstr "Przegląd"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
@@ -386,46 +403,46 @@ msgstr ""
 "nadrzędnych, przeciągając &#38; upuszczanie i skanowanie w poszukiwaniu "
 "nowych. Aktualnie używane uplink jest podkreślone na niebiesko."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Hasło"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Hasło klucza prywatnego"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Ścieżka do certyfikatu CA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Ścieżka do certyfikatu klienta"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Ścieżka do klucza prywatnego"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr "Zainstaluj osobny pakiet „qrencode”."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
@@ -433,19 +450,11 @@ msgstr ""
 "Uwaga: Powiadomienia e-mail wymagają oddzielnej konfiguracji <em>mstmp</em> "
 "pakietu. <br /> <p> &#xa0; </p>"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-"Uwaga: połączenia VPN wymagają oddzielnej konfiguracji pakietu "
-"<em>Wireguard</em> lub <em>OpenVPN</em>. <br /> <p> &#xa0; </p>"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "Przełącznik połączenia ProActive"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
@@ -453,27 +462,35 @@ msgstr ""
 "Aktywnie skanuj i przełączaj na łącze o wyższym priorytecie, pomimo już "
 "istniejącego połączenia."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr "Profil używany przez \"msmtp\" do powiadomień travelmate e-mail."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr "Przegląd kodów QR"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "Wybór radia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "Losowe adresy MAC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr "Adres odbiorcy wiadomości e-mail z powiadomieniem o travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Usuń"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
@@ -481,76 +498,77 @@ msgstr ""
 "Renderuj kod QR wybranego punktu dostępowego, aby w wygodny sposób przesłać "
 "dane uwierzytelniające WLAN do urządzeń mobilnych."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "Powtórz skanowanie"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
-"Ogranicz travelmate do jednego radia lub zmień ogólną kolejność skanowania "
-"(np. 'radio1 radio0')."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "Limit powtórzeń do połączenia."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "Uruchomione flagi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (ukryty)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Zapisz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "Rozmiar bufora skanowania"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr "Skanowanie włączone"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr "Argumenty skryptu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr "Adres nadawcy dla powiadomień e-mail dla travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 "Wysyła powiadomienie e-mail po każdym udanym połączeniu przez sieć uplink."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "Priorytet usługi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "Próg jakości sygnału"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
@@ -558,72 +576,68 @@ msgstr ""
 "Rozdzielona spacjami lista dodatkowych argumentów przekazanych do skryptu "
 "automatycznego logowania, np. nazwa użytkownika i hasło"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr "Rozpoczynanie skanowania"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "Identyfikator stacji"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "Interfejs stacji"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "Stacja MAC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Status / Wersja"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "Siła"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "Nie można wygenerować kodu QR!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "Nazwa strefy zapory"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr "Metryka interfejsu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr "Urządzenie sieci lan, np. 'br-lan'."
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr "Logiczny interfejs sieci VPN, np. „wg0” lub „tun0”."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 "Wybrany adres URL będzie używany do sprawdzania łączności i portalu "
 "dostępowego."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr "Wybrany priorytet będzie używany w procesach travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -637,15 +651,21 @@ msgstr ""
 "Wyjście dziennika systemowego, wstępnie filtrowane aby zawierało tylko "
 "informacje związane z travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr "Interfejs uplink został zaktualizowany."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr "Nazwa interfejsu uplink"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
@@ -655,7 +675,7 @@ msgstr ""
 "Kreator ten tworzy interfejs sieciowy IPv4- i IPv6 alias z wszystkimi "
 "wymaganymi ustawieniami sieci i zapory sieciowej."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr "Temat powiadomień e-mail travelmate."
 
@@ -663,49 +683,53 @@ msgstr "Temat powiadomień e-mail travelmate."
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr "Ustawienia Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "Traktuj brak dostępu do internetu jako błąd."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Opóźnienie wyzwalacza"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "Agent użytkownika"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr "VPN Hook"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "Interfejs VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "Usługa VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr "Ustawienia VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Pełne rejestrowanie debugowania"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr "WPA Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr "WPA Ent. (TKIP)"
 
@@ -713,101 +737,101 @@ msgstr "WPA Ent. (TKIP)"
 msgid "WPA Flags"
 msgstr "Flagi WPA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr "WPA Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr "WPA Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr "WPA Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr "WPA/WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr "WPA/WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr "WPA/WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr "WPA/WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr "WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr "WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr "WPA2 Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr "WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr "WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr "WPA2/WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr "WPA2/WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr "WPA2/WPA3 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr "WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr "WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr "WPA3 OWE (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr "WPA3 Pers. (SAE)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "Bezprzewodowe skanowanie"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr "Ustawienia sieci bezprzewodowej"
 
@@ -815,20 +839,65 @@ msgstr "Ustawienia sieci bezprzewodowej"
 msgid "Wireless Stations"
 msgstr "Stacje bezprzewodowe"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr "auth=MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "auth=PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "brak"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "Automatyczna obsługa połączeń VPN."
+
+#~ msgid "Del"
+#~ msgstr "Usuń"
+
+#~ msgid "Delete this network"
+#~ msgstr "Usuń tą sieć"
+
+#~ msgid "LAN Device"
+#~ msgstr "Urządzenie LAN"
+
+#~ msgid ""
+#~ "Please note: VPN connections require the separate setup of the "
+#~ "<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Uwaga: połączenia VPN wymagają oddzielnej konfiguracji pakietu "
+#~ "<em>Wireguard</em> lub <em>OpenVPN</em>. <br /> <p> &#xa0; </p>"
+
+#~ msgid ""
+#~ "Restrict travelmate to a single radio or change the overall scanning "
+#~ "order (e.g. 'radio1 radio0')."
+#~ msgstr ""
+#~ "Ogranicz travelmate do jednego radia lub zmień ogólną kolejność "
+#~ "skanowania (np. 'radio1 radio0')."
+
+#~ msgid "The lan network device, e.g. 'br-lan'."
+#~ msgstr "Urządzenie sieci lan, np. 'br-lan'."
 
 #~ msgid ""
 #~ "Configuration of the travelmate package to to enable travel router "
@@ -1010,9 +1079,6 @@ msgstr "brak"
 
 #~ msgid "Radio Selection / Order"
 #~ msgstr "Wybór radia/kolejność"
-
-#~ msgid "Remove"
-#~ msgstr "Usuń"
 
 #~ msgid "Remove this Uplink"
 #~ msgstr "Usuń to połączenie"

--- a/applications/luci-app-travelmate/po/pt/travelmate.po
+++ b/applications/luci-app-travelmate/po/pt/travelmate.po
@@ -10,45 +10,49 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- Seleção do AP --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "Códigos QR do AP..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "Adicionar ligação ascendente %q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "Adicionar ligação ascendente..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Configurações adicionais"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr "Atraso adicional em segundos antes do travelmate processe os gatilhos."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Script de Login Automático"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr "Adicionar ligações ascendentes abertos automaticamente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
@@ -57,7 +61,7 @@ msgstr ""
 "minutos, por exemplo, quando as tentativas de login fracassarem. <br /> O "
 "valor predefinido '0' desativa esse recurso."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
@@ -65,7 +69,7 @@ msgstr ""
 "Adicionar ligações ascendentes abertas automaticamente, como portais cativos "
 "de hotéis, à sua configuração wireless."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
@@ -74,40 +78,43 @@ msgstr ""
 "por exemplo, para conexões que forem cronometradas. <br /> A predefinição "
 "'0' desativa esse recurso."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "Lidar com (re-)conexões do VPN automaticamente."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 "Tamanho do buffer em bytes para preparar resultados de varreduras próximas."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr "CHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "Detecção de Portal de Autenticação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr "URL do portal cativo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Canal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
@@ -115,7 +122,7 @@ msgstr ""
 "Verifique o acesso à Internet, lide com os redirecionamentos cativos do "
 "portal e mantenha a ligação ascendente 'viva'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -131,136 +138,132 @@ msgstr ""
 "Nota:</em> Na primeira inicialização chame o 'Assistente da interface', para "
 "fazer as configurações necessárias da rede e do firewall."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr "Fim da conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr "Validade do fim da conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "Limite de conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr "Início da conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr "Validade do inicio da conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "Excluir"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Apagar esta rede"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Aparelho"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "Nome do aparelho"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Arraste para reordenar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr "Gancho do e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "Perfil de e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de e-mail do destinatário"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Endereço de e-mail do remetente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr "Configurações do e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Assunto do e-mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr "EAP-GTC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr "EAP-TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Editar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Editar esta rede"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr "Ative o serviço travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registo de depuração detalhado para casos de todos os erros de "
 "processamento."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Encriptação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr "Ganchos externos"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
@@ -268,16 +271,16 @@ msgstr ""
 "Referência de script externo que será chamado para logins automatizados de "
 "portal cativo."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "RÁPIDO"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 "Gerar um endereço MAC unicast aleatório para cada ligação ascendente da "
@@ -287,65 +290,75 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr "Conceder acesso ao LuCI ao app travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 "Quanto tempo o travelmate irá esperar pelo sucesso da ligação ascendente sem "
 "fio."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "Identificar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "Ignore o BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Informação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr "Nome da interface"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "Estouro de Tempo da Interface"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "Assistente da Interface"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr "Assistente da interface..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr "Aparelho LAN"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Última Execução"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Vista do registo log"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
@@ -353,7 +366,7 @@ msgstr ""
 "Limite percentual mínimo da qualidade do sinal para (des)conexões de ligação "
 "ascendente."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "Verificação de Erros de Rede"
 
@@ -361,15 +374,19 @@ msgstr "Verificação de Erros de Rede"
 msgid "No travelmate related logs yet!"
 msgstr "Ainda não há registos log relacionados com o travelmate!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "Estouro de Tempo Global"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "Estouro de tempo global em segundos."
 
@@ -377,7 +394,7 @@ msgstr "Estouro de tempo global em segundos."
 msgid "Overview"
 msgstr "Visão Geral"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
@@ -389,46 +406,46 @@ msgstr ""
 "ligações ascendentes. A ligação ascendente atualmente utilizada está "
 "destacada em azul."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Palavra-passe"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Palavra-passe da Chave Privada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Caminho para o certificado da AC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Caminho para o Certificado do Cliente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Caminho para a Chave Privada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr "Instale o pacote separado 'qrencode'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
@@ -436,19 +453,11 @@ msgstr ""
 "Observação: as notificações do e-mail requerem a configuração separada do "
 "pacote <em>mstmp</em>.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-"Observação: as conexões de VPN requerem a configuração separada do pacote "
-"<em>Wireguard</em> ou do <em>OpenVPN</em>. <br /><p>&#xa0;</p>"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "Comutador de ligação ascendente ProActive"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
@@ -456,30 +465,38 @@ msgstr ""
 "Analise e mude proativamente para uma ligação ascendente priorizado mais "
 "alto, apesar de uma conexão já existente."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 "Perfil usado pelo 'msmtp' para a notificação dos e-mails do travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr "Visão geral do código QR"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "Seleção do rádio"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "Randomizar os endereços MAC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 "Endereço do e-mail do destinatário para o recebimento das notificações do "
 "travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Remover"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
@@ -487,77 +504,78 @@ msgstr ""
 "Renderize o código QR do ponto de acesso selecionado para transferir "
 "confortavelmente as credenciais do WLAN para os seus aparelhos móveis."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "Repetir a varredura"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
-"Restringir o travelmate para um único rádio ou alterar a ordem geral da "
-"varredura (por exemplo, 'radio1 radio0')."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "Limite de retentiva de conexão com uma ligação ascendente."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "Flags de Execução"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (oculto)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Guardar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "Tamanho do Buffer de Varredura"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr "Varredura ligada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr "Argumentos do script"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr "Endereço e-mail do remetente para as notificações do travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 "Envia e-mails de notificação após cada conexão bem-recebida da ligação "
 "ascendente."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "Prioridade do serviço"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "Limite da Qualidade do Sinal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
@@ -565,72 +583,68 @@ msgstr ""
 "Lista separada por espaços de argumentos adicionais passados ao Script de "
 "Login Automático, ou seja, nome de utilizador e palavra-passe"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr "A iniciar a varredura sem fio em '"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "ID da estação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "Interface da Estação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "MAC da estação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Condição geral / versão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "Força"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "O código QR não pôde ser gerado!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "O nome da zona do firewall"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr "A métrica de interface"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr "O aparelho lan da rede, por exemplo, 'br-lan'."
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr "A interface lógica da rede de vpn, por exemplo, 'wg0' ou 'tun0'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 "A URL selecionada será utilizada para as verificações do portal de "
 "conectividade e do portal cativo."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr "A prioridade selecionada será usada pelos processos do travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -642,15 +656,21 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr "Mensagens do syslog relacionadas ao travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr "A interface da ligação ascendente foi atualizada."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr "O nome da interface da ligação ascendente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
@@ -660,7 +680,7 @@ msgstr ""
 "Este assistente cria uma interface pseudónima de rede IPv4 e de IPv6 com "
 "todas as configurações necessárias da rede e do firewall."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr "O assunto do e-mail usado pela notificação do travelmate."
 
@@ -668,49 +688,53 @@ msgstr "O assunto do e-mail usado pela notificação do travelmate."
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr "Configurações do Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "Tratar a falta de disponibilidade da Internet como um erro."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Atraso do Gatilho"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "Agente do utilizador"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr "Gancho de VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "Interface da VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "Serviço de VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr "Configurações da VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Registos detalhados de depuração"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr "WPA Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr "WPA Ent. (TKIP)"
 
@@ -718,101 +742,101 @@ msgstr "WPA Ent. (TKIP)"
 msgid "WPA Flags"
 msgstr "Sinalizadores do WPA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr "WPA Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr "WPA Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr "WPA Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr "WPA/WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr "WPA/WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr "WPA/WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr "WPA/WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr "WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr "WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr "WPA2 Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr "WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr "WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr "WPA2/WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr "WPA2/WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr "WPA2/WPA3 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr "WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr "WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr "WPA3 OWE (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr "WPA3 Pers. (SAE)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "Escaneamento da Rede Sem Fio"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr "Configurações da rede sem fio"
 
@@ -820,20 +844,65 @@ msgstr "Configurações da rede sem fio"
 msgid "Wireless Stations"
 msgstr "Estações Associadas"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr "auth=MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "auth=PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "nenhum"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "Lidar com (re-)conexões do VPN automaticamente."
+
+#~ msgid "Del"
+#~ msgstr "Excluir"
+
+#~ msgid "Delete this network"
+#~ msgstr "Apagar esta rede"
+
+#~ msgid "LAN Device"
+#~ msgstr "Aparelho LAN"
+
+#~ msgid ""
+#~ "Please note: VPN connections require the separate setup of the "
+#~ "<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Observação: as conexões de VPN requerem a configuração separada do pacote "
+#~ "<em>Wireguard</em> ou do <em>OpenVPN</em>. <br /><p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Restrict travelmate to a single radio or change the overall scanning "
+#~ "order (e.g. 'radio1 radio0')."
+#~ msgstr ""
+#~ "Restringir o travelmate para um único rádio ou alterar a ordem geral da "
+#~ "varredura (por exemplo, 'radio1 radio0')."
+
+#~ msgid "The lan network device, e.g. 'br-lan'."
+#~ msgstr "O aparelho lan da rede, por exemplo, 'br-lan'."
 
 #~ msgid ""
 #~ "Configuration of the travelmate package to to enable travel router "
@@ -1016,9 +1085,6 @@ msgstr "nenhum"
 
 #~ msgid "Radio Selection / Order"
 #~ msgstr "Seleção / Ordem de Rádio"
-
-#~ msgid "Remove"
-#~ msgstr "Remover"
 
 #~ msgid "Remove this Uplink"
 #~ msgstr "Remover este Uplink"

--- a/applications/luci-app-travelmate/po/pt_BR/travelmate.po
+++ b/applications/luci-app-travelmate/po/pt_BR/travelmate.po
@@ -13,45 +13,49 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- Seleção do AP --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "Códigos QR do AP..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "Adicionar Enlace %q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "Adicionar o Enlace..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Configurações Adicionais"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr "Atraso adicional em segundos antes do travelmate processe os gatilhos."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Autenticação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Script de Login Automático"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr "Adicionar Automaticamente os Uplinks Abertos"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
@@ -60,7 +64,7 @@ msgstr ""
 "tentativas de login fracassarem. <br /> O valor predefinido '0' desativa "
 "esse recurso."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
@@ -68,7 +72,7 @@ msgstr ""
 "Adicione automaticamente uplinks abertos, como os usados em portais cativos "
 "de hotéis na sua configuração sem fio."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
@@ -77,41 +81,44 @@ msgstr ""
 "para conexões que forem cronometradas. <br /> A predefinição '0' desativa "
 "esse recurso."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "Lide automaticamente com as (re-)conexões VPN."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 "Tamanho do buffer em bytes para preparar os resultados de varredura mais "
 "próximos."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr "CHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "Detecção de Portal de Autenticação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr "URL do Portal Cativo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Canal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
@@ -119,7 +126,7 @@ msgstr ""
 "Verifique a disponibilidade da Internet, lide com os redirecionamentos "
 "cativos do portal e mantenha a conexão do enlace 'viva'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -135,151 +142,147 @@ msgstr ""
 "Nota:</em> Na primeira inicialização chame o 'Assistente da interface', para "
 "fazer as configurações necessárias da rede e do firewall."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr "Fim da conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr "Validade do fim da conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "Limite de conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr "Início da conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr "Validade do inicio da conexão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "Excluir"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Apagar esta rede"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Dispositivo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "Nome do dispositivo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Arraste para reordenar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr "Gancho do E-Mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr "Configurações do E-Mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr "EAP-GTC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Método EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr "EAP-TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Editar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Editar esta rede"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr "Ative o serviço travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Ativa o registro de depuração detalhada nos casos de qualquer erro de "
 "processamento."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Criptografia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr "Ganchos Externos"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr "Script externo de referência que será usado para logins automatizados."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "RÁPIDO"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr "Gere um endereço MAC unicast aleatório para cada enlace da conexão."
 
@@ -287,65 +290,75 @@ msgstr "Gere um endereço MAC unicast aleatório para cada enlace da conexão."
 msgid "Grant access to LuCI app travelmate"
 msgstr "Conceda ao aplicativo travelmate acesso ao LuCI"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 "Quanto tempo o travelmate irá esperar pelo sucesso da conexão sem fio "
 "externa."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "Identificar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "Ignore o BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Informações"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr "Nome da Interface"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "Estouro de Tempo da Interface"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "Assistente da Interface"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr "Assistente da Interface..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr "Dispositivo LAN"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Última Execução"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Exiba o registro log"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
@@ -353,7 +366,7 @@ msgstr ""
 "Limite percentual mínimo da qualidade do sinal para (des)conexões de enlaces "
 "para fora."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "Verificação de Erros da Rede"
 
@@ -361,15 +374,19 @@ msgstr "Verificação de Erros da Rede"
 msgid "No travelmate related logs yet!"
 msgstr "Ainda não há registos log relacionados com o travelmate!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "Estouro de Tempo Global"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "Estouro de tempo global em segundos."
 
@@ -377,7 +394,7 @@ msgstr "Estouro de tempo global em segundos."
 msgid "Overview"
 msgstr "Visão geral"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
@@ -388,46 +405,46 @@ msgstr ""
 "soltar e fazer uma varredura para novos enlaces. O enlace atualmente "
 "utilizado está destacado em azul."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Senha"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Senha da chave privada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Caminho para o certificado CA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Caminho para o certificado do cliente"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Caminho para a chave privada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr "Instale o pacote 'qrencode' separado."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
@@ -435,19 +452,11 @@ msgstr ""
 "Observação: As notificações do e-mail requerem a configuração separada do "
 "pacote <em>mstmp</em>.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-"Observação: As conexões VPN requerem a configuração separada do pacote "
-"<em>Wireguard</em> ou o <em>OpenVPN</em>. <br /><p>&#xa0;</p>"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "ProActive Switch de Ligação Acendente (Uplink)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
@@ -455,30 +464,38 @@ msgstr ""
 "Faça uma varredura de forma proativa e selecione um switch com prioridade "
 "mais alta, mesmo que já exista uma conexão."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 "Perfil usado pelo 'msmtp' para a notificação dos E-mails do travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr "Visão geral do código QR"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "Seleção do Rádio"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "Randomize os endereços MAC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 "Endereço do E-Mail do destinatário para o recebimento das notificações do "
 "travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Remover"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
@@ -486,75 +503,76 @@ msgstr ""
 "Renderize o código QR do Ponto de Acesso selecionado para transferir "
 "confortavelmente as credenciais do WLAN para os seus dispositivos móveis."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "Repetir a varredura"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
-"Restringir o travelmate para um único rádio ou alterar a ordem geral da "
-"varredura (por exemplo, 'radio1 radio0')."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "Limite de novas tentativas de conexão com um enlace externo."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "Executar Flags"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (oculto)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Salvar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "Tamanho do Buffer de Varredura"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr "Varredura ligada"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr "Argumentos do script"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr "Endereço E-Mail do remetente para as notificações do travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr "Envia e-mails de notificação após cada conexão bem-recebida do enlace."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "Prioridade do serviço"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "Limite da Qualidade do Sinal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
@@ -562,72 +580,68 @@ msgstr ""
 "Lista de argumentos adicionais separados por espaço que serão passados ao "
 "Script de Login Automático, por exemplo, nome de usuário e senha"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr "Iniciando a varredura sem fio em '"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "ID da estação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "Interface da Estação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "MAC da estação"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Condição Geral / Versão"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "Força"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "O Código QR não pôde ser gerado!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "O nome da zona do firewall"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr "A métrica de interface"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr "O dispositivo lan da rede, por exemplo, 'br-lan'."
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr "A interface lógica da rede vpn, por exemplo, 'wg0' ou 'tun0'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 "A URL selecionada será utilizada para as verificações do portal de "
 "conectividade e do portal cativo."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr "A prioridade selecionada será usada pelos processos do travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -639,15 +653,21 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr "Mensagens do syslog relacionadas ao travelmate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr "A interface do enlace foi atualizada."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr "O nome da interface do enlace"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
@@ -657,7 +677,7 @@ msgstr ""
 "enlace. Este assistente cria uma interface de rede IPv4 e uma interface IPv6 "
 "com todas as configurações necessárias da rede e do firewall."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr "O assunto do E-mail usado pela notificação do travelmate."
 
@@ -665,49 +685,53 @@ msgstr "O assunto do E-mail usado pela notificação do travelmate."
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr "Configurações do Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "Tratar a falta de disponibilidade da Internet como um erro."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Gatilho de Atraso"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "Agente do usuário"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr "Gancho VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "Interface da VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "Serviço VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr "Configurações da VPN"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Registros Detalhados de Depuração"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr "WPA Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr "WPA Ent. (TKIP)"
 
@@ -715,101 +739,101 @@ msgstr "WPA Ent. (TKIP)"
 msgid "WPA Flags"
 msgstr "Sinalizadores do WPA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr "WPA Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr "WPA Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr "WPA Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr "WPA/WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr "WPA/WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr "WPA/WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr "WPA/WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr "WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr "WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr "WPA2 Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr "WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr "WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr "WPA2/WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr "WPA2/WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr "WPA2/WPA3 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr "WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr "WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr "WPA3 OWE (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr "WPA3 Pers. (SAE)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "Escaneamento da Rede Sem Fio"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr "Configurações da rede sem fio"
 
@@ -817,20 +841,65 @@ msgstr "Configurações da rede sem fio"
 msgid "Wireless Stations"
 msgstr "Estações Associadas"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr "auth=MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "auth=PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "nenhum"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "Lide automaticamente com as (re-)conexões VPN."
+
+#~ msgid "Del"
+#~ msgstr "Excluir"
+
+#~ msgid "Delete this network"
+#~ msgstr "Apagar esta rede"
+
+#~ msgid "LAN Device"
+#~ msgstr "Dispositivo LAN"
+
+#~ msgid ""
+#~ "Please note: VPN connections require the separate setup of the "
+#~ "<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Observação: As conexões VPN requerem a configuração separada do pacote "
+#~ "<em>Wireguard</em> ou o <em>OpenVPN</em>. <br /><p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Restrict travelmate to a single radio or change the overall scanning "
+#~ "order (e.g. 'radio1 radio0')."
+#~ msgstr ""
+#~ "Restringir o travelmate para um único rádio ou alterar a ordem geral da "
+#~ "varredura (por exemplo, 'radio1 radio0')."
+
+#~ msgid "The lan network device, e.g. 'br-lan'."
+#~ msgstr "O dispositivo lan da rede, por exemplo, 'br-lan'."
 
 #~ msgid ""
 #~ "Configuration of the travelmate package to to enable travel router "
@@ -1019,9 +1088,6 @@ msgstr "nenhum"
 
 #~ msgid "Radio Selection / Order"
 #~ msgstr "Seleção de Rádio / Ordem"
-
-#~ msgid "Remove"
-#~ msgstr "Remover"
 
 #~ msgid "Remove this Uplink"
 #~ msgstr "Remover este Uplink"

--- a/applications/luci-app-travelmate/po/ro/travelmate.po
+++ b/applications/luci-app-travelmate/po/ro/travelmate.po
@@ -11,101 +11,108 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -115,149 +122,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Modifică"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -265,69 +268,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Ultima rulare"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -335,15 +348,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -351,236 +368,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Prezentare generală"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Salvează"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -590,22 +608,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -613,49 +637,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Intârzierea declanșării"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -663,101 +691,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -765,19 +793,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"

--- a/applications/luci-app-travelmate/po/ru/travelmate.po
+++ b/applications/luci-app-travelmate/po/ru/travelmate.po
@@ -16,101 +16,108 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- Выбор точки доступа --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "Добавить канал %q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "Добавить канал..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Дополнительные настройки"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr "Дополнительная задержка в секундах до запуска TravelMate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Аутентификация"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Скрипт автоматического входа"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "Автоматически обрабатывать (пере-)подключения VPN."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "Обнаружение Captive Portal-а"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Канал"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -120,149 +127,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "Ограничение соединений"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "Удалить"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Удалить эту сеть"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Устройство"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "Имя устройства"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Закрыть"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Перетащите, чтобы изменить порядок"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "Профиль электронной почты"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "Адрес получателя"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Адрес отправителя"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "Тема"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Метод EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Изменить"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Изменить эту сеть"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Включить подробное формирование отчёта на случай возникновения ошибок."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Включено"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Шифрование"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Общие настройки"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -270,69 +273,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr "Предоставить доступ LuCI к приложению travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "Игнорировать BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Информация"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "Временная задержка интерфейса"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "Помощник настройки интерфейса"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Последний запуск"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Просмотр журнала"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -340,15 +353,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "Общее время ожидания"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -356,237 +373,238 @@ msgstr ""
 msgid "Overview"
 msgstr "Обзор"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Пароль"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Пароль к Приватному ключу"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Путь к CA-сертификату"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Путь к client-сертификату"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Путь к Приватному ключу"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Удалить"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 #, fuzzy
 msgid "Run Flags"
 msgstr "Рабочие флаги"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (скрытый)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Сохранить"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Настройки"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "Интерфейс клиента"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Статус / Версия"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -598,22 +616,28 @@ msgstr ""
 "Страница просмотра системного журнала, показаны только события связанные с "
 "работой утилиты TravelMate."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -621,49 +645,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr "TravelMate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Задержка запуска"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Подробный журнал отладки"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -671,101 +699,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "Найденные точки доступа Wi-Fi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -773,20 +801,45 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr "Клиенты беспроводной сети"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "ничего"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "Автоматически обрабатывать (пере-)подключения VPN."
+
+#~ msgid "Del"
+#~ msgstr "Удалить"
+
+#~ msgid "Delete this network"
+#~ msgstr "Удалить эту сеть"
 
 #~ msgid "Action"
 #~ msgstr "Действие"
@@ -899,9 +952,6 @@ msgstr "ничего"
 
 #~ msgid "Passphrase"
 #~ msgstr "Парольная фраза"
-
-#~ msgid "Remove"
-#~ msgstr "Удалить"
 
 #~ msgid "Repeat scan"
 #~ msgstr "Повторить поиск"

--- a/applications/luci-app-travelmate/po/sk/travelmate.po
+++ b/applications/luci-app-travelmate/po/sk/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.7\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Overenie totožnosti"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Zariadenie"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Zahodiť"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Spôsob EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Upraviť"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Šifrovanie"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Prehľad"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Heslo"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Heslo súkromného kľúča"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Cesta k súkromnému kľúču"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Odstrániť"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Uložiť"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Nastavenia"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,19 +792,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"
@@ -793,9 +837,6 @@ msgstr ""
 
 #~ msgid "Identity"
 #~ msgstr "Identita"
-
-#~ msgid "Remove"
-#~ msgstr "Odstrániť"
 
 #~ msgid "Restart"
 #~ msgstr "Reštartovať"

--- a/applications/luci-app-travelmate/po/sv/travelmate.po
+++ b/applications/luci-app-travelmate/po/sv/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Fler inställningar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Autentisering"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Automatiskt inloggningsskript"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Kanal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Ta bort det här nätverket"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Enhet"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "Enhetens namn"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Avfärda"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Dra för att sortera om"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "Avsändaradress för e-post"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "E-postämne"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "EAP-metod"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Redigera"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Redigera det här nätverket"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "Aktivera utförlig avlusningsloggning i händelse av behandlingsfel."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "SNABB"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Generella inställningar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "Identifiera"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "Ignorera BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Information"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Kördes senast"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Logutsikt"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Överblick"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Lösenord"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Den privata nyckelns lösenord"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Genväg till CA-certifikat"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Genväg till klient-certifikat"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Genväg till privat nyckel"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "Val av radio"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "Slumpa MAC-adresser"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Ta bort"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "Upprepa skanning"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "Förflaggor"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (gömd)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Spara"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Inställningar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "Stationens ID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "Stationens gränssnitt"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "Stationens MAC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Status / Version"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "Styrka"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "QR-koden kunde inte genereras!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "Namnet på brandväggszonen"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr "Reskompis"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "Användaragent"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "VPN-gränsnitt"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "VPN-tjänst"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr "WPA-flaggor"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "Trådlös skanning"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,20 +792,39 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr "Trådlösa stationer"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "auth=pap"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "inga"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Delete this network"
+#~ msgstr "Ta bort det här nätverket"
 
 #~ msgid "Action"
 #~ msgstr "Åtgärd"
@@ -826,9 +873,6 @@ msgstr "inga"
 #~ msgstr ""
 #~ "Alternativ för ytterligare finjustering om standardvärdena inte passar "
 #~ "dig."
-
-#~ msgid "Remove"
-#~ msgstr "Ta bort"
 
 #~ msgid "Restart"
 #~ msgstr "Starta om"

--- a/applications/luci-app-travelmate/po/templates/travelmate.pot
+++ b/applications/luci-app-travelmate/po/templates/travelmate.pot
@@ -1,101 +1,108 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -105,149 +112,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -255,69 +258,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -325,15 +338,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -341,236 +358,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -580,22 +598,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -603,49 +627,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -653,101 +681,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -755,17 +783,33 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""

--- a/applications/luci-app-travelmate/po/tr/travelmate.po
+++ b/applications/luci-app-travelmate/po/tr/travelmate.po
@@ -10,55 +10,59 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- Erişim Noktası Seçimi --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "Bağlantı Noktası QR-Kodları..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "Yukarı Bağlantı Ekle %q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "Yukarı Bağlantı Ekle..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "Ek Ayarlar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 "Travelmate işleme başlamadan önce saniye cinsinden ek tetikleme gecikmesi."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Kimlik Doğrulama"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "Otomatik Oturum Açma Betiği"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr "Açık Yukarı Bağlantılarıları Otomatik Ekle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 "Yukarı bağlantıyı <em>n</em> dakika sonra otomatik olarak (yeniden) "
-"etkinleştirin, ör. başarısız giriş denemelerinden sonra.<br /> Varsayılan \"0"
-"\" bu özelliği devre dışı bırakır."
+"etkinleştirin, ör. başarısız giriş denemelerinden sonra.<br /> Varsayılan "
+"\"0\" bu özelliği devre dışı bırakır."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
@@ -66,7 +70,7 @@ msgstr ""
 "Kablosuz yapılandırmanıza otomatik olarak otel giriş portalları gibi açık "
 "yukarı bağlantıları ekleyin."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
@@ -75,40 +79,43 @@ msgstr ""
 "bırakın, ör. zamanlanmış bağlantılar için.<br /> Varsayılan \"0\" bu "
 "özelliği devre dışı bırakır."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "VPN (yeniden) bağlantılarını otomatik olarak işle."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 "Yakındaki tarama sonuçlarını hazırlamak için bayt cinsinden arabellek boyutu."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr "CHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "Captive portal algılama"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr "Captive Portal URL'si"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "Kanal"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
@@ -116,7 +123,7 @@ msgstr ""
 "İnternet kullanılabilirliğini kontrol edin, sabit portal yeniden "
 "yönlendirmelerini yönetin ve yukarı bağlantı bağlantısını 'canlı' tutun."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -132,136 +139,132 @@ msgstr ""
 "dikkat: </em> İlk başlangıçta gerekli ağ ve güvenlik duvarı ayarlarını "
 "yapmak için lütfen 'Arayüz Sihirbazı'nı bir kez çalıştırın."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr "Bağlantı Sonu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr "Bağlantı Sonu Son kullanma tarihi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "Bağlantı Sınırı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr "Bağlantı Başlatma"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr "Bağlantı Başlangıcı Son kullanma tarihi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "Sil"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "Bu ağı sil"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Cihaz"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "Cihaz adı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Kapat"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "Yeniden sıralamak için sürükleyin"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr "E-Posta Kancası"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "E-Posta Profili"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "E-Posta Alıcı Adresi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "E-Posta Gönderen Adresi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr "E-Posta ayarları"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "E-Posta Konusu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr "EAP-GTC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "EAP Yöntemi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr "EAP-TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Düzenle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "Bu ağı düzenle"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr "Travelmate hizmetini etkinleştir."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 "Herhangi bir işleme hatası durumunda ayrıntılı hata ayıklama günlüğünü "
 "etkinleştirin."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Etkin"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Şifreleme"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr "Harici Kancalar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
@@ -269,16 +272,16 @@ msgstr ""
 "Otomatik sabit portal oturum açma işlemleri için çağrılacak harici komut "
 "dosyası referansı."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "HIZLI"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Genel Ayarlar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 "Her yukarı bağlantı bağlantısı için rastgele bir tek noktaya yayın MAC "
@@ -288,64 +291,74 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr "LuCI uygulaması travelmate'e erişim izni verin"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 "Travelmate başarılı bir wlan uplink bağlantısı için ne kadar beklemelidir."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "Tanımla"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "BSSID'yi Yoksay"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "Bilgi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr "Arayüz Adı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "Arayüz Zaman Aşımı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "Arayüz Sihirbazı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr "Arayüz Sihirbazı..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr "LAN Cihazı"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "Son çalışma zamanı"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Günlük Kayıtlarını Göster"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
@@ -353,7 +366,7 @@ msgstr ""
 "Koşullu uplink, bağlantı(bağ. kopması) için yüzde olarak minimum sinyal "
 "kalitesi eşiği."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "Net Hata Kontrolü"
 
@@ -361,15 +374,19 @@ msgstr "Net Hata Kontrolü"
 msgid "No travelmate related logs yet!"
 msgstr "Henüz travelmate ile ilgili kayıt yok!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "Genel Zaman Aşımı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "Saniye cinsinden genel yeniden deneme zaman aşımı."
 
@@ -377,7 +394,7 @@ msgstr "Saniye cinsinden genel yeniden deneme zaman aşımı."
 msgid "Overview"
 msgstr "Genel bakış"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
@@ -388,46 +405,46 @@ msgstr ""
 "kaldırabilir veya önceliklendirebilirsiniz. bırakın ve yenileri için "
 "tarayın. Şu anda kullanılan yukarı bağlantı mavi renkle vurgulanmıştır."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Parola"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Özel Anahtarın Şifresi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "CA-Sertifikasına Giden Yol"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "İstemci Sertifikasına Giden Yol"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Özel Anahtara Giden Yol"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr "Lütfen ayrı 'qrencode' paketini kurun."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
@@ -435,19 +452,11 @@ msgstr ""
 "Lütfen dikkat: E-posta bildirimleri, <em>mstmp</em> paketinin ayrı "
 "kurulumunu gerektirir.<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-"Lütfen unutmayın: VPN bağlantıları, <em>Wireguard</em> veya <em>OpenVPN</em> "
-"paketinin ayrı kurulumunu gerektirir.<br /><p>&#xa0;</p>"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "ProActive Uplink Switchi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
@@ -455,28 +464,36 @@ msgstr ""
 "Önceden var olan bir bağlantıya rağmen proaktif olarak tarayın ve daha "
 "yüksek öncelikli bir yukarı bağlantıya geçin."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 "'Msmtp' tarafından travelmate bildirim e-postaları için kullanılan profil."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr "QR Koduna Genel Bakış"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "Kablosuz Seçimi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "MAC Adreslerini Rastgeleleştir"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr "Travelmate bildirim e-postaları için alıcı adresi."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
@@ -484,75 +501,77 @@ msgstr ""
 "WLAN kimlik bilgilerini mobil cihazlarınıza rahatça aktarmak için seçilen "
 "Erişim Noktasının QR Kodunu işle."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "Taramayı Tekrarla"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
-"Travelmate'i tek bir kablosuzla sınırlayın veya genel tarama sırasını "
-"değiştirin (örn.'radio1 radio0')."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "Uplink bağlanma yeniden deneme sınırı."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "Bayrakları Çalıştır"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (gizli)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Kaydet"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "Tarama Arabelleği Boyutu"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr "Tarama açık"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr "Komut Dosyası Bağımsız Değişkenleri"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr "Travelmate bildirim e-postaları için gönderen adresi."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
-msgstr "Her başarılı uplink bağlantısından sonra bildirim e-postaları gönderir."
+msgstr ""
+"Her başarılı uplink bağlantısından sonra bildirim e-postaları gönderir."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "Hizmet Önceliği"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "Sinyal Kalitesi Eşiği"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
@@ -560,72 +579,68 @@ msgstr ""
 "Otomatik Oturum Açma Komut Dosyasına iletilen ek argümanların boşlukla "
 "ayrılmış listesi, yani kullanıcı adı ve parola"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr "Kablosuz tarama başlatılıyor '"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "İstasyon kimliği"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "İstasyon Arayüzü"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "İstasyon MAC'i"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "Durum / Sürüm"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "Güç"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "QR Kodu oluşturulamadı!"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "Güvenlik duvarı bölgesi adı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr "Arayüz metriği"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr "LAN ağ cihazı, ör. \"br-lan\"."
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr "Mantıksal vpn ağ arayüzü, ör. 'wg0' veya 'tun0'."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 "Seçilen URL, bağlantı ve doğrulama amacıyla yönlendirme yapan portal "
 "kontrolleri için kullanılacaktır."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr "Seçilen öncelik travelmate işlemleri için kullanılacaktır."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -639,15 +654,21 @@ msgstr ""
 "Yalnızca travelmate ile ilgili mesajlar için önceden filtrelenmiş syslog "
 "çıktısı."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr "Uplink arayüzü güncellendi."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr "Uplink arayüzü adı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
@@ -657,7 +678,7 @@ msgstr ""
 "sihirbaz, gerekli tüm ağ ve güvenlik duvarı ayarlarıyla bir IPv4 ve IPv6 "
 "diğer ad ağ arabirimi oluşturur."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr "Travelmate bildirim e-postaları için konu."
 
@@ -665,49 +686,53 @@ msgstr "Travelmate bildirim e-postaları için konu."
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr "Travelmate Ayarları"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "Eksik internet kullanılabilirliğini bir hata olarak ele al."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Tetikleme Gecikmesi"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "Kullanıcı Aracısı"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr "VPN Kancası"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "VPN Arayüzü"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "VPN Hizmeti"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr "VPN Ayarları"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "Ayrıntılı Hata Ayıklama Günlüğü"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr "WPA Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr "WPA Ent. (TKIP)"
 
@@ -715,101 +740,101 @@ msgstr "WPA Ent. (TKIP)"
 msgid "WPA Flags"
 msgstr "WPA Bayrakları"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr "WPA Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr "WPA Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr "WPA Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr "WPA/WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr "WPA/WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr "WPA/WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr "WPA/WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr "WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr "WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr "WPA2 Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr "WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr "WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr "WPA2/WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr "WPA2/WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr "WPA2/WPA3 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr "WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr "WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr "WPA3 OWE (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr "WPA3 Pers. (SAE)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "Kablosuz Tarama"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr "Kablosuz Ağ Ayarları"
 
@@ -817,20 +842,65 @@ msgstr "Kablosuz Ağ Ayarları"
 msgid "Wireless Stations"
 msgstr "Kablosuz İstasyonları"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr "auth=MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "auth=PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "hiçbiri"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "VPN (yeniden) bağlantılarını otomatik olarak işle."
+
+#~ msgid "Del"
+#~ msgstr "Sil"
+
+#~ msgid "Delete this network"
+#~ msgstr "Bu ağı sil"
+
+#~ msgid "LAN Device"
+#~ msgstr "LAN Cihazı"
+
+#~ msgid ""
+#~ "Please note: VPN connections require the separate setup of the "
+#~ "<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "Lütfen unutmayın: VPN bağlantıları, <em>Wireguard</em> veya <em>OpenVPN</"
+#~ "em> paketinin ayrı kurulumunu gerektirir.<br /><p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Restrict travelmate to a single radio or change the overall scanning "
+#~ "order (e.g. 'radio1 radio0')."
+#~ msgstr ""
+#~ "Travelmate'i tek bir kablosuzla sınırlayın veya genel tarama sırasını "
+#~ "değiştirin (örn.'radio1 radio0')."
+
+#~ msgid "The lan network device, e.g. 'br-lan'."
+#~ msgstr "LAN ağ cihazı, ör. \"br-lan\"."
 
 #~ msgid "AP on"
 #~ msgstr "AP (erişim noktası) açık"

--- a/applications/luci-app-travelmate/po/uk/travelmate.po
+++ b/applications/luci-app-travelmate/po/uk/travelmate.po
@@ -11,101 +11,108 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "Автентифікація"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -115,149 +122,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "Пристрій"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "Закрити"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "Метод EAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "Редагувати"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "Шифрування"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "Загальні налаштування"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -265,69 +268,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -335,15 +348,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -351,236 +368,237 @@ msgstr ""
 msgid "Overview"
 msgstr "Огляд"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "Пароль"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "Пароль закритого ключа"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "Шлях до сертифіката CA"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "Шлях до сертифіката клієнта"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "Шлях до закритого ключа"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "Видалити"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "Зберегти"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "Налаштування"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -590,22 +608,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -613,49 +637,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -663,101 +691,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -765,19 +793,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"
@@ -818,9 +862,6 @@ msgstr ""
 
 #~ msgid "Move up"
 #~ msgstr "Вгору"
-
-#~ msgid "Remove"
-#~ msgstr "Видалити"
 
 #~ msgid "Restart"
 #~ msgstr "Перезавантажити"

--- a/applications/luci-app-travelmate/po/vi/travelmate.po
+++ b/applications/luci-app-travelmate/po/vi/travelmate.po
@@ -10,101 +10,108 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -114,149 +121,145 @@ msgid ""
 "once, to make the necessary network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "Bật"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr ""
 
@@ -264,69 +267,79 @@ msgstr ""
 msgid "Grant access to LuCI app travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
+msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
-msgid "Last Run"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
 msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr ""
 
@@ -334,15 +347,19 @@ msgstr ""
 msgid "No travelmate related logs yet!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr ""
 
@@ -350,236 +367,237 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
 "ones. The currently used uplink is emphasized in blue."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr ""
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -589,22 +607,28 @@ msgstr ""
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
 "network- and firewall settings."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr ""
 
@@ -612,49 +636,53 @@ msgstr ""
 msgid "Travelmate"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "Kích hoạt độ trễ"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr ""
 
@@ -662,101 +690,101 @@ msgstr ""
 msgid "WPA Flags"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr ""
 
@@ -764,19 +792,35 @@ msgstr ""
 msgid "Wireless Stations"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
 msgstr ""
 
 #~ msgid "Action"

--- a/applications/luci-app-travelmate/po/zh_Hans/travelmate.po
+++ b/applications/luci-app-travelmate/po/zh_Hans/travelmate.po
@@ -16,45 +16,49 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- 选择 AP --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "AP二维码..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "添加上行链路%q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "添加上行链路..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "额外设置"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr "在 travelmate 处理开始前的额外触发延迟（秒）。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "身份验证"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "自动登录脚本"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr "自动添加开放的上行链路"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
@@ -62,13 +66,13 @@ msgstr ""
 "在登录失败等情况下，等待<em>n</em>分钟后（重新）启用上行链路。<br />默认数"
 "值“0”将禁用此功能。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr "自动将开放的上行链路（例如酒店的强制登录门户）添加到您的无线配置中。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
@@ -76,46 +80,49 @@ msgstr ""
 "在连接超时等情况下，等待<em>n</em>分钟后自动禁用上行链路。<br />默认数值“0”将"
 "禁用此功能。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "自动处理VPN（重）连接。"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr "用于暂存扫描结果的缓冲区大小（单位为字节）。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr "CHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "强制登录门户检测"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr "强制登录门户网址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "信道"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 "检查网络可连接性，处理强制登录门户重定向的同时保持上行链路处于活动状态。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -124,154 +131,151 @@ msgid ""
 "<em>Please note:</em> On first start please call the 'Interface Wizard' "
 "once, to make the necessary network- and firewall settings."
 msgstr ""
-"travelmate 包的配置以启用旅行路由器功能。了解更多信息 <a href=\"https://github.com/openwrt/"
-"packages/blob/master/net/travelmate/files/README.md\" target=\"_blank\" rel="
-"\"noreferrer noopener\" > 查看在线文档 </a>。<br "
-"/><em>请注意：</em>第一次启动时，请调用“接口向导”一次，以进行必要的网络和防火墙设置。"
+"travelmate 包的配置以启用旅行路由器功能。了解更多信息 <a href=\"https://"
+"github.com/openwrt/packages/blob/master/net/travelmate/files/README.md\" "
+"target=\"_blank\" rel=\"noreferrer noopener\" > 查看在线文档 </a>。<br /><em>"
+"请注意：</em>第一次启动时，请调用“接口向导”一次，以进行必要的网络和防火墙设"
+"置。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr "连接终止"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr "连接终止超时"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "连接限制"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr "连接启动"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr "连接启动超时"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "删除"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "删除此网络"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "设备"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "设备名称"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "关闭"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "拖动以重排"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr "电子邮件接口"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "电子邮件概要"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "电子邮件收件人地址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "电子邮件发件人地址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr "电子邮件设置"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "电子邮件主题"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr "EAP-GTC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "EAP 类型"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr "EAP-TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "编辑"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "编辑此网络"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr "启用travelmate服务。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在出现任何处理错误时启用详细的调试日志。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "已启用"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "加密"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr "外部接口"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr "引用外部脚本，将用于强制登录门户的登录。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "FAST"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr "为每个上行链路生成一个随机的unicast MAC地址。"
 
@@ -279,69 +283,79 @@ msgstr "为每个上行链路生成一个随机的unicast MAC地址。"
 msgid "Grant access to LuCI app travelmate"
 msgstr "授予访问 LuCI 应用 travelmate 的权限"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr "travelmate 等待 wlan 上行链路连接成功的最长时间。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "认证"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "忽略 BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "信息"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr "接口名称"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "接口超时"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "接口向导"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr "接口向导..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr "本地网络设备"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "最后运行"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "日志视图"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr "最小信号质量阈值（百分比），作为连接（断开）上行链路的条件。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "网络错误检查"
 
@@ -349,15 +363,19 @@ msgstr "网络错误检查"
 msgid "No travelmate related logs yet!"
 msgstr "还没有和travlemate相关的日志！"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "总体超时"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "总体重试超时（秒）。"
 
@@ -365,7 +383,7 @@ msgstr "总体重试超时（秒）。"
 msgid "Overview"
 msgstr "概览"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
@@ -375,233 +393,230 @@ msgstr ""
 "行编辑、移除、排序，或者扫描新的上行链路。目前使用中的上行链路会用蓝色予以强"
 "调。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "密码"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "私钥密码"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "CA 证书路径"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "客户端证书路径"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "私钥路径"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr "请安装“qrencode”软件包。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr "请注意：电子邮件通知需要安装<em>mstmp</em>软件包<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-"请注意：VPN连接需要安装<em>wireguard</em>或者<em>OpenVPN</em>软件包<br /"
-"><p>&#xa0;</p>"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "ProActive 上行链路切换器"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr "不管已经存在的连接，主动扫描并切换到更高优先级的上行链路。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr "用于travelmate电子邮件提醒的“msmtp”资料。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr "二维码概览"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "发射天线选择"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "随机MAC地址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr "travelmate电子邮件提醒的收件人地址。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr "移除"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr "为选中的AP生成二维码来便利的传输登录信息至移动设备。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "重复扫描"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
-"限制travelmate只能使用单一发射天线，或者修改总体的扫描顺序（如“radio1 "
-"radio0”）。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "连接到上行链路的重试次数限制。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "运行标记"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID（隐藏）"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "保存"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "扫描用缓冲区大小"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr "在此扫描"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr "脚本参数"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr "travelmate电子邮件提醒的发件人地址。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr "在每次上行链路连接成功后都发送电子邮件提醒。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "服务优先级"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "信号质量阈值"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr "分隔传递给自动登录脚本的其他可选参数的列表，比如用户名和密码"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr "在此开始无线扫描"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "站点ID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "站点接口"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "站点MAC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "状态 / 版本"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "强度"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "无法生成二维码！"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "防火墙区域名称"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr "接口跃点"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr "本地网络接口，如“br-lan”。"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr "VPN网络逻辑接口，如“wg0”或“tun0”。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr "选中的网址将用于网络可连接性和强制登录门户检查。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr "travelmate进程的优先级。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -611,15 +626,21 @@ msgstr "选中的用户将用于网络可连接性和强制登录门户检查。
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr "此表单显示 syslog 输出，仅针对 travelmate 相关消息进行预过滤。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr "上行链路接口已被更新。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr "上行链路接口名称"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
@@ -628,7 +649,7 @@ msgstr ""
 "为了使用travelmate，你需要设置一次上行链路接口。此向导将生成IPv4和IPv6的相关"
 "网络接口及其相关的防火墙和网络设置。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr "travelmate电子邮件提醒的标题。"
 
@@ -636,49 +657,53 @@ msgstr "travelmate电子邮件提醒的标题。"
 msgid "Travelmate"
 msgstr "Travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr "Travelmate设置"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "将无法连接互联网视为错误。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "触发延时"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "User Agent"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr "VPN接口"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "VPN接口"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "VPN服务"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr "VPN设置"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "详细的调试记录"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr "WPA Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr "WPA Ent. (TKIP)"
 
@@ -686,101 +711,101 @@ msgstr "WPA Ent. (TKIP)"
 msgid "WPA Flags"
 msgstr "WPA参数"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr "WPA Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr "WPA Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr "WPA Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr "WPA/WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr "WPA/WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr "WPA/WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr "WPA/WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr "WPA2 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr "WPA2 Ent. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr "WPA2 Pers."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr "WPA2 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr "WPA2 Pers. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr "WPA2/WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr "WPA2/WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr "WPA2/WPA3 Pers. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr "WPA3 Ent."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr "WPA3 Ent. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr "WPA3 OWE (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr "WPA3 Pers. (SAE)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "无线扫描"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr "无线设置"
 
@@ -788,20 +813,65 @@ msgstr "无线设置"
 msgid "Wireless Stations"
 msgstr "无线站点"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr "auth=MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "auth=PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "无"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "自动处理VPN（重）连接。"
+
+#~ msgid "Del"
+#~ msgstr "删除"
+
+#~ msgid "Delete this network"
+#~ msgstr "删除此网络"
+
+#~ msgid "LAN Device"
+#~ msgstr "本地网络设备"
+
+#~ msgid ""
+#~ "Please note: VPN connections require the separate setup of the "
+#~ "<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "请注意：VPN连接需要安装<em>wireguard</em>或者<em>OpenVPN</em>软件包<br /"
+#~ "><p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Restrict travelmate to a single radio or change the overall scanning "
+#~ "order (e.g. 'radio1 radio0')."
+#~ msgstr ""
+#~ "限制travelmate只能使用单一发射天线，或者修改总体的扫描顺序（如“radio1 "
+#~ "radio0”）。"
+
+#~ msgid "The lan network device, e.g. 'br-lan'."
+#~ msgstr "本地网络接口，如“br-lan”。"
 
 #~ msgid ""
 #~ "Configuration of the travelmate package to to enable travel router "
@@ -965,9 +1035,6 @@ msgstr "无"
 
 #~ msgid "Radio Selection / Order"
 #~ msgstr "无线电选择/顺序"
-
-#~ msgid "Remove"
-#~ msgstr "移除"
 
 #~ msgid "Remove this Uplink"
 #~ msgstr "删除此上行链路"

--- a/applications/luci-app-travelmate/po/zh_Hant/travelmate.po
+++ b/applications/luci-app-travelmate/po/zh_Hant/travelmate.po
@@ -16,45 +16,49 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.7\n"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:73
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:75
 msgid "-- AP Selection --"
 msgstr "-- 選擇AP --"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:261
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:265
 msgid "AP QR-Codes..."
 msgstr "AP QR-Codes..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:823
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:956
 msgid "Add Uplink %q"
 msgstr "新增上行連接 %q"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:679
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:813
 msgid "Add Uplink..."
 msgstr "上行連接..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:280
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:291
 msgid "Additional Settings"
 msgstr "附加設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid ""
 "Additional trigger delay in seconds before travelmate processing begins."
 msgstr "附加觸發 travelmate 行程開始延遲的秒數。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:360
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:787
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:396
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:920
 msgid "Authentication"
 msgstr "認證"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:484
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:489
+msgid "Auto Added Open Uplink"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:568
 msgid "Auto Login Script"
 msgstr "自動登入指令碼"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid "AutoAdd Open Uplinks"
 msgstr "自動新增開放的上行連接"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:551
 msgid ""
 "Automatically (re-)enable the uplink after <em>n</em> minutes, e.g. after "
 "failed login attempts.<br /> The default of '0' disables this feature."
@@ -62,13 +66,13 @@ msgstr ""
 "在登錄失敗等情況下，等待<em>n</em>分鍾後 (重新) 啟用上傳。<br />預設數值 '0' "
 "將停用此功能。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:327
 msgid ""
 "Automatically add open uplinks like hotel captive portals to your wireless "
 "config."
 msgstr "自動新增開放的上行連接 (例如旅館的強制登錄門戶) 加入到您的無線設定中。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:449
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:533
 msgid ""
 "Automatically disable the uplink after <em>n</em> minutes, e.g. for timed "
 "connections.<br /> The default of '0' disables this feature."
@@ -76,46 +80,49 @@ msgstr ""
 "在連接逾時等情況下，等待<em>n</em>分鍾後自動停用上行連接。<br />預設數值 '0' "
 "將停用此功能。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
-msgid "Automatically handle VPN (re-) connections."
-msgstr "自動處理 VPN (重新) 連接。"
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
+msgid ""
+"Automatically handle VPN connections.<br /> Please note: This feature "
+"requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
+"em>."
+msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:574
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:743
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:708
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Buffer size in bytes to prepare nearby scan results."
 msgstr "緩衝區大小（以位元組為單位）以準備附近的掃描結果。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:362
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:790
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
 msgstr "CHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid "Captive Portal Detection"
 msgstr "網頁驗證入口偵測"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid "Captive Portal URL"
 msgstr "網頁驗證入口網址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:572
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:706
 msgid "Channel"
 msgstr "頻道"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:310
 msgid ""
 "Check the internet availability, handle captive portal redirections and keep "
 "the uplink connection 'alive'."
 msgstr ""
 "檢查網際網路可用性，處理網頁驗證入口重導的同時保持上行連接處於 '存活' 狀態。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:147
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:149
 msgid ""
 "Configuration of the travelmate package to enable travel router "
 "functionality. For further information <a href=\"https://github.com/openwrt/"
@@ -124,154 +131,151 @@ msgid ""
 "<em>Please note:</em> On first start please call the 'Interface Wizard' "
 "once, to make the necessary network- and firewall settings."
 msgstr ""
-"travelmate 軟體包的設定以啟用旅行路由器功能。了解更多資訊 <a href=\"https://github.com/openwrt/"
-"packages/blob/master/net/travelmate/files/README.md\" target=\"_blank\" rel="
-"\"noreferrer noopener\" > 檢視線上文件 </a>。<br "
-"/><em>請注意：</em>第一次啟動時，請呼叫「介面精靈」一次，以進行必要的網路和防火牆設定。"
+"travelmate 軟體包的設定以啟用旅行路由器功能。了解更多資訊 <a href=\"https://"
+"github.com/openwrt/packages/blob/master/net/travelmate/files/README.md\" "
+"target=\"_blank\" rel=\"noreferrer noopener\" > 檢視線上文件 </a>。<br /><em>"
+"請注意：</em>第一次啟動時，請呼叫「介面精靈」一次，以進行必要的網路和防火牆設"
+"定。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:437
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:478
 msgid "Connection End"
 msgstr "連接終止"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:466
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:550
 msgid "Connection End Expiry"
 msgstr "連線終止逾時"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Connection Limit"
 msgstr "連線限制"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:426
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:467
 msgid "Connection Start"
 msgstr "連線啟動"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:448
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:532
 msgid "Connection Start Expiry"
 msgstr "連線啟動逾時"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:228
-msgid "Del"
-msgstr "刪除"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:226
-msgid "Delete this network"
-msgstr "刪除這個網路"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:245
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:281
 msgid "Device"
 msgstr "裝置"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:716
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:849
 msgid "Device Name"
 msgstr "裝置名稱"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:43
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:129
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:587
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:829
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:45
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:131
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:721
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:962
 msgid "Dismiss"
 msgstr "關閉"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:215
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:246
 msgid "Drag to reorder"
 msgstr "拖動來排序"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "E-Mail Hook"
 msgstr "電子郵件掛鉤"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "E-Mail Profile"
 msgstr "電郵設定檔"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "E-Mail Receiver Address"
 msgstr "電郵收件人位址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "E-Mail Sender Address"
 msgstr "電郵寄件人位址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid "E-Mail Settings"
 msgstr "電子郵件設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "E-Mail Topic"
 msgstr "電郵主旨"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:365
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:793
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:401
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:926
 msgid "EAP-GTC"
 msgstr "EAP-GTC"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:366
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:794
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:402
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:927
 msgid "EAP-MD5"
 msgstr "EAP-MD5"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:367
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:795
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:403
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:928
 msgid "EAP-MSCHAPV2"
 msgstr "EAP-MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:351
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:779
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:387
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:912
 msgid "EAP-Method"
 msgstr "可擴展身份驗證協定(EAP)-方式"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:368
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:796
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:929
 msgid "EAP-TLS"
 msgstr "EAP-TLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:223
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:254
 msgid "Edit"
 msgstr "編輯"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:221
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:252
 msgid "Edit this network"
 msgstr "編輯此網路"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
 msgid "Enable the travelmate service."
 msgstr "啟用 travelmate 服務。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Enable verbose debug logging in case of any processing errors."
 msgstr "在出現任何處理錯誤的情況下，請啟用詳細除錯日誌記錄。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:287
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:233
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
+msgid "Enable/Disable this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
 msgid "Enabled"
 msgstr "啟用"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:256
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:575
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:749
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:292
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:709
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:882
 msgid "Encryption"
 msgstr "加密(Encryption)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:244
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:246
 msgid "Ext. Hooks"
 msgstr "外部掛勾"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:485
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:569
 msgid ""
 "External script reference which will be called for automated captive portal "
 "logins."
 msgstr "引用外部指令碼，將用於網頁驗證入口的登錄。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:355
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:784
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:391
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:917
 msgid "FAST"
 msgstr "快速"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Generate a random unicast MAC address for each uplink connection."
 msgstr "為每個上行連路產生一個隨機的單播MAC 位址。"
 
@@ -279,69 +283,79 @@ msgstr "為每個上行連路產生一個隨機的單播MAC 位址。"
 msgid "Grant access to LuCI app travelmate"
 msgstr "授予 luci-app-travelmate 擁有 UCI 存取的權限"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid ""
 "How long should travelmate wait for a successful wlan uplink connection."
 msgstr "travelmate 等待 wlan 上行連線成功最長時間。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:375
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:801
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:411
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:934
 msgid "Identify"
 msgstr "識別"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:735
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:868
 msgid "Ignore BSSID"
 msgstr "忽略 BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:224
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:220
 msgid "Information"
 msgstr "資訊"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:720
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:853
 msgid "Interface Name"
 msgstr "介面名稱"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:336
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:355
 msgid "Interface Timeout"
 msgstr "介面逾時"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:19
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:22
 msgid "Interface Wizard"
 msgstr "介面精靈"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:279
 msgid "Interface Wizard..."
 msgstr "介面精靈..."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "LAN Device"
-msgstr "區域網路裝置"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:247
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:250
 msgid "Last Run"
 msgstr "最後執行"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid "Limit AutoAdd"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+msgid ""
+"Limit the maximum number of automatically added open uplinks. To disable "
+"this limitation set it to '0'."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "日誌檢視"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:363
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:791
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:506
+msgid "MAC Address"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:399
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:924
 msgid "MSCHAP"
 msgstr "MSCHAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:364
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:792
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:400
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:925
 msgid "MSCHAPV2"
 msgstr "MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid ""
 "Minimum signal quality threshold as percent for conditional uplink (dis-) "
 "connections."
 msgstr "最小訊號品質閾值 (百分比)，作為 (中斷) 連線上行的條件。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Net Error Check"
 msgstr "網路錯誤檢查"
 
@@ -349,15 +363,19 @@ msgstr "網路錯誤檢查"
 msgid "No travelmate related logs yet!"
 msgstr "還沒有和 travlemate 相關的日誌！"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:275
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:311
 msgid "OWE"
 msgstr "OWE"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
+msgid "On/Off"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall Timeout"
 msgstr "總體逾時"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:341
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:360
 msgid "Overall retry timeout in seconds."
 msgstr "總體重試逾時 (秒)。"
 
@@ -365,7 +383,7 @@ msgstr "總體重試逾時 (秒)。"
 msgid "Overview"
 msgstr "概覽"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:201
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:231
 msgid ""
 "Overview of all configured uplinks for travelmate.<br /> You can edit, "
 "remove or prioritize existing uplinks by drag &#38; drop and scan for new "
@@ -374,233 +392,230 @@ msgstr ""
 "travelmate 已設定的所有上行概覽。<br />您可以透過拖曳來對已有的上行進行編輯、"
 "移除、排序，或者掃描新的上行。目前使用中的上行會用藍色予以強調。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:361
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:789
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:397
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:922
 msgid "PAP"
 msgstr "PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:354
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:783
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:390
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:916
 msgid "PEAP"
 msgstr "PEAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:343
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:772
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:905
 msgid "Password"
 msgstr "密碼"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:394
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:816
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:430
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:949
 msgid "Password of Private Key"
 msgstr "私鑰密碼"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:379
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:804
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:415
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:937
 msgid "Path to CA-Certificate"
 msgstr "CA 憑證路徑"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:384
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:808
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:420
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:941
 msgid "Path to Client-Certificate"
 msgstr "用戶憑證的路徑"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:812
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:425
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:945
 msgid "Path to Private Key"
 msgstr "私鑰的路徑"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:258
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:262
 msgid "Please install the separate 'qrencode' package."
 msgstr "請安裝「qrencode」套件。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:282
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:292
 msgid ""
 "Please note: E-Mail notifications require the separate setup of the "
 "<em>mstmp</em> package.<br /><p>&#xa0;</p>"
 msgstr "請注意：電子郵件通知需要安裝<em>mstmp</em>套件<br /><p>&#xa0;</p>"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
-msgid ""
-"Please note: VPN connections require the separate setup of the "
-"<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
-msgstr ""
-"請注意：VPN 連線需要安裝<em>wireguard</em>或者<em>OpenVPN</em>套件<br /"
-"><p>&#xa0;</p>"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid "ProActive Uplink Switch"
 msgstr "ProActive 上行切換器"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:319
 msgid ""
 "Proactively scan and switch to a higher prioritized uplink, despite of an "
 "already existing connection."
 msgstr "不管已經存在的連線，主動掃描並切換到更高優先順序的上行。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:422
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:418
 msgid "Profile used by 'msmtp' for travelmate notification E-Mails."
 msgstr "用於 travelmate 電子郵件提醒的「msmtp」資料。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:114
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:116
 msgid "QR-Code Overview"
 msgstr "QR-Code 概覽"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
 msgid "Radio Selection"
 msgstr "發射天線選擇"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:323
 msgid "Randomize MAC Addresses"
 msgstr "隨機 MAC 位址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:407
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:403
 msgid "Receiver address for travelmate notification E-Mails."
 msgstr "travelmate 電子郵件提醒的收件人位址。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:115
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
+msgid "Remove"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
+msgid "Remove this network"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:117
 msgid ""
 "Render the QR-Code of the selected Access Point to comfortably transfer the "
 "WLAN credentials to your mobile devices."
 msgstr "為選取的 AP 產生 QR-Code 來便利的傳輸登錄資訊至行動裝置。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:592
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:726
 msgid "Repeat Scan"
 msgstr "重複掃描"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:293
-msgid ""
-"Restrict travelmate to a single radio or change the overall scanning order "
-"(e.g. 'radio1 radio0')."
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:272
+msgid "Restart Interface"
 msgstr ""
-"限制 travelmate 只能使用單一發射天線，或者修改總體的掃描順序 (例如 'radio1 "
-"radio0')。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:326
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:303
+msgid ""
+"Restrict travelmate to a single radio or change the overall scanning order."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:345
 msgid "Retry limit to connect to an uplink."
 msgstr "連線到上行連線的重試限制。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:241
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:242
 msgid "Run Flags"
 msgstr "執行旗標"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:248
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:404
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:573
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:729
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:284
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:445
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:707
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:862
 msgid "SSID"
 msgstr "SSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:725
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:858
 msgid "SSID (hidden)"
 msgstr "SSID (隱藏)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:61
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:834
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:63
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:967
 msgid "Save"
 msgstr "儲存"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:346
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
 msgid "Scan Buffer Size"
 msgstr "掃描緩衝區大小"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:557
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
 msgstr "在此掃描"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:523
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:607
 msgid "Script Arguments"
 msgstr "指令碼參數"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:412
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:408
 msgid "Sender address for travelmate notification E-Mails."
 msgstr "travelmate 電子郵件提醒的發件人位址。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:404
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:400
 msgid "Sends notification E-Mails after every succesful uplink connect."
 msgstr "在每次上行連接成功後都傳送電子郵件提醒。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "Service Priority"
 msgstr "服務優先權"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:277
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:288
 msgid "Settings"
 msgstr "設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:331
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:350
 msgid "Signal Quality Threshold"
 msgstr "訊號品質閾值"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:524
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:608
 msgid ""
 "Space separated list of additional arguments passed to the Auto Login "
 "Script, i.e. username and password"
 msgstr "分隔傳遞給自動登錄指令碼的其他可選參數的列表，比如使用者名稱和密碼"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:579
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:713
 msgid "Starting wireless scan on '"
 msgstr "在此開始無線掃描"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:229
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
 msgid "Station ID"
 msgstr "站台 ID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:235
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:234
 msgid "Station Interface"
 msgstr "站台介面"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:232
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:230
 msgid "Station MAC"
 msgstr "站台MAC位址"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:226
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:222
 msgid "Status / Version"
 msgstr "狀態／版本"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:571
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:705
 msgid "Strength"
 msgstr "強度"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:352
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:781
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:388
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:914
 msgid "TLS"
 msgstr "傳輸層安全性協定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:353
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:782
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:915
 msgid "TTLS"
 msgstr "TTLS"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:105
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:107
 msgid "The QR-Code could not be generated!"
 msgstr "無法產生 QR-Code！"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:31
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:33
 msgid "The firewall zone name"
 msgstr "防火牆區域名稱"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:36
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:38
 msgid "The interface metric"
 msgstr "介面指標"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:395
-msgid "The lan network device, e.g. 'br-lan'."
-msgstr "本地網路介面，例如 'br-lan'。"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "The logical vpn network interface, e.g. 'wg0' or 'tun0'."
 msgstr "VPN 網路邏輯介面，如「wg0」或「tun0」。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:351
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:370
 msgid ""
 "The selected URL will be used for connectivity- and captive portal checks."
 msgstr "選取的網址將用於網路可連接性和網頁驗證入口檢查。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:368
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:388
 msgid "The selected priority will be used for travelmate processes."
 msgstr "travelmate 行程將使用已選擇的優先權。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid ""
 "The selected user agent will be used for connectivity- and captive portal "
 "checks."
@@ -610,15 +625,21 @@ msgstr "選取的使用者將用於網路可連接性和網頁驗證入口檢查
 msgid "The syslog output, pre-filtered for travelmate related messages only."
 msgstr "此表單顯示 syslog 輸出，僅針對 travelmate 相關訊息進行預過濾。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:56
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:58
 msgid "The uplink interface has been updated."
 msgstr "上行介面已被更新。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:26
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:28
 msgid "The uplink interface name"
 msgstr "上行介面名稱"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:20
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:490
+msgid ""
+"This option is selected by default if this uplink was added automatically "
+"and counts as 'Open Uplink'."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
 "To use Travelmate, you have to set up an uplink interface once. This wizard "
 "creates an IPv4- and an IPv6 alias network interface with all required "
@@ -627,7 +648,7 @@ msgstr ""
 "為了使用 travelmate，您需要設定一次上行介面。此精靈將產生 IPv4 和 IPv6 的相關"
 "網路介面及其相關的防火牆和網路設定。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:417
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:413
 msgid "Topic for travelmate notification E-Mails."
 msgstr "travelmate 電子郵件提醒的標題。"
 
@@ -635,49 +656,53 @@ msgstr "travelmate 電子郵件提醒的標題。"
 msgid "Travelmate"
 msgstr "travelmate"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:209
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:239
 msgid "Travelmate Settings"
 msgstr "travelmate 設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:314
 msgid "Treat missing internet availability as an error."
 msgstr "將無法連接網際網路視為錯誤。"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:321
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:340
 msgid "Trigger Delay"
 msgstr "觸發延遲"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:359
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:507
+msgid "Use the specified MAC address for this uplink."
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:379
 msgid "User Agent"
 msgstr "用戶代理"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:380
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:628
 msgid "VPN Hook"
 msgstr "VPN掛鉤"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:389
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:660
 msgid "VPN Interface"
 msgstr "VPN 介面"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:383
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:645
 msgid "VPN Service"
 msgstr "VPN 服務"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:281
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:240
 msgid "VPN Settings"
 msgstr "VPN 設定"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:290
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:300
 msgid "Verbose Debug Logging"
 msgstr "詳細除錯日誌"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:271
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:764
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:307
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:897
 msgid "WPA Ent. (CCMP)"
 msgstr "WPA企業（CCMP）"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:272
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:765
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:308
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:898
 msgid "WPA Ent. (TKIP)"
 msgstr "WPA 企業. (TKIP)"
 
@@ -685,101 +710,101 @@ msgstr "WPA 企業. (TKIP)"
 msgid "WPA Flags"
 msgstr "WPA 參數"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:262
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:755
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:298
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:888
 msgid "WPA Pers."
 msgstr "WPA 個人."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:263
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:756
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:299
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:889
 msgid "WPA Pers. (CCMP)"
 msgstr "WPA 個人. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:264
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:757
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:300
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:890
 msgid "WPA Pers. (TKIP)"
 msgstr "WPA 個人. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:273
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:766
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:309
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:899
 msgid "WPA/WPA2 Ent. (CCMP)"
 msgstr "WPA/WPA2 企業. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:274
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:767
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:310
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:900
 msgid "WPA/WPA2 Ent. (TKIP)"
 msgstr "WPA/WPA2 個人. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:265
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:758
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:301
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:891
 msgid "WPA/WPA2 Pers. (CCMP)"
 msgstr "WPA/WPA2 個人. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:266
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:759
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:302
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:892
 msgid "WPA/WPA2 Pers. (TKIP)"
 msgstr "WPA/WPA2 個人. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:269
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:762
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:305
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:895
 msgid "WPA2 Ent. (CCMP)"
 msgstr "WPA2 企業. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:270
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:763
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:306
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:896
 msgid "WPA2 Ent. (TKIP)"
 msgstr "WPA2 企業. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:259
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:752
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:295
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:885
 msgid "WPA2 Pers."
 msgstr "WPA2 個人."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:260
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:753
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:296
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:886
 msgid "WPA2 Pers. (CCMP)"
 msgstr "WPA2 個人. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:261
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:754
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:297
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:887
 msgid "WPA2 Pers. (TKIP)"
 msgstr "WPA2 個人. (TKIP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:761
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:894
 msgid "WPA2/WPA3 Ent."
 msgstr "WPA2/WPA3 企業."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:268
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:304
 msgid "WPA2/WPA3 Ent. (CCMP)"
 msgstr "WPA2/WPA3 企業 (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:258
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:751
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:294
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:884
 msgid "WPA2/WPA3 Pers. (CCMP)"
 msgstr "WPA2/WPA3 個人. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:760
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:893
 msgid "WPA3 Ent."
 msgstr "WPA3 企業."
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:267
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:303
 msgid "WPA3 Ent. (CCMP)"
 msgstr "WPA3 企業. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:768
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:901
 msgid "WPA3 OWE (CCMP)"
 msgstr "WPA3 OWE (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:257
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:750
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:293
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:883
 msgid "WPA3 Pers. (SAE)"
 msgstr "WPA3 個人. (CCMP)"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:581
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:715
 msgid "Wireless Scan"
 msgstr "無線掃描"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:208
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:238
 msgid "Wireless Settings"
 msgstr "無線設定"
 
@@ -787,20 +812,65 @@ msgstr "無線設定"
 msgid "Wireless Stations"
 msgstr "無線站點"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:370
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:798
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:406
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:931
 msgid "auth=MSCHAPV2"
 msgstr "驗證= MSCHAPV2"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:369
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:797
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:405
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:930
 msgid "auth=PAP"
 msgstr "驗證= PAP"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:276
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:769
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:312
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:902
 msgid "none"
 msgstr "無"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:306
+msgid "use both radios, normal sort order (radio0 radio1)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:307
+msgid "use both radios, reverse sort order (radio1 radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:304
+msgid "use the first radio only (radio0)"
+msgstr ""
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
+msgid "use the second radio only (radio1)"
+msgstr ""
+
+#~ msgid "Automatically handle VPN (re-) connections."
+#~ msgstr "自動處理 VPN (重新) 連接。"
+
+#~ msgid "Del"
+#~ msgstr "刪除"
+
+#~ msgid "Delete this network"
+#~ msgstr "刪除這個網路"
+
+#~ msgid "LAN Device"
+#~ msgstr "區域網路裝置"
+
+#~ msgid ""
+#~ "Please note: VPN connections require the separate setup of the "
+#~ "<em>Wireguard</em> or <em>OpenVPN</em> package.<br /><p>&#xa0;</p>"
+#~ msgstr ""
+#~ "請注意：VPN 連線需要安裝<em>wireguard</em>或者<em>OpenVPN</em>套件<br /"
+#~ "><p>&#xa0;</p>"
+
+#~ msgid ""
+#~ "Restrict travelmate to a single radio or change the overall scanning "
+#~ "order (e.g. 'radio1 radio0')."
+#~ msgstr ""
+#~ "限制 travelmate 只能使用單一發射天線，或者修改總體的掃描順序 (例如 "
+#~ "'radio1 radio0')。"
+
+#~ msgid "The lan network device, e.g. 'br-lan'."
+#~ msgstr "本地網路介面，例如 'br-lan'。"
 
 #~ msgid ""
 #~ "Configuration of the travelmate package to to enable travel router "

--- a/applications/luci-app-travelmate/root/usr/share/rpcd/acl.d/luci-app-travelmate.json
+++ b/applications/luci-app-travelmate/root/usr/share/rpcd/acl.d/luci-app-travelmate.json
@@ -16,8 +16,10 @@
 				"/tmp/trm_runtime.json": [ "read" ],
 				"/sbin/logread -e trm-": [ "exec" ],
 				"/usr/sbin/logread -e trm-": [ "exec" ],
+				"/usr/sbin/ifup *": [ "exec" ],
 				"/etc/init.d/travelmate reload" : [ "exec" ],
 				"/etc/init.d/travelmate restart" : [ "exec" ],
+				"/etc/init.d/travelmate assoc" : [ "exec" ],
 				"/etc/init.d/travelmate setup [0-9a-z_]* [0-9a-z_]* [0-9]*" : [ "exec" ],
 				"/etc/init.d/travelmate scan radio[0-9]" : [ "exec" ],
 				"/usr/bin/qrencode --inline --8bit --type=SVG --output=- *" : [ "exec" ]


### PR DESCRIPTION
* support new features of travelmate 2.0.5
* made the station manager more comfortable
* a few minor bugfixes
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>