### PR TITLE
luci-mod-status: optimize view/formatting for status/routing

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -246,7 +246,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -346,20 +345,20 @@ msgstr "إجراءات"
 msgid "Active"
 msgstr "نشيط"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "الطرق <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>النشطة"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "الطرق <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>النشطة"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2760,6 +2759,7 @@ msgstr "نفق GRETAP عبر IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "بوابة"
 
@@ -3054,6 +3054,8 @@ msgid "IP Type"
 msgstr "نوع IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "نوع IP"
 
@@ -3086,7 +3088,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "جدار حماية IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3098,7 +3104,6 @@ msgstr "IPv4 المنبع"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "عنوان IPv4"
@@ -3112,7 +3117,6 @@ msgid "IPv4 broadcast"
 msgstr "بث IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "بوابة IPv4"
 
@@ -3175,7 +3179,7 @@ msgstr "جدار حماية IPv6"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "جيران IPv6"
 
@@ -3183,7 +3187,7 @@ msgstr "جيران IPv6"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3202,7 +3206,6 @@ msgstr "IPv6 المنبع"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "عنوان IPv6"
 
@@ -5997,7 +6000,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7050,7 +7053,7 @@ msgstr ""
 "قارنهما بالملف الأصلي لضمان تكامل البيانات. <br /> انقر فوق \"متابعة\" أدناه "
 "لبدء إجراء الفلاش."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "القواعد التالية نشطة حاليًا على هذا النظام."
 

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -245,7 +245,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -343,20 +342,20 @@ msgstr "Действия"
 msgid "Active"
 msgstr "Активен"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2698,6 +2697,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -2991,6 +2991,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr ""
 
@@ -3023,7 +3025,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3035,7 +3041,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr ""
@@ -3049,7 +3054,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3112,7 +3116,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3120,7 +3124,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3139,7 +3143,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5865,7 +5868,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6861,7 +6864,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr ""
 

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -244,7 +244,6 @@ msgstr ""
 msgid "APN"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr ""
@@ -342,20 +341,20 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2676,6 +2675,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -2969,6 +2969,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr ""
 
@@ -3001,7 +3003,11 @@ msgstr ""
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3013,7 +3019,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr ""
@@ -3027,7 +3032,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3090,7 +3094,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3117,7 +3121,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5841,7 +5844,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6837,7 +6840,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr ""
 

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -252,7 +252,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -353,20 +352,20 @@ msgstr "Accions"
 msgid "Active"
 msgstr "Actiu"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Rutes <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> actives"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Rutes <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> actives"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2724,6 +2723,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Passarel·la"
 
@@ -3022,6 +3022,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Adreça IP"
 
@@ -3054,7 +3056,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Tallafocs IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3066,7 +3072,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Adreça IPv4"
@@ -3080,7 +3085,6 @@ msgid "IPv4 broadcast"
 msgstr "Difusió IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Passarel·la IPv4"
 
@@ -3143,7 +3147,7 @@ msgstr "Tallafocs IPv6"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "Veïns IPv6"
 
@@ -3151,7 +3155,7 @@ msgstr "Veïns IPv6"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3170,7 +3174,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Adreça IPv6"
 
@@ -5915,7 +5918,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6915,7 +6918,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Les següents regles estan actualment actives en aquest sistema."
 

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -246,7 +246,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -348,24 +347,24 @@ msgstr "Akce"
 msgid "Active"
 msgstr "Aktivní"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Aktivní záznamy ve směrovací tabulce <abbr title=\"Internet Protocol Version "
 "4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Aktivní záznamy ve směrovací tabulce <abbr title=\"Internet Protocol Version "
 "6\">IPv6</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2773,6 +2772,7 @@ msgstr "Tunel GRETAP přes IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Brána"
 
@@ -3068,6 +3068,8 @@ msgid "IP Type"
 msgstr "Typ IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP adresy"
 
@@ -3100,7 +3102,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4 firewall"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3112,7 +3118,6 @@ msgstr "IPv4 Upstream"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4 adresa"
@@ -3126,7 +3131,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4 broadcast"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4 brána"
 
@@ -3190,7 +3194,7 @@ msgstr "IPv6 firewall"
 msgid "IPv6 MTU"
 msgstr "IPv6 MTU"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "Sousedé IPv6"
 
@@ -3198,7 +3202,7 @@ msgstr "Sousedé IPv6"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3217,7 +3221,6 @@ msgstr "IPv6 Upstream"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6 adresa"
 
@@ -6037,7 +6040,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7073,7 +7076,7 @@ msgstr ""
 "souboru. Porovnejte je s originálním souborem pro zajištění integrity dat. "
 "<br /> Klepněte na \"Pokračovat\" níže pro zahájení procedury flashování."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Následující pravidla jsou nyní na tomto systému aktivní."
 

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -250,7 +250,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -353,20 +352,20 @@ msgstr "Aktionen"
 msgid "Active"
 msgstr "Aktiv"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2850,6 +2849,7 @@ msgstr "GRETAP-Tunnel über IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Gateway"
 
@@ -3148,6 +3148,8 @@ msgid "IP Type"
 msgstr "IP-Typ"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP-Adresse"
 
@@ -3180,7 +3182,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4 Firewall"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3192,7 +3198,6 @@ msgstr "IPv4-Upstream"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4 Adresse"
@@ -3206,7 +3211,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4 Broadcast"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4 Gateway"
 
@@ -3269,7 +3273,7 @@ msgstr "IPv6 Firewall"
 msgid "IPv6 MTU"
 msgstr "IPv6-MTU"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6 Nachbarn"
 
