### PR TITLE
luci-app-travelmate: sync with travelmate 2.0.5-3

### DIFF
--- a/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js
+++ b/applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js
@@ -362,9 +362,9 @@ return view.extend({
 		o.datatype = 'range(30,300)';
 		o.rmempty = true;
 
-		o = s.taboption('additional', form.Value, 'trm_scanbuffer', _('Scan Buffer Size'), _('Buffer size in bytes to prepare nearby scan results.'));
-		o.placeholder = '1024';
-		o.datatype = 'range(256,4096)';
+		o = s.taboption('additional', form.Value, 'trm_maxscan', _('Scan Limit'), _('Limit the nearby scan results to process only the strongest uplinks.'));
+		o.placeholder = '10';
+		o.datatype = 'range(1,30)';
 		o.rmempty = true;
 
 		o = s.taboption('additional', form.ListValue, 'trm_captiveurl', _('Captive Portal URL'), _('The selected URL will be used for connectivity- and captive portal checks.'));

--- a/applications/luci-app-travelmate/po/ar/travelmate.po
+++ b/applications/luci-app-travelmate/po/ar/travelmate.po
@@ -85,10 +85,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -316,6 +312,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "عرض السجل"
@@ -502,7 +502,7 @@ msgid "Save"
 msgstr "إحفض"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/bg/travelmate.po
+++ b/applications/luci-app-travelmate/po/bg/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr "Запази"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/bn_BD/travelmate.po
+++ b/applications/luci-app-travelmate/po/bn_BD/travelmate.po
@@ -78,10 +78,6 @@ msgstr ""
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -309,6 +305,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -495,7 +495,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/ca/travelmate.po
+++ b/applications/luci-app-travelmate/po/ca/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr "Desar"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/cs/travelmate.po
+++ b/applications/luci-app-travelmate/po/cs/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Zobrazení protokolu"
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr "Uložit"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/de/travelmate.po
+++ b/applications/luci-app-travelmate/po/de/travelmate.po
@@ -92,10 +92,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr "Puffergröße in Bytes, um die Scan-Resultate aufzubereiten."
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -331,6 +327,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Protokollansicht"
@@ -531,8 +531,8 @@ msgid "Save"
 msgstr "Speichern"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "Scan-Puffergröße"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -865,6 +865,12 @@ msgstr ""
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr ""
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr "Puffergröße in Bytes, um die Scan-Resultate aufzubereiten."
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "Scan-Puffergröße"
 
 #~ msgid "Automatically handle VPN (re-) connections."
 #~ msgstr "Automatisch den Auf- und Abbau von VPN-Verbindungen regeln."

--- a/applications/luci-app-travelmate/po/el/travelmate.po
+++ b/applications/luci-app-travelmate/po/el/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/en/travelmate.po
+++ b/applications/luci-app-travelmate/po/en/travelmate.po
@@ -78,10 +78,6 @@ msgstr ""
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -309,6 +305,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -495,7 +495,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/es/travelmate.po
+++ b/applications/luci-app-travelmate/po/es/travelmate.po
@@ -97,11 +97,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-"Tamaño del búfer en bytes para preparar resultados de escaneo cercanos."
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -346,6 +341,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Vista de registro"
@@ -548,8 +547,8 @@ msgid "Save"
 msgstr "Guardar"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "Tamaño del búfer de escaneo"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -886,6 +885,13 @@ msgstr ""
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr ""
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr ""
+#~ "Tamaño del búfer en bytes para preparar resultados de escaneo cercanos."
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "Tamaño del búfer de escaneo"
 
 #~ msgid "Automatically handle VPN (re-) connections."
 #~ msgstr "Maneja automáticamente las (rec-) conexiones VPN."

--- a/applications/luci-app-travelmate/po/fi/travelmate.po
+++ b/applications/luci-app-travelmate/po/fi/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr "Tallenna"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/fr/travelmate.po
+++ b/applications/luci-app-travelmate/po/fr/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -317,6 +313,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Vue du journal"
@@ -503,7 +503,7 @@ msgid "Save"
 msgstr "Enregistrer"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/he/travelmate.po
+++ b/applications/luci-app-travelmate/po/he/travelmate.po
@@ -85,10 +85,6 @@ msgstr ""
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -316,6 +312,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -502,7 +502,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/hi/travelmate.po
+++ b/applications/luci-app-travelmate/po/hi/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/hu/travelmate.po
+++ b/applications/luci-app-travelmate/po/hu/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -316,6 +312,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Log nézet"
@@ -502,7 +502,7 @@ msgid "Save"
 msgstr "Mentés"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/it/travelmate.po
+++ b/applications/luci-app-travelmate/po/it/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -316,6 +312,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -502,7 +502,7 @@ msgid "Save"
 msgstr "Salva"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/ja/travelmate.po
+++ b/applications/luci-app-travelmate/po/ja/travelmate.po
@@ -89,10 +89,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr "スキャン結果を準備するためのバッファー サイズ (byte) です。"
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -322,6 +318,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "ログビュー"
@@ -512,8 +512,8 @@ msgid "Save"
 msgstr "保存"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "スキャンバッファー サイズ"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -835,6 +835,12 @@ msgstr ""
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr ""
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr "スキャン結果を準備するためのバッファー サイズ (byte) です。"
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "スキャンバッファー サイズ"
 
 #~ msgid "Delete this network"
 #~ msgstr "このネットワークを削除"

--- a/applications/luci-app-travelmate/po/ko/travelmate.po
+++ b/applications/luci-app-travelmate/po/ko/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/mr/travelmate.po
+++ b/applications/luci-app-travelmate/po/mr/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/ms/travelmate.po
+++ b/applications/luci-app-travelmate/po/ms/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/nb_NO/travelmate.po
+++ b/applications/luci-app-travelmate/po/nb_NO/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Loggvisning"
@@ -502,7 +502,7 @@ msgid "Save"
 msgstr "Lagre"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/pl/travelmate.po
+++ b/applications/luci-app-travelmate/po/pl/travelmate.po
@@ -95,11 +95,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-"Rozmiar bufora w bajtach do przygotowania rezultatu skanowania okolicy."
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -342,6 +337,10 @@ msgstr ""
 "Ogranicz maksymalną liczbę automatycznie dodawanych otwartych łączy uplink. "
 "Aby wyłączyć to ograniczenie, ustaw je na '0'."
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Widok dziennika"
@@ -541,8 +540,8 @@ msgid "Save"
 msgstr "Zapisz"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "Rozmiar bufora skanowania"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -876,6 +875,13 @@ msgstr "używaj tylko pierwszego radia (radio0)"
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr "używaj tylko drugiego radia (radio1)"
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr ""
+#~ "Rozmiar bufora w bajtach do przygotowania rezultatu skanowania okolicy."
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "Rozmiar bufora skanowania"
 
 #~ msgid "Automatically handle VPN (re-) connections."
 #~ msgstr "Automatyczna obsługa połączeń VPN."

--- a/applications/luci-app-travelmate/po/pt/travelmate.po
+++ b/applications/luci-app-travelmate/po/pt/travelmate.po
@@ -95,11 +95,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-"Tamanho do buffer em bytes para preparar resultados de varreduras próximas."
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -345,6 +340,10 @@ msgstr ""
 "Limitar a quantidade máxima de ligações ascendentes abertas automaticamente. "
 "Para desativar esta limitação, defina-a como '0'."
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Vista do registo log"
@@ -549,8 +548,8 @@ msgid "Save"
 msgstr "Guardar"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "Tamanho do Buffer de Varredura"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -883,6 +882,14 @@ msgstr "usar apenas o primeiro rádio (radio0)"
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr "usar apenas o segundo rádio (radio1)"
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr ""
+#~ "Tamanho do buffer em bytes para preparar resultados de varreduras "
+#~ "próximas."
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "Tamanho do Buffer de Varredura"
 
 #~ msgid "Automatically handle VPN (re-) connections."
 #~ msgstr "Lidar com (re-)conexões do VPN automaticamente."

--- a/applications/luci-app-travelmate/po/pt_BR/travelmate.po
+++ b/applications/luci-app-travelmate/po/pt_BR/travelmate.po
@@ -97,12 +97,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-"Tamanho do buffer em bytes para preparar os resultados de varredura mais "
-"próximos."
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -344,6 +338,10 @@ msgstr ""
 "Limite a quantidade máxima de uplinks abertos automaticamente. Para "
 "desativar esta limitação, defina-a como '0'."
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Exiba o registro log"
@@ -547,8 +545,8 @@ msgid "Save"
 msgstr "Salvar"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "Tamanho do Buffer de Varredura"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -879,6 +877,14 @@ msgstr "use apenas o primeiro rádio (radio0)"
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr "use apenas o segundo rádio (radio1)"
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr ""
+#~ "Tamanho do buffer em bytes para preparar os resultados de varredura mais "
+#~ "próximos."
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "Tamanho do Buffer de Varredura"
 
 #~ msgid "Automatically handle VPN (re-) connections."
 #~ msgstr "Lide automaticamente com as (re-)conexões VPN."

--- a/applications/luci-app-travelmate/po/ro/travelmate.po
+++ b/applications/luci-app-travelmate/po/ro/travelmate.po
@@ -85,10 +85,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -316,6 +312,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -502,7 +502,7 @@ msgid "Save"
 msgstr "Salvează"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/ru/travelmate.po
+++ b/applications/luci-app-travelmate/po/ru/travelmate.po
@@ -90,10 +90,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -321,6 +317,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Просмотр журнала"
@@ -508,7 +508,7 @@ msgid "Save"
 msgstr "Сохранить"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/sk/travelmate.po
+++ b/applications/luci-app-travelmate/po/sk/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr "Uložiť"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/sv/travelmate.po
+++ b/applications/luci-app-travelmate/po/sv/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Logutsikt"
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr "Spara"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/templates/travelmate.pot
+++ b/applications/luci-app-travelmate/po/templates/travelmate.pot
@@ -75,10 +75,6 @@ msgstr ""
 msgid "BSSID"
 msgstr ""
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -306,6 +302,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -492,7 +492,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/tr/travelmate.po
+++ b/applications/luci-app-travelmate/po/tr/travelmate.po
@@ -93,11 +93,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-"Yakındaki tarama sonuçlarını hazırlamak için bayt cinsinden arabellek boyutu."
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -340,6 +335,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "Günlük Kayıtlarını Göster"
@@ -539,8 +538,8 @@ msgid "Save"
 msgstr "Kaydet"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "Tarama Arabelleği Boyutu"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -872,6 +871,14 @@ msgstr ""
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr ""
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr ""
+#~ "Yakındaki tarama sonuçlarını hazırlamak için bayt cinsinden arabellek "
+#~ "boyutu."
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "Tarama Arabelleği Boyutu"
 
 #~ msgid "Automatically handle VPN (re-) connections."
 #~ msgstr "VPN (yeniden) bağlantılarını otomatik olarak işle."

--- a/applications/luci-app-travelmate/po/uk/travelmate.po
+++ b/applications/luci-app-travelmate/po/uk/travelmate.po
@@ -85,10 +85,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -316,6 +312,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -502,7 +502,7 @@ msgid "Save"
 msgstr "Зберегти"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/vi/travelmate.po
+++ b/applications/luci-app-travelmate/po/vi/travelmate.po
@@ -84,10 +84,6 @@ msgstr ""
 msgid "BSSID"
 msgstr "BSSID"
 
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr ""
-
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
 msgid "CHAP"
@@ -315,6 +311,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr ""
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr ""
@@ -501,7 +501,7 @@ msgid "Save"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
+msgid "Scan Limit"
 msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691

--- a/applications/luci-app-travelmate/po/zh_Hans/travelmate.po
+++ b/applications/luci-app-travelmate/po/zh_Hans/travelmate.po
@@ -85,7 +85,9 @@ msgid ""
 "Automatically handle VPN connections.<br /> Please note: This feature "
 "requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
 "em>."
-msgstr "自动处理 VPN 连接。<br />请注意：此功能需要额外配置 <em>Wireguard</em>或<em>OpenVPN</em>。"
+msgstr ""
+"自动处理 VPN 连接。<br />请注意：此功能需要额外配置 <em>Wireguard</em>或"
+"<em>OpenVPN</em>。"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
@@ -93,10 +95,6 @@ msgstr "自动处理 VPN 连接。<br />请注意：此功能需要额外配置 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr "用于暂存扫描结果的缓冲区大小（单位为字节）。"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
@@ -331,6 +329,10 @@ msgid ""
 "this limitation set it to '0'."
 msgstr "限制自动添加的开放上行链路的最大数量。 要禁用此限制，请将其设置为“0”。"
 
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
+
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
 msgstr "日志视图"
@@ -520,8 +522,8 @@ msgid "Save"
 msgstr "保存"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "扫描用缓冲区大小"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -843,6 +845,12 @@ msgstr "仅使用第一个 radio (radio0)"
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr "仅使用第二个 radio (radio1)"
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr "用于暂存扫描结果的缓冲区大小（单位为字节）。"
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "扫描用缓冲区大小"
 
 #~ msgid "Automatically handle VPN (re-) connections."
 #~ msgstr "自动处理VPN（重）连接。"

--- a/applications/luci-app-travelmate/po/zh_Hant/travelmate.po
+++ b/applications/luci-app-travelmate/po/zh_Hant/travelmate.po
@@ -85,7 +85,9 @@ msgid ""
 "Automatically handle VPN connections.<br /> Please note: This feature "
 "requires the additional configuration of <em>Wireguard</em> or <em>OpenVPN</"
 "em>."
-msgstr "自動處理 VPN 連接。<br />請注意：此功能需要額外設定 <em>Wireguard</em>或<em>OpenVPN</em>。"
+msgstr ""
+"自動處理 VPN 連接。<br />請注意：此功能需要額外設定 <em>Wireguard</em>或"
+"<em>OpenVPN</em>。"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:288
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:456
@@ -93,10 +95,6 @@ msgstr "自動處理 VPN 連接。<br />請注意：此功能需要額外設定 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:876
 msgid "BSSID"
 msgstr "BSSID"
-
-#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Buffer size in bytes to prepare nearby scan results."
-msgstr "緩衝區大小（以位元組為單位）以準備附近的掃描結果。"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:398
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:923
@@ -329,7 +327,12 @@ msgstr "限制自動加入"
 msgid ""
 "Limit the maximum number of automatically added open uplinks. To disable "
 "this limitation set it to '0'."
-msgstr "限制自動加入的開放上行鏈路的最大數量。 要停用此限制，請將其設定為「0」。"
+msgstr ""
+"限制自動加入的開放上行鏈路的最大數量。 要停用此限制，請將其設定為「0」。"
+
+#: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
+msgid "Limit the nearby scan results to process only the strongest uplinks."
+msgstr ""
 
 #: applications/luci-app-travelmate/root/usr/share/luci/menu.d/luci-app-travelmate.json:35
 msgid "Log View"
@@ -519,8 +522,8 @@ msgid "Save"
 msgstr "儲存"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:365
-msgid "Scan Buffer Size"
-msgstr "掃描緩衝區大小"
+msgid "Scan Limit"
+msgstr ""
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/stations.js:691
 msgid "Scan on"
@@ -637,7 +640,8 @@ msgstr "上行介面名稱"
 msgid ""
 "This option is selected by default if this uplink was added automatically "
 "and counts as 'Open Uplink'."
-msgstr "如果此上行鏈路是自動加入的並被算作「開放的上行鏈路」，則預設選取此選項。"
+msgstr ""
+"如果此上行鏈路是自動加入的並被算作「開放的上行鏈路」，則預設選取此選項。"
 
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:23
 msgid ""
@@ -842,6 +846,12 @@ msgstr "僅使用第一個 radio (radio0)"
 #: applications/luci-app-travelmate/htdocs/luci-static/resources/view/travelmate/overview.js:305
 msgid "use the second radio only (radio1)"
 msgstr "僅使用第二個 radio (radio1)"
+
+#~ msgid "Buffer size in bytes to prepare nearby scan results."
+#~ msgstr "緩衝區大小（以位元組為單位）以準備附近的掃描結果。"
+
+#~ msgid "Scan Buffer Size"
+#~ msgstr "掃描緩衝區大小"
 
 #~ msgid "Automatically handle VPN (re-) connections."
 #~ msgstr "自動處理 VPN (重新) 連接。"


### PR DESCRIPTION
* adapt the travelmate UI to support the changed 'trm_maxscan' option
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>