### PR TITLE
luci-app-statistics: add support for MaxMissed

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/ping.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/ping.js
@@ -13,7 +13,7 @@ return baseclass.extend({
 
 		o = s.option(form.DynamicList, 'Hosts', _('Monitor hosts'));
 		o.default = '127.0.0.1';
-		o.datatype = 'ipaddr("nomask")';
+		o.datatype = 'host';
 		o.depends('enable', '1');
 
 		o = s.option(form.ListValue, 'AddressFamily', _('Address family'));
@@ -31,6 +31,13 @@ return baseclass.extend({
 		o = s.option(form.Value, 'Interval', _('Interval for pings'), _('Seconds'));
 		o.default = '30';
 		o.datatype = 'ufloat';
+		o.depends('enable', '1');
+
+	    o=s.option(form.Value,'MaxMissed',_('Maximum Missed Packets'),
+		       _('When a host has not replied to this number of packets in a row, re-resolve the hostname in DNS.  Useful for dynamic DNS hosts.'));
+		o.placeholder = '10';
+		o.datatype = 'uinteger';
+		o.optional = true;
 		o.depends('enable', '1');
 	},
 

--- a/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/ping.json
+++ b/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/ping.json
@@ -2,7 +2,7 @@
 	"title": "Ping",
 	"category": "network",
 	"legend": [
-		["TTL", "Interval", "AddressFamily"],
+		["TTL", "Interval", "AddressFamily", "MaxMissed"],
 		[],
 		["Hosts"]
 	]


### PR DESCRIPTION
* Add support for MaxMissed, documented in collectd: https://collectd.org/documentation/manpages/collectd.conf.5.shtml#plugin_ping
* Correct the type of hosts entries, they can be hostnames as well as IP addresses

Tested in concert with a change to packages/collectd-mod-ping to manage the collectd configuration for `MaxMissed`, viewable here: https://github.com/openwrt/packages/pull/16362

I tested setting the value to -1 does not re-resolve hosts after pings fail.
Watched DNS traffic with tcpdump to see that setting the value to positive integer results in a DNS re-resolve after that many ping failures. I swapped my phone between two networks reachable from the same router, and saw that after switching networks, collectd switched to pinging the new address after the desired number of failures.

Signed-off-by: John Kohl <jtk.git@bostonpog.org>