### PR TITLE
Remove kmod-wireguard dependency

### DIFF
--- a/applications/luci-app-wireguard/Makefile
+++ b/applications/luci-app-wireguard/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=WireGuard Status
-LUCI_DEPENDS:=+wireguard-tools +kmod-wireguard +luci-proto-wireguard
+LUCI_DEPENDS:=+wireguard-tools +luci-proto-wireguard
 LUCI_PKGARCH:=all
 
 include ../../luci.mk


### PR DESCRIPTION
`kmod-wireguard` does not even exist in 21.02 and should be removed as it prevents `luci-app-wireguard` from installing.

Signed-off-by: Avinash Duduskar <strykar@hotmail.com>