### PR TITLE
luci-mod-status: Add Target Platform (e.g. ath79/ipq806x/etc)

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/10_system.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/10_system.js
@@ -54,6 +54,7 @@ return baseclass.extend({
 			_('Hostname'),         boardinfo.hostname,
 			_('Model'),            boardinfo.model,
 			_('Architecture'),     boardinfo.system,
+			_('Target Platform'),  (L.isObject(boardinfo.release) ? boardinfo.release.target : ''),
 			_('Firmware Version'), (L.isObject(boardinfo.release) ? boardinfo.release.description + ' / ' : '') + (luciversion || ''),
 			_('Kernel Version'),   boardinfo.kernel,
 			_('Local Time'),       datestr,


### PR DESCRIPTION
revealed under:
`ubus call system board`
board.release.target

Useful reminder for what to download

Signed-off-by: Paul Dee <systemcrash@users.noreply.github.com>