@@ -3277,7 +3281,7 @@ msgstr "IPv6 Nachbarn"
 msgid "IPv6 RA Settings"
 msgstr "IPv6-RA-Einstellungen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3296,7 +3300,6 @@ msgstr "IPv6-Upstream"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6 Adresse"
 
@@ -6166,7 +6169,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7320,7 +7323,7 @@ msgstr ""
 "zu gewährleisten.<br />Auf \"Fortfahren\" klicken um den Schreibvorgang zu "
 "starten."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Die folgenden Regeln sind zur Zeit auf dem System aktiv."
 

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -247,7 +247,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr ""
@@ -348,22 +347,22 @@ msgstr "Ενέργειες"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Ενεργές Διαδρομές <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Ενεργές Διαδρομές <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2734,6 +2733,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Πύλη"
 
@@ -3029,6 +3029,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Διεύθυνση IP"
 
@@ -3061,7 +3063,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4 Τείχος Προστασίας"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3073,7 +3079,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Διεύθυνση IPv4"
@@ -3087,7 +3092,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Πύλη IPv4"
 
@@ -3150,7 +3154,7 @@ msgstr "IPv6 Τείχος Προστασίας"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3158,7 +3162,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3177,7 +3181,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Διεύθυνση IPv6"
 
@@ -5926,7 +5929,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6926,7 +6929,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Οι παρακάτω κανόνες είναι αυτή τη στιγμή ενεργοί σε αυτό το σύστημα."
 

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -248,7 +248,6 @@ msgstr ""
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr ""
@@ -349,20 +348,20 @@ msgstr "Actions"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2711,6 +2710,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -3006,6 +3006,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP address"
 
@@ -3038,7 +3040,11 @@ msgstr ""
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3050,7 +3056,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr ""
@@ -3064,7 +3069,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3127,7 +3131,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3135,7 +3139,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3154,7 +3158,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5896,7 +5899,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6894,7 +6897,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "The following rules are currently active on this system."
 

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -253,7 +253,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -356,20 +355,20 @@ msgstr "Acciones"
 msgid "Active"
 msgstr "Activo"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Rutas <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> activas"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr "Reglas <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> activas"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Rutas <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> activas"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr "Reglas <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> activas"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2850,6 +2849,7 @@ msgstr "Túnel GRETAP sobre IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Puerta de enlace"
 
@@ -3151,6 +3151,8 @@ msgid "IP Type"
 msgstr "Tipo de IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Dirección IP"
 
@@ -3183,7 +3185,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Cortafuegos IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr "Enrutamiento IPv4"
 
@@ -3195,7 +3201,6 @@ msgstr "Conexión IPv4 ascendente"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Dirección IPv4"
@@ -3209,7 +3214,6 @@ msgid "IPv4 broadcast"
 msgstr "Difusión IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Puerta de enlace IPv4"
 
@@ -3272,7 +3276,7 @@ msgstr "Cortafuegos IPv6"
 msgid "IPv6 MTU"
 msgstr "MTU IPv6"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "Vecinos de IPv6"
 
@@ -3280,7 +3284,7 @@ msgstr "Vecinos de IPv6"
 msgid "IPv6 RA Settings"
 msgstr "Configuración de RA de IPv6"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr "Enrutamiento IPv6"
 
@@ -3299,7 +3303,6 @@ msgstr "Conexión IPv6 ascendente"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Dirección IPv6"
 
@@ -6153,7 +6156,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr "Enrutamiento"
@@ -7298,7 +7301,7 @@ msgstr ""
 "para garantizar la integridad de los datos. <br /> Haga clic en \"Continuar"
 "\" a continuación para iniciar el procedimiento de instalación."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Las siguientes reglas están actualmente activas en este sistema."
 

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -244,7 +244,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -345,23 +344,23 @@ msgstr "Toiminnot"
 msgid "Active"
 msgstr "Aktiivinen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Aktiiviset <abbr title = \"Internet Protocol Version 4\"> IPv4 </abbr> -"
 "reitit"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Aktiiviset <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-reitit"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2784,6 +2783,7 @@ msgstr "GRETAP tunneli IPv6:n yli"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Yhdyskäytävä"
 
@@ -3080,6 +3080,8 @@ msgid "IP Type"
 msgstr "IP-tyyppi"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP-osoite"
 
@@ -3112,7 +3114,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4-palomuuri"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3124,7 +3130,6 @@ msgstr "IPv4 ylävirta"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4-osoite"
@@ -3138,7 +3143,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4-lähetys"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4-yhdyskäytävä"
 
@@ -3201,7 +3205,7 @@ msgstr "IPv6-palomuuri"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6-naapurit"
 
@@ -3209,7 +3213,7 @@ msgstr "IPv6-naapurit"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3228,7 +3232,6 @@ msgstr "IPv6 ylävirta"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6-osoite"
 
@@ -6043,7 +6046,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7118,7 +7121,7 @@ msgstr ""
 "niitä alkuperäiseen tiedostoon tietojen eheyden varmistamiseksi. <br /> "
 "Aloita levykuvan kirjoittaminen napsauttamalla alla olevaa Jatka-painiketta."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Seuraavat säännöt ovat tällä hetkellä käytössä tässä järjestelmässä."
 

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -254,7 +254,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -362,20 +361,20 @@ msgstr "Actions"
 msgid "Active"
 msgstr "Actif"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Routes <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> actives"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Routes <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> actives"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2820,6 +2819,7 @@ msgstr "Tunnel GRETAP sur IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Passerelle"
 
