### PR TITLE
fix wrong ed25519 information

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js
@@ -95,7 +95,7 @@ var SSHPubkeyDecoder = baseclass.singleton({
 			return { type: 'DSA', bits: len1 * 8, comment: comment, options: options, fprint: fprint, src: s };
 
 		case 'ssh-ed25519':
-			return { type: 'ECDH', curve: 'Curve25519', comment: comment, options: options, fprint: fprint, src: s };
+			return { type: 'EdDSA', curve: 'Curve25519', comment: comment, options: options, fprint: fprint, src: s };
 
 		case 'ecdsa-sha2':
 			return { type: 'ECDSA', curve: curve, comment: comment, options: options, fprint: fprint, src: s };


### PR DESCRIPTION
ECDH is not used for the ed25519. The scheme is called EdDSA.

Curve25519 is a Montgomery curve. ed25519 uses an Edwards curve. The
author recommends X25519 as a replacement for Curve25519 in any form.

Signed-off-by: Rosen Penev <rosenp@gmail.com>