### PR TITLE
luci-base: support loopback by widgets.NetworkSelect

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
@@ -372,7 +372,10 @@ var CBINetworkSelect = form.ListValue.extend({
 			var network = this.networks[i],
 			    name = network.getName();
 
-			if (name == 'loopback' || name == this.exclude || !this.filter(section_id, name))
+			if (name == this.exclude || !this.filter(section_id, name))
+				continue;
+
+			if (name == 'loopback' && !this.loopback)
 				continue;
 
 			if (this.novirtual && network.isVirtual())


### PR DESCRIPTION
Support the "loopback" interface by "widgets.NetworkSelect".
Enable the "loopback" option to include this interface.
Can be used to configure interface binding for services.

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>