@@ -3117,6 +3117,8 @@ msgid "IP Type"
 msgstr "Type IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Adresse IP"
 
@@ -3149,7 +3151,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Pare-feu IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3161,7 +3167,6 @@ msgstr "IPv4 en amont"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Adresse IPv4"
@@ -3175,7 +3180,6 @@ msgid "IPv4 broadcast"
 msgstr "Diffusion IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Passerelle IPv4"
 
@@ -3238,7 +3242,7 @@ msgstr "Pare-feu IPv6"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "Voisinage IPv6"
 
@@ -3246,7 +3250,7 @@ msgstr "Voisinage IPv6"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3265,7 +3269,6 @@ msgstr "IPv6 amont"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Adresse IPv6"
 
@@ -6080,7 +6083,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7169,7 +7172,7 @@ msgstr ""
 "pour garantir l'intégrité des données. <br/> Cliquez sur \"Continuer\" ci-"
 "dessous pour démarrer la procédure de flash."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Les règles suivantes sont actuellement actives sur ce système."
 

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -246,7 +246,6 @@ msgstr ""
 msgid "APN"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr ""
@@ -347,20 +346,20 @@ msgstr "פעולות"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2699,6 +2698,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -2992,6 +2992,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr ""
 
@@ -3024,7 +3026,11 @@ msgstr ""
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3036,7 +3042,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "כתבות IPv4"
@@ -3050,7 +3055,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3113,7 +3117,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3121,7 +3125,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3140,7 +3144,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5864,7 +5867,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6865,7 +6868,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "החוקים הבאים מאופשרים כרגע במערכת זו."
 

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -243,7 +243,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr ""
@@ -344,20 +343,20 @@ msgstr "चाल-चलन"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2678,6 +2677,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -2971,6 +2971,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr ""
 
@@ -3003,7 +3005,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3015,7 +3021,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr ""
@@ -3029,7 +3034,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3092,7 +3096,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3100,7 +3104,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3119,7 +3123,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5843,7 +5846,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6839,7 +6842,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr ""
 

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -249,7 +249,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -352,22 +351,22 @@ msgstr "Műveletek"
 msgid "Active"
 msgstr "Aktív"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Aktív <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> útvonalak"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Aktív <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-útvonalak"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2788,6 +2787,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Átjáró"
 
@@ -3084,6 +3084,8 @@ msgid "IP Type"
 msgstr "IP típusa"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP-cím"
 
@@ -3116,7 +3118,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4 tűzfal"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3128,7 +3134,6 @@ msgstr "Külső IPv4"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4-cím"
@@ -3142,7 +3147,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4 üzenetszórás"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4-átjáró"
 
@@ -3205,7 +3209,7 @@ msgstr "IPv6 tűzfal"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6 szomszédok"
 
@@ -3213,7 +3217,7 @@ msgstr "IPv6 szomszédok"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3232,7 +3236,6 @@ msgstr "Külső IPv6"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6-cím"
 
@@ -6055,7 +6058,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7105,7 +7108,7 @@ msgstr ""
 "adatok helyességéről.<br />Kattintson a lenti „Folytatás” gombra a "
 "telepítési eljárás indításához."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Jelenleg a következő szabályok aktívak a rendszeren."
 

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -253,7 +253,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -354,22 +353,22 @@ msgstr "Azioni"
 msgid "Active"
 msgstr "Attivo"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Instradamenti <abbr title=\"Internet Protocol Version 4\">IPv4</abbr> attivi"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Instradamenti <abbr title=\"Internet Protocol Version 6\">IPv6</abbr> attivi"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2738,6 +2737,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Gateway"
 
@@ -3033,6 +3033,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Indirizzo IP"
 
@@ -3065,7 +3067,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Firewall IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3077,7 +3083,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Indirizzi IPv4"
@@ -3091,7 +3096,6 @@ msgid "IPv4 broadcast"
 msgstr "Broadcast IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Gateway IPv4"
 
@@ -3154,7 +3158,7 @@ msgstr "Firewall IPv6"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3162,7 +3166,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3181,7 +3185,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Indirizzi IPv6"
 
@@ -5938,7 +5941,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6950,7 +6953,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Le seguenti regole sono al momento attive su questo sistema."
 

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -248,7 +248,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -350,22 +349,22 @@ msgstr "操作"
 msgid "Active"
 msgstr "アクティブ"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "アクティブな<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>ルート"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "アクティブな<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>ルート"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2786,6 +2785,7 @@ msgstr "IPv6上のGRETAPトンネル"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "ゲートウェイ"
 
@@ -3083,6 +3083,8 @@ msgid "IP Type"
 msgstr "IPの種類"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IPアドレス"
 
@@ -3115,7 +3117,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4ファイアウォール"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3127,7 +3133,6 @@ msgstr "IPv4アップストリーム"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4アドレス"
@@ -3141,7 +3146,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4ブロードキャスト"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4ゲートウェイ"
 
@@ -3204,7 +3208,7 @@ msgstr "IPv6ファイアウォール"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6隣接装置"
 
@@ -3212,7 +3216,7 @@ msgstr "IPv6隣接装置"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3231,7 +3235,6 @@ msgstr "IPv6アップストリーム"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6アドレス"
 
@@ -6049,7 +6052,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7125,7 +7128,7 @@ msgstr ""
 "イズです。オリジナルのファイルと比較し、データの整合性を確認してください。"
 "<br />\"続行\" をクリックすると、フラッシュ処理を開始します。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "このシステムでは、現在以下のルールが有効です。"
 

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -248,7 +248,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -350,22 +349,22 @@ msgstr "관리 도구"
 msgid "Active"
 msgstr "활성화"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Route 경로"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Route 경로"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2722,6 +2721,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -3016,6 +3016,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP 주소"
 
