### PR TITLE
luci-app-bcp38: update info URL in help text

### DIFF
--- a/applications/luci-app-bcp38/luasrc/model/cbi/bcp38.lua
+++ b/applications/luci-app-bcp38/luasrc/model/cbi/bcp38.lua
@@ -20,7 +20,7 @@ local ifaces = sys.net:devices()
 m = Map("bcp38", translate("BCP38"),
 	translate("This function blocks packets with private address destinations " ..
 		"from going out onto the internet as per " ..
-		"<a href=\"http://tools.ietf.org/html/bcp38\">BCP 38</a>. " ..
+		"<a href=\"https://www.rfc-editor.org/info/bcp38\">BCP 38</a>. " ..
 		"For IPv6, only source specific default routes are installed, so " ..
 		"no BCP38 firewall routes are needed."))
 


### PR DESCRIPTION
Maintainer: me / @tohojo
Compile tested: N/A
Run tested: N/A

Description:

The url https://tools.ietf.org/html/bcp38 redirects currently to the one proposed in this PR https://www.rfc-editor.org/info/bcp38.

Makes sense to point straight to the final one, where resides the useful information.

Related with https://github.com/openwrt/packages/pull/16403