### PR TITLE
luci-mod-network: fix src/dest textvalue for rules

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js
@@ -149,7 +149,7 @@ return view.extend({
 			o.datatype = (family == 6) ? 'cidr6' : 'cidr4';
 			o.placeholder = (family == 6) ? '::/0' : '0.0.0.0/0';
 			o.textvalue = function(section_id) {
-				return E('em', _('any'));
+				return this.cfgvalue(section_id) || E('em', _('any'));
 			};
 
 			o = s.taboption('general', widgets.NetworkSelect, 'out', _('Outgoing interface'));
@@ -160,7 +160,7 @@ return view.extend({
 			o.datatype = (family == 6) ? 'cidr6' : 'cidr4';
 			o.placeholder = (family == 6) ? '::/0' : '0.0.0.0/0';
 			o.textvalue = function(section_id) {
-				return E('em', _('any'));
+				return this.cfgvalue(section_id) || E('em', _('any'));
 			};
 
 			o = s.taboption('general', form.Value, 'lookup', _('Table'));


### PR DESCRIPTION
Fix the incorrectly displayed src/dest textvalue for the rules.

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>