@@ -3048,7 +3050,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4 방화벽"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3061,7 +3067,6 @@ msgstr "IPv4 업스트림"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4 주소"
@@ -3075,7 +3080,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3138,7 +3142,7 @@ msgstr "IPv6 방화벽"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6 Neighbour 들"
 
@@ -3146,7 +3150,7 @@ msgstr "IPv6 Neighbour 들"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3165,7 +3169,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6-주소"
 
@@ -5907,7 +5910,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6922,7 +6925,7 @@ msgstr ""
 "본 파일과 비교하여 데이터 무결성을 검증하세요.<br />아래 \"진행하기\"를 눌러 "
 "플래시 절차를 시작하세요."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 #, fuzzy
 msgid "The following rules are currently active on this system."
 msgstr "다음의 규칙들이 현재 이 시스템에 적용 중입니다."

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -244,7 +244,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -342,20 +341,20 @@ msgstr "क्रिया"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2676,6 +2675,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -2969,6 +2969,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr ""
 
@@ -3001,7 +3003,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3013,7 +3019,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr ""
@@ -3027,7 +3032,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3090,7 +3094,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3098,7 +3102,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3117,7 +3121,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5841,7 +5844,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6837,7 +6840,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr ""
 

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -248,7 +248,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -346,20 +345,20 @@ msgstr "Aksi"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Aktive IPv4-Routen"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Aktif IPv6-Laluan"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2686,6 +2685,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -2981,6 +2981,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Alamat IP"
 
@@ -3013,7 +3015,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3025,7 +3031,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr ""
@@ -3039,7 +3044,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3102,7 +3106,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3110,7 +3114,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3129,7 +3133,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5867,7 +5870,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6866,7 +6869,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Peraturan berikut sedang aktif pada sistem ini."
 

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -244,7 +244,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "<abbr title=\"Aksesspunkt Navn\">APN</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -350,20 +349,20 @@ msgstr "Handlinger"
 msgid "Active"
 msgstr "Aktiv"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Ruter"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Aktive <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Ruter"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2723,6 +2722,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Gateway"
 
@@ -3018,6 +3018,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP adresse"
 
@@ -3050,7 +3052,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4 Brannmur"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3062,7 +3068,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4 adresse"
@@ -3076,7 +3081,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4 kringkasting"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4 gateway"
 
@@ -3139,7 +3143,7 @@ msgstr "IPv6 Brannmur"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3147,7 +3151,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3166,7 +3170,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6 adresse"
 
@@ -5919,7 +5922,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6929,7 +6932,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Følgende regler er aktiver på systemet."
 

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -245,7 +245,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -347,20 +346,20 @@ msgstr "Acties"
 msgid "Active"
 msgstr "Actief"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Actieve <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Actieve <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2688,6 +2687,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -2981,6 +2981,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr ""
 
@@ -3013,7 +3015,11 @@ msgstr ""
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3025,7 +3031,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr ""
@@ -3039,7 +3044,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3102,7 +3106,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3110,7 +3114,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3129,7 +3133,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5858,7 +5861,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6854,7 +6857,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr ""
 

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -250,7 +250,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -355,20 +354,20 @@ msgstr "Akcje"
 msgid "Active"
 msgstr "Aktywny"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Aktywne trasy <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr "Aktywne reguły <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Aktywne trasy <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr "Aktywne reguły <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2829,6 +2828,7 @@ msgstr "Tunel GRETAP przez IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Brama"
 
@@ -3129,6 +3129,8 @@ msgid "IP Type"
 msgstr "Typ IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Adres IP"
 
@@ -3161,7 +3163,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Zapora sieciowa IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr "Trasowanie IPv4"
 
@@ -3173,7 +3179,6 @@ msgstr "Połączenie IPv4"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Adres IPv4"
@@ -3187,7 +3192,6 @@ msgid "IPv4 broadcast"
 msgstr "Transmisja IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Brama IPv4"
 
@@ -3250,7 +3254,7 @@ msgstr "Zapora sieciowa IPv6"
 msgid "IPv6 MTU"
 msgstr "IPv6 MTU"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "Sąsiedztwo IPv6"
 
@@ -3258,7 +3262,7 @@ msgstr "Sąsiedztwo IPv6"
 msgid "IPv6 RA Settings"
 msgstr "Ustawienia RA IPv6"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr "Trasowanie IPv6"
 
@@ -3277,7 +3281,6 @@ msgstr "Połączenie IPv6"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Adres IPv6"
 
@@ -6127,7 +6130,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr "Trasowanie"
@@ -7257,7 +7260,7 @@ msgstr ""
 "pliku, porównaj je z oryginalnym plikiem, aby zapewnić integralność danych. "
 "<br /> Kliknij \"Kontynuuj\" poniżej, aby rozpocząć procedurę flashowania."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Następujące zasady są obecnie aktywne w tym systemie."
 

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -253,7 +253,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -356,22 +355,22 @@ msgstr "Ações"
 msgid "Active"
 msgstr "Ativo"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Rotas-<abbr title=\"Protocolo de Internet Versão 4\">IPv4</abbr> Ativas"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Rotas-<abbr title=\"Protocolo de Internet Versão 6\">IPv6</abbr> Ativas"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2838,6 +2837,7 @@ msgstr "Túnel GRETAP sobre IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Gateway"
 
