### PR TITLE
uci-mod-network: distance setting - allow "auto" as a value

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -886,7 +886,7 @@ return view.extend({
 					o.default = o.enabled;
 
 					o = ss.taboption('advanced', form.Value, 'distance', _('Distance Optimization'), _('Distance to farthest network member in meters.'));
-					o.datatype = 'range(0,114750)';
+					o.datatype = 'or(range(0,114750),"auto")';
 					o.placeholder = 'auto';
 
 					o = ss.taboption('advanced', form.Value, 'frag', _('Fragmentation Threshold'));


### PR DESCRIPTION
Since https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=15612706c930ed26af9e05b649efc2d245157273 makes it possible to use "auto" as a value (uci set wireless.radio0.distance='auto') also accept this value in luci.

Signed-off-by: Sebastian Knapp sebastian4842@outlook.com
