### PR TITLE
luci-proto-wireguard: make AllowedIPs optional

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -140,16 +140,9 @@ return network.registerProtocol('wireguard', {
 		o.validate = validateBase64;
 		o.optional = true;
 
-		o = ss.option(form.DynamicList, 'allowed_ips', _('Allowed IPs'), _("Required. IP addresses and prefixes that this peer is allowed to use inside the tunnel. Usually the peer's tunnel IP addresses and the networks the peer routes through the tunnel."));
+		o = ss.option(form.DynamicList, 'allowed_ips', _('Allowed IPs'), _("Optional. IP addresses and prefixes that this peer is allowed to use inside the tunnel. Usually the peer's tunnel IP addresses and the networks the peer routes through the tunnel."));
 		o.datatype = 'ipaddr';
-		o.validate = function(section, value) {
-			var opt = this.map.lookupOption('allowed_ips', section);
-			var ips = opt[0].formvalue(section);
-			if (ips.length == 0) {
-				return _('Value must not be empty');
-			}
-			return true;
-		};
+		o.optional = true;
 
 		o = ss.option(form.Flag, 'route_allowed_ips', _('Route Allowed IPs'), _('Optional. Create routes for Allowed IPs for this peer.'));
 


### PR DESCRIPTION
From #5307

Honestly, I haven't tested this because I'm not sure how to build openwrt.  In theory it should work because I have tried removing the `AllowedIPs` lines from `/etc/config/network` and the wireguard interface worked fine.  

So I think this commit should fix it without any side effects... but I would appreciate if someone would test it or help me test it.  