@@ -3138,6 +3138,8 @@ msgid "IP Type"
 msgstr "Tipo de IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Endereço IP"
 
@@ -3170,7 +3172,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Firewall IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3182,7 +3188,6 @@ msgstr "IPv4 Superior"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Endereço IPv4"
@@ -3196,7 +3201,6 @@ msgid "IPv4 broadcast"
 msgstr "Broadcast IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Gateway IPv4"
 
@@ -3259,7 +3263,7 @@ msgstr "Firewall IPv6"
 msgid "IPv6 MTU"
 msgstr "MTU IPv6"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "Vizinhos IPv6"
 
@@ -3267,7 +3271,7 @@ msgstr "Vizinhos IPv6"
 msgid "IPv6 RA Settings"
 msgstr "Configurações do IPv6 RA"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3286,7 +3290,6 @@ msgstr "IPv6 Superior"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Endereço IPv6"
 
@@ -6146,7 +6149,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7276,7 +7279,7 @@ msgstr ""
 "integridade dos dados. <br /> Clique em 'Continuar' abaixo para iniciar o "
 "procedimento flash."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "As seguintes regras estão actualmente acivas neste sistema."
 

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -257,7 +257,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "<abbr title=\"Access Point Name\">APN</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -366,23 +365,23 @@ msgstr "Ações"
 msgid "Active"
 msgstr "Ativo"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Rotas <abbr title=\"Protocolo de Internet Versão 4\">IPv4</abbr> ativas"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 "Ative as regras <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Rotas <abbr title=\"Protocolo de Internet Versão 6\">IPv6</abbr> ativas"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 "Ative as regras <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
 
@@ -2874,6 +2873,7 @@ msgstr "Túnel GRETAP sobre IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Roteador"
 
@@ -3178,6 +3178,8 @@ msgid "IP Type"
 msgstr "Tipo de IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Endereço IP"
 
@@ -3210,7 +3212,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Firewall para IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr "Roteamento IPv4"
 
@@ -3222,7 +3228,6 @@ msgstr "Enlace IPv4 Superior"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Endereço IPv4"
@@ -3236,7 +3241,6 @@ msgid "IPv4 broadcast"
 msgstr "Broadcast IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Roteador padrão IPv4"
 
@@ -3299,7 +3303,7 @@ msgstr "Firewall para IPv6"
 msgid "IPv6 MTU"
 msgstr "MTU IPv6"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "Vizinhos IPv6"
 
@@ -3307,7 +3311,7 @@ msgstr "Vizinhos IPv6"
 msgid "IPv6 RA Settings"
 msgstr "Configurações do IPv6 RA"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr "Roteamento IPv6"
 
@@ -3328,7 +3332,6 @@ msgstr "Enlace IPv6 Superior"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Endereço IPv6"
 
@@ -6200,7 +6203,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr "Roteamento"
@@ -7345,7 +7348,7 @@ msgstr ""
 "integridade dos dados. <br /> Clique em 'Continuar' para iniciar o "
 "procedimento de atualização."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "As seguintes regras estão atualmente ativas neste sistema."
 

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -248,7 +248,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -349,20 +348,20 @@ msgstr "Actiune"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Rute active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Rute active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2700,6 +2699,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Gateway"
 
@@ -2995,6 +2995,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Adresa IP"
 
@@ -3027,7 +3029,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Firewall IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3039,7 +3045,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Adresa IPv4"
@@ -3053,7 +3058,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3116,7 +3120,7 @@ msgstr "Firewall IPv6"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3124,7 +3128,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3143,7 +3147,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Adresa IPv6"
 
@@ -5874,7 +5877,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6870,7 +6873,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr ""
 

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -254,7 +254,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -356,23 +355,23 @@ msgstr "Действия"
 msgid "Active"
 msgstr "Активный"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Активные <abbr title=\"Интернет протокол версии 4\">IPv4</abbr>-маршруты"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 "Активные <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-правила"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Активные <abbr title=\"Интернет протокол версии 6\">IPv6</abbr>-маршруты"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 "Активные <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-правила"
 
@@ -2843,6 +2842,7 @@ msgstr "GRETAP туннель через IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Шлюз"
 
@@ -3141,6 +3141,8 @@ msgid "IP Type"
 msgstr "Тип IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP-адрес"
 
@@ -3173,7 +3175,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Межсетевой экран IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr "IPv4 маршрутизация"
 
@@ -3185,7 +3191,6 @@ msgstr "Подключение IPv4 (upstream)"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4-адрес"
@@ -3199,7 +3204,6 @@ msgid "IPv4 broadcast"
 msgstr "Широковещательный IPv4-адрес"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4-адрес шлюза"
 
@@ -3262,7 +3266,7 @@ msgstr "Межсетевой экран IPv6"
 msgid "IPv6 MTU"
 msgstr "IPv6 MTU"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6 соседи (neighbours)"
 
@@ -3270,7 +3274,7 @@ msgstr "IPv6 соседи (neighbours)"
 msgid "IPv6 RA Settings"
 msgstr "Настройки IPv6 RA"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr "IPv6 маршрутизация"
 
@@ -3289,7 +3293,6 @@ msgstr "Подключение IPv6 (upstream)"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6-адрес"
 
@@ -6150,7 +6153,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr "Маршрутизация"
@@ -7279,7 +7282,7 @@ msgstr ""
 "сравните их с оригинальным файлом для обеспечения целостности данных.<br /"
 ">Нажмите кнопку «Продолжить» ниже, чтобы начать процедуру прошивки."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "На данном устройстве активны следующие правила."
 

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -249,7 +249,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -347,20 +346,20 @@ msgstr "Akcie"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2700,6 +2699,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Brána"
 
