### PR TITLE
luci-theme-bootstrap: fix dummy dropdown scroll

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -1503,8 +1503,7 @@ body.modal-overlay-active #modal_overlay {
 	margin: 0 !important;
 	padding: 0;
 	list-style: none;
-	overflow-x: hidden;
-	overflow-y: auto;
+	overflow: hidden;
 	display: flex;
 	width: 100%;
 }
@@ -1517,6 +1516,10 @@ body.modal-overlay-active #modal_overlay {
 .cbi-dropdown.btn.spinning > ul:not(.dropdown),
 .cbi-dropdown.cbi-button.spinning > ul:not(.dropdown) {
 	margin: 0 !important;
+}
+
+.cbi-dropdown > ul.dropdown {
+	overflow-y: auto;
 }
 
 .cbi-dropdown > ul.preview {


### PR DESCRIPTION
Hide dummy vertical scrolling for closed dropdown lists.
Only show vertical scrolling for expanded dropdown lists.

The issue is relevant for dropdown lists with interface badges.
It affects "widgets.NetworkSelect" and "widgets.ZoneSelect".

Fixes: https://github.com/openwrt/luci/issues/5441

![zone-select-scroll](https://user-images.githubusercontent.com/20725816/132838558-18a4d315-80ee-488e-a5d2-c4c49d9f48a9.png)
![zone-select-noscroll](https://user-images.githubusercontent.com/20725816/132838518-42ec111c-fae9-4812-979c-84fef5d2b71f.png)

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>