### PR TITLE
luci-mod-status: move index acl into own file

### DIFF
--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json
@@ -1,0 +1,52 @@
+{
+	"luci-mod-status-index": {
+		"description": "Grant access to main status display",
+		"read": {
+			"file": {
+				"/proc/sys/net/netfilter/nf_conntrack_count": [ "read" ],
+				"/proc/sys/net/netfilter/nf_conntrack_max": [ "read" ],
+				"/usr/lib/lua/luci/version.lua": [ "read" ],
+				"/www/luci-static/resources/view/status/include": [ "list" ]
+			},
+			"ubus": {
+				"file": [ "list", "read" ],
+				"system": [ "board", "info" ]
+			}
+		},
+		"write": {
+			"uci": [ "dhcp" ]
+		}
+	},
+
+	"luci-mod-status-index-dhcp": {
+		"description": "Grant access to DHCP status display",
+		"read": {
+			"ubus": {
+				"luci-rpc": [ "getDHCPLeases" ]
+			}
+		}
+	},
+
+	"luci-mod-status-index-dsl": {
+		"description": "Grant access to DSL status display",
+		"read": {
+			"ubus": {
+				"dsl": [ "metrics" ]
+			}
+		}
+	},
+
+	"luci-mod-status-index-wifi": {
+		"description": "Grant access to wireless status display",
+		"read": {
+			"ubus": {
+				"iwinfo": [ "assoclist" ]
+			}
+		},
+		"write": {
+			"ubus": {
+				"hostapd.*": [ "del_client", "wps_start", "wps_cancel", "wps_status" ]
+			}
+		}
+	}
+}

--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -90,56 +90,5 @@
 				"file": [ "exec" ]
 			}
 		}
-	},
-
-	"luci-mod-status-index": {
-		"description": "Grant access to main status display",
-		"read": {
-			"file": {
-				"/proc/sys/net/netfilter/nf_conntrack_count": [ "read" ],
-				"/proc/sys/net/netfilter/nf_conntrack_max": [ "read" ],
-				"/usr/lib/lua/luci/version.lua": [ "read" ],
-				"/www/luci-static/resources/view/status/include": [ "list" ]
-			},
-			"ubus": {
-				"file": [ "list", "read" ],
-				"system": [ "board", "info" ]
-			}
-		},
-		"write": {
-			"uci": [ "dhcp" ]
-		}
-	},
-
-	"luci-mod-status-index-dhcp": {
-		"description": "Grant access to DHCP status display",
-		"read": {
-			"ubus": {
-				"luci-rpc": [ "getDHCPLeases" ]
-			}
-		}
-	},
-
-	"luci-mod-status-index-dsl": {
-		"description": "Grant access to DSL status display",
-		"read": {
-			"ubus": {
-				"dsl": [ "metrics" ]
-			}
-		}
-	},
-
-	"luci-mod-status-index-wifi": {
-		"description": "Grant access to wireless status display",
-		"read": {
-			"ubus": {
-				"iwinfo": [ "assoclist" ]
-			}
-		},
-		"write": {
-			"ubus": {
-				"hostapd.*": [ "del_client", "wps_start", "wps_cancel", "wps_status" ]
-			}
-		}
 	}
 }


### PR DESCRIPTION
The ACL file luci-mod-status.json is already quite long.
It is also a separate menu item in LuCI, so in my view it makes sense to
move it to a separate file. An additional positive effect is that the
file then becomes clearer.