@@ -2996,6 +2996,8 @@ msgid "IP Type"
 msgstr "Typ IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Adresa IP"
 
@@ -3028,7 +3030,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Brána Firewall IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3041,7 +3047,6 @@ msgstr "IPv4 prúd"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Adresa IPv4"
@@ -3055,7 +3060,6 @@ msgid "IPv4 broadcast"
 msgstr "Vysielanie IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Brána IPv4"
 
@@ -3118,7 +3122,7 @@ msgstr "Brána Firewall IPv6"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6 susedia"
 
@@ -3126,7 +3130,7 @@ msgstr "IPv6 susedia"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3145,7 +3149,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Adresa IPv6"
 
@@ -5883,7 +5886,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6888,7 +6891,7 @@ msgstr ""
 "<br/> Kliknutím na „Pokračovať“ nižsie, spustíte procedúru nahrávania do "
 "pamäte flash."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "V tomto systéme sú momentálne aktívne nasledujúce pravidlá."
 

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -247,7 +247,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -345,20 +344,20 @@ msgstr "Åtgärder"
 msgid "Active"
 msgstr "Aktiv"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Aktiva <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-rutter"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Aktiva <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-rutter"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2692,6 +2691,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Gateway"
 
@@ -2987,6 +2987,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP-adress"
 
@@ -3019,7 +3021,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4-brandvägg"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3031,7 +3037,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4-adress"
@@ -3045,7 +3050,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4-gateway"
 
@@ -3108,7 +3112,7 @@ msgstr "IPv6-brandvägg"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPV6-grannar"
 
@@ -3116,7 +3120,7 @@ msgstr "IPV6-grannar"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3135,7 +3139,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6-adress"
 
@@ -5864,7 +5867,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6860,7 +6863,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr ""
 

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -235,7 +235,6 @@ msgstr ""
 msgid "APN"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr ""
@@ -333,20 +332,20 @@ msgstr ""
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2667,6 +2666,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -2960,6 +2960,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr ""
 
@@ -2992,7 +2994,11 @@ msgstr ""
 msgid "IPv4 Firewall"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3004,7 +3010,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr ""
@@ -3018,7 +3023,6 @@ msgid "IPv4 broadcast"
 msgstr ""
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3081,7 +3085,7 @@ msgstr ""
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3089,7 +3093,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3108,7 +3112,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr ""
 
@@ -5832,7 +5835,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -6828,7 +6831,7 @@ msgid ""
 "'Continue' below to start the flash procedure."
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr ""
 

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -248,7 +248,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -350,20 +349,20 @@ msgstr "Eylemler"
 msgid "Active"
 msgstr "Etkin"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "Aktif <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rotaları"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr "Aktif <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Kurallar"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "Aktif <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rotaları"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr "Aktif <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Kurallar"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2814,6 +2813,7 @@ msgstr "IPv6 üzerinden GRETAP tüneli"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Ağ Geçidi"
 
@@ -3113,6 +3113,8 @@ msgid "IP Type"
 msgstr "IP Türü"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP adresi"
 
@@ -3145,7 +3147,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4 Güvenlik Duvarı"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr "IPv4 Yönlendirme"
 
@@ -3157,7 +3163,6 @@ msgstr "IPv4 Yukarı Akış"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4 adresi"
@@ -3171,7 +3176,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4 yayını"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4 ağ geçidi"
 
@@ -3234,7 +3238,7 @@ msgstr "IPv6 Güvenlik Duvarı"
 msgid "IPv6 MTU"
 msgstr "IPv6 MTU"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6 Komşuları"
 
@@ -3242,7 +3246,7 @@ msgstr "IPv6 Komşuları"
 msgid "IPv6 RA Settings"
 msgstr "IPv6 RA Ayarları"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr "IPv6 Yönlendirme"
 
@@ -3261,7 +3265,6 @@ msgstr "IPv6 Yukarı Akım"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6 adresi"
 
@@ -6097,7 +6100,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr "Yönlendirme"
@@ -7220,7 +7223,7 @@ msgstr ""
 "karşılaştırın.<br /> Cihaza yazma prosedürünü başlatmak için aşağıdaki "
 "'Devam Et'e tıklayın."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Aşağıdaki kurallar bu sistemde şu anda etkin durumdadır."
 

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -256,7 +256,6 @@ msgid "APN"
 msgstr ""
 "<abbr title=\"Access Point Name — символічна назва точки доступу\">APN</abbr>"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -364,20 +363,20 @@ msgstr "Дії"
 msgid "Active"
 msgstr "Активний"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "<abbr title=\"Інтернет-протокол версії 4\">IPv4</abbr>-маршрути"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "<abbr title=\"Інтернет-протокол версії 6\">IPv6</abbr>-маршрути"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2819,6 +2818,7 @@ msgstr "Тунель GRETAP через IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "Шлюз"
 
@@ -3118,6 +3118,8 @@ msgid "IP Type"
 msgstr "Тип IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP-адреса"
 
@@ -3150,7 +3152,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Брандмауер IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3162,7 +3168,6 @@ msgstr "Висхідне з'єднання IPv4"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Адреса IPv4"
@@ -3176,7 +3181,6 @@ msgid "IPv4 broadcast"
 msgstr "Широкомовний IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "Шлюз IPv4"
 
@@ -3239,7 +3243,7 @@ msgstr "Брандмауер IPv6"
 msgid "IPv6 MTU"
 msgstr "IPv6 MTU"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "Сусіди IPv6"
 
