### PR TITLE
luci-app-statistics: irq plugin: handle numeric interrupt names

### DIFF
--- a/applications/luci-app-statistics/root/usr/bin/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/bin/stat-genconfig
@@ -251,8 +251,8 @@ function _string( s, n, nopad )
 	if not nopad then pad = "\t" end
 
 	if s then
-		if s:find("[^%d]") or n == "Port" then
-			if not s:find("[^%w]") and n ~= "Port" then
+		if s:find("[^%d]") or n == "Port" or n == "Irq" then
+			if not s:find("[^%w]") and n ~= "Port" and n ~= "Irq" then
 				str = pad .. n .. " " .. luci.util.trim(s)
 			else
 				str = pad .. n .. ' "' .. luci.util.trim(s) .. '"'


### PR DESCRIPTION
If the interrupt names are only numeric

/proc/interrupts
```
           CPU0       CPU1       
  4:         13          0   IO-APIC   4-edge      ttyS0
  8:          0          0   IO-APIC   8-edge      rtc0
  9:          2          0   IO-APIC   9-fasteoi   acpi
117:          0       7949   PCI-MSI 32768-edge      i915
118:      47996          0   PCI-MSI 327680-edge      xhci_hcd
119:          1          0   PCI-MSI 524288-edge      eth0
120:          0       5878   PCI-MSI 524289-edge      eth0-rx-0
121:       4947          0   PCI-MSI 524290-edge      eth0-rx-1
122:          0       5316   PCI-MSI 524291-edge      eth0-tx-0
```
 the command `/usr/bin/stat-genconfig` does not create a working collectd config.

/etc/config/luci_statistics
```
config statistics 'collectd_irq'
	option enable '1'
	list Irqs '120'
	list Irqs '121'
	list Irqs '122'
	list Irqs '123'
	list Irqs '125'
	list Irqs '126'
	list Irqs '127'
	list Irqs '128'
```
/etc/collectd.conf
```
LoadPlugin irq
<Plugin irq>
	IgnoreSelected false
	Irq 120
	Irq 121
	Irq 122
	Irq 123
	Irq 125
	Irq 126
	Irq 127
	Irq 128
</Plugin>
```
It should look like this:
```
LoadPlugin irq
<Plugin irq>
	IgnoreSelected false
	Irq "120"
	Irq "121"
	Irq "122"
	Irq "123"
	Irq "125"
	Irq "126"
	Irq "127"
	Irq "128"
</Plugin>
```
