### PR TITLE
luci-mod-network: support network.interface.sourcefilter

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -952,6 +952,11 @@ return view.extend({
 				for (var i = 0; i < rtTables.length; i++)
 					o.value(rtTables[i][1], '%s (%d)'.format(rtTables[i][1], rtTables[i][0]));
 
+				if (protoval == 'dhcpv6') {
+					o = nettools.replaceOption(s, 'advanced', form.Flag, 'sourcefilter', _('IPv6 source routing'), _('Automatically handle multiple uplink interfaces using source-based policy routing.'));
+					o.default = o.enabled;
+				}
+
 				o = nettools.replaceOption(s, 'advanced', form.Flag, 'delegate', _('Delegate IPv6 prefixes'), _('Enable downstream delegation of IPv6 prefixes available on this interface'));
 				o.default = o.enabled;
 


### PR DESCRIPTION
Allow to modify the sourcefilter option in the network.interface config.
This is required for custom policy routing with IPv6 MWAN and/or NAT6.

Signed-off-by: Vladislav Grigoryev <vg.aetera@gmail.com>