@@ -3247,7 +3251,7 @@ msgstr "Сусіди IPv6"
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3268,7 +3272,6 @@ msgstr "Висхідне з'єднання IPv6"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Адреса IPv6"
 
@@ -6102,7 +6105,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7157,7 +7160,7 @@ msgstr ""
 "Порівняйте їх з вихідним файлом, щоб переконатися в цілісності даних. <br /> "
 "Натисніть 'Продовжити', щоб розпочати процедуру прошивання."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Наразі в цій системі активні такі правила."
 

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -250,7 +250,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -353,24 +352,24 @@ msgstr "Hành động"
 msgid "Active"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr ""
 "Active <abbr title=\"giao thức kết nối internet phiên bản 4\">IPv4</abbr>-"
 "Routes"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr ""
 "Active <abbr title=\"giao thức kết nối internet phiên bản 6\">IPv6</abbr>-"
 "Routes"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2751,6 +2750,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr ""
 
@@ -3046,6 +3046,8 @@ msgid "IP Type"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "Địa chỉ IP"
 
@@ -3078,7 +3080,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "Tường lửa địa chỉ IPv4"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr ""
 
@@ -3090,7 +3096,6 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "Địa chỉ IPv4"
@@ -3104,7 +3109,6 @@ msgid "IPv4 broadcast"
 msgstr "Quảng bá IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr ""
 
@@ -3167,7 +3171,7 @@ msgstr "Tường lửa IPv6"
 msgid "IPv6 MTU"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr ""
 
@@ -3175,7 +3179,7 @@ msgstr ""
 msgid "IPv6 RA Settings"
 msgstr ""
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr ""
 
@@ -3194,7 +3198,6 @@ msgstr ""
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "Địa chỉ IPv6"
 
@@ -5989,7 +5992,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr ""
@@ -7015,7 +7018,7 @@ msgstr ""
 "được liệt kê, so sánh chúng với tệp gốc để đảm bảo tính toàn vẹn dữ liệu. "
 "<br /> Nhấp vào ' Tiếp tục ' bên dưới để bắt đầu quy trình flash."
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "Các quy tắc sau hiện đang hoạt động trên hệ thống"
 

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -248,7 +248,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -348,20 +347,20 @@ msgstr "操作"
 msgid "Active"
 msgstr "活跃"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "活动的 <abbr title=\"互联网协议第 4 版\">IPv4</abbr> 路由"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr "活跃的<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>规则"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "活动的 <abbr title=\"互联网协议第 6 版\">IPv6</abbr> 路由"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr "活跃的<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>规则"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2736,6 +2735,7 @@ msgstr "承载于 IPv6 上的 GRETAP 通道"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "网关"
 
@@ -3031,6 +3031,8 @@ msgid "IP Type"
 msgstr "IP 类型"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP 地址"
 
@@ -3063,7 +3065,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4 防火墙"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr "IPv4 路由"
 
@@ -3075,7 +3081,6 @@ msgstr "IPv4 上游"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4 地址"
@@ -3089,7 +3094,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4 广播地址"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4 网关"
 
@@ -3152,7 +3156,7 @@ msgstr "IPv6 防火墙"
 msgid "IPv6 MTU"
 msgstr "IPv6 MTU"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6 网上邻居"
 
@@ -3160,7 +3164,7 @@ msgstr "IPv6 网上邻居"
 msgid "IPv6 RA Settings"
 msgstr "IPv6 RA 设置"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr "IPv6 路由"
 
@@ -3179,7 +3183,6 @@ msgstr "IPv6 上游"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6 地址"
 
@@ -5952,7 +5955,7 @@ msgstr "路由指定通过哪个接口和网关可以到达某个主机或网络
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr "路由"
@@ -6992,7 +6995,7 @@ msgstr ""
 "刷写镜像已上传。下面是列出的校验和及文件大小，将它们与原始文件进行比较以确保"
 "数据完整性。<br />单击下面的“继续”开始刷写。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "以下规则当前在系统中处于活动状态。"
 

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -249,7 +249,6 @@ msgstr "ANSI T1.413"
 msgid "APN"
 msgstr "APN"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:353
 msgid "ARP"
 msgstr "ARP"
@@ -349,20 +348,20 @@ msgstr "動作"
 msgid "Active"
 msgstr "活躍"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:243
+msgid "Active IPv4 Routes"
 msgstr "啟用 <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-路由"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:254
-msgid "Active <abbr title=\"Internet Protocol Version 4\">IPv4</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:246
+msgid "Active IPv4 Rules"
 msgstr "使用中的<abbr title=\"Internet Protocol Version 4\">IPv4</abbr>規則"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Routes"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:253
+msgid "Active IPv6 Routes"
 msgstr "啟用 <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-路由"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:264
-msgid "Active <abbr title=\"Internet Protocol Version 6\">IPv6</abbr>-Rules"
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:256
+msgid "Active IPv6 Rules"
 msgstr "使用中的<abbr title=\"Internet Protocol Version 6\">IPv6</abbr>規則"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
@@ -2744,6 +2743,7 @@ msgstr "IPv6上的GRETAP隧道"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:74
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "Gateway"
 msgstr "閘道器"
 
@@ -3039,6 +3039,8 @@ msgid "IP Type"
 msgstr "IP 類型"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:501
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IP address"
 msgstr "IP位址"
 
@@ -3071,7 +3073,11 @@ msgstr "IPv4"
 msgid "IPv4 Firewall"
 msgstr "IPv4防火牆"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:247
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:240
+msgid "IPv4 Neighbours"
+msgstr ""
+
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:239
 msgid "IPv4 Routing"
 msgstr "IPv4 路由"
 
@@ -3083,7 +3089,6 @@ msgstr "IPv4 上游"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:585
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:88
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:164
 msgid "IPv4 address"
 msgstr "IPv4位址"
@@ -3097,7 +3102,6 @@ msgid "IPv4 broadcast"
 msgstr "IPv4 廣播"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:180
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:188
 msgid "IPv4 gateway"
 msgstr "IPv4閘道"
 
@@ -3160,7 +3164,7 @@ msgstr "IPv6防火牆"
 msgid "IPv6 MTU"
 msgstr "IPv6 MTU"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:258
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:250
 msgid "IPv6 Neighbours"
 msgstr "IPv6網路芳鄰"
 
@@ -3168,7 +3172,7 @@ msgstr "IPv6網路芳鄰"
 msgid "IPv6 RA Settings"
 msgstr "IPv6 RA 設定"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:257
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:249
 msgid "IPv6 Routing"
 msgstr "IPv6 路由"
 
@@ -3187,7 +3191,6 @@ msgstr "IPv6 上游"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js:127
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:204
 msgid "IPv6 address"
 msgstr "IPv6位址"
 
@@ -5959,7 +5962,7 @@ msgstr "路由器指定介面導出到特定主機或者能夠到達的網路."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:50
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:236
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
 msgstr "路由"
@@ -7001,7 +7004,7 @@ msgstr ""
 "映像檔已上傳。下方是效驗碼和大小，請與原始檔比較確認無誤。<br />按下方「執"
 "行」開始燒錄程序。"
 
-#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:245
+#: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:237
 msgid "The following rules are currently active on this system."
 msgstr "以下的規則現正作用在系統中."
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js
@@ -175,7 +175,7 @@ return view.extend({
 
 		var neigh4tbl = E('table', { 'class': 'table' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
-				E('th', { 'class': 'th' }, [ _('IPv4 address') ]),
+				E('th', { 'class': 'th' }, [ _('IP address') ]),
 				E('th', { 'class': 'th' }, [ _('MAC address') ]),
 				E('th', { 'class': 'th' }, [ _('Interface') ])
 			])
@@ -185,7 +185,7 @@ return view.extend({
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th' }, [ _('Network') ]),
 				E('th', { 'class': 'th' }, [ _('Target') ]),
-				E('th', { 'class': 'th' }, [ _('IPv4 gateway') ]),
+				E('th', { 'class': 'th' }, [ _('Gateway') ]),
 				E('th', { 'class': 'th' }, [ _('Metric') ]),
 				E('th', { 'class': 'th' }, [ _('Table') ]),
 				E('th', { 'class': 'th' }, [ _('Protocol') ])
@@ -201,7 +201,7 @@ return view.extend({
 
 		var neigh6tbl = E('table', { 'class': 'table' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
-				E('th', { 'class': 'th' }, [ _('IPv6 address') ]),
+				E('th', { 'class': 'th' }, [ _('IP address') ]),
 				E('th', { 'class': 'th' }, [ _('MAC address') ]),
 				E('th', { 'class': 'th' }, [ _('Interface') ])
 			])
@@ -233,35 +233,27 @@ return view.extend({
 		cbi_update_table(rule6tbl, this.parseRule(ip6rule, networks, false));
 
 		var view = E([], [
-			E('style', { 'type': 'text/css' }, [
-				'.cbi-tooltip-container, span.jump { border-bottom:1px dotted #00f;cursor:pointer }',
-				'ul { list-style:none }',
-				'.references { position:relative }',
-				'.references .cbi-tooltip { left:0!important;top:1.5em!important }',
-				'h4>span { font-size:90% }'
-			]),
-
 			E('h2', {}, [ _('Routing') ]),
 			E('p', {}, [ _('The following rules are currently active on this system.') ]),
 			E('div', {}, [
 				E('div', { 'data-tab': 'ipv4routing', 'data-tab-title': _('IPv4 Routing') }, [
-					E('h3', {}, [ _('ARP') ]),
+					E('h3', {}, [ _('IPv4 Neighbours') ]),
 					neigh4tbl,
 
-					E('h3', {}, _('Active <abbr title="Internet Protocol Version 4">IPv4</abbr>-Routes')),
+					E('h3', {}, [ _('Active IPv4 Routes') ]),
 					route4tbl,
 
-					E('h3', {}, _('Active <abbr title="Internet Protocol Version 4">IPv4</abbr>-Rules')),
+					E('h3', {}, [ _('Active IPv4 Rules') ]),
 					rule4tbl
 				]),
 				E('div', { 'data-tab': 'ipv6routing', 'data-tab-title': _('IPv6 Routing') }, [
 					E('h3', {}, [ _('IPv6 Neighbours') ]),
 					neigh6tbl,
 
-					E('h3', {}, _('Active <abbr title="Internet Protocol Version 6">IPv6</abbr>-Routes')),
+					E('h3', {}, [ _('Active IPv6 Routes') ]),
 					route6tbl,
 
-					E('h3', {}, _('Active <abbr title="Internet Protocol Version 6">IPv6</abbr>-Rules')),
+					E('h3', {}, [ _('Active IPv6 Rules') ]),
 					rule6tbl
 				])
 			])


### PR DESCRIPTION
Optimize view and formatting for the status/routing page.
Remove redundant style and header abbreviations.
Consolidate terminology for IPv4 and IPv6 categories.

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>