### PR TITLE
luci-app-firewall: add ipv6 exclusive ICMP types to firewall

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
@@ -298,6 +298,8 @@ return view.extend({
 		o.value('', 'any');
 		o.value('address-mask-reply');
 		o.value('address-mask-request');
+		o.value('address-unreachable'); /* ipv6 */
+		o.value('bad-header');  /* ipv6 */
 		o.value('communication-prohibited');
 		o.value('destination-unreachable');
 		o.value('echo-reply');
@@ -315,6 +317,7 @@ return view.extend({
 		o.value('network-redirect');
 		o.value('network-unknown');
 		o.value('network-unreachable');
+		o.value('no-route');  /* ipv6 */
 		o.value('packet-too-big');
 		o.value('parameter-problem');
 		o.value('port-unreachable');
@@ -335,6 +338,8 @@ return view.extend({
 		o.value('TOS-network-unreachable');
 		o.value('ttl-zero-during-reassembly');
 		o.value('ttl-zero-during-transit');
+		o.value('unknown-header-type');  /* ipv6 */
+		o.value('unknown-option');  /* ipv6 */
 		o.depends({ proto: 'icmp', '!contains': true });
 		o.depends({ proto: 'icmpv6', '!contains': true });
 


### PR DESCRIPTION
....'Match ICMP type' field.

Signed-off-by: Paul Dee <systemcrash@users.noreply.github.com>


See issue #5213