### PR TITLE
module status: show buffered + cached rows on 0 bytes used too

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js
@@ -36,10 +36,10 @@ return baseclass.extend({
 			_('Used'),            (mem.total && mem.free) ? (mem.total - mem.free) : null, mem.total,
 		];
 
-		if (mem.buffered)
+		if (mem.buffered != null)
 			fields.push(_('Buffered'), mem.buffered, mem.total);
 
-		if (mem.cached)
+		if (mem.cached != null)
 			fields.push(_('Cached'), mem.cached, mem.total);
 
 		if (swap.total > 0)


### PR DESCRIPTION
and hide them only on invalid values,
eg missing line in /proc/meminfo
