### PR TITLE
luci-app-ledtrig-usbport: fix allow multiple selection

### DIFF
--- a/applications/luci-app-ledtrig-usbport/htdocs/luci-static/resources/view/system/led-trigger/usbport.js
+++ b/applications/luci-app-ledtrig-usbport/htdocs/luci-static/resources/view/system/led-trigger/usbport.js
@@ -16,7 +16,7 @@ return baseclass.extend({
 	addFormOptions(s){
 		var o;
 
-		o = s.option(form.Value, 'port', _('USB Ports'));
+		o = s.option(form.MultiValue, 'port', _('USB Ports'));
 		o.depends('trigger', 'usbport');
 		o.rmempty = true;
 		o.modalonly = true;


### PR DESCRIPTION
The kernel module `kmod-usb-ledtrig-usbport` allows for multiple selections of
USB ports to trigger a single LED.
See https://www.kernel.org/doc/html/latest/leds/ledtrig-usbport.html

This simplest of fixes allows for selection one or more USB ports to trigger a LED.

The ASUS RT-AC88U router which is getting ported to OpenWrt by arinc9 has got an
USB 3.0 port at the front which will use different internal USB ports, depending
on if you connect an USB 2.0 device or an USB 3.0 device.

This fix/patch was tested on the mentioned router.

Signed-off-by: Thomas Kupper <thomas.kupper@gmail.com>