### PR TITLE
luci-app-radicale2: Fix library loading

### DIFF
--- a/applications/luci-app-radicale2/luasrc/model/cbi/radicale2/auth.lua
+++ b/applications/luci-app-radicale2/luasrc/model/cbi/radicale2/auth.lua
@@ -1,6 +1,6 @@
 -- Licensed to the public under the Apache License 2.0.
 
-local rad2 = luci.controller.radicale2
+local rad2 = require "luci.controller.radicale2"
 local fs = require("nixio.fs")
 local util = require("luci.util")
 

--- a/applications/luci-app-radicale2/luasrc/model/cbi/radicale2/storage.lua
+++ b/applications/luci-app-radicale2/luasrc/model/cbi/radicale2/storage.lua
@@ -1,6 +1,6 @@
 -- Licensed to the public under the Apache License 2.0.
 
-local rad2 = luci.controller.radicale2
+local rad2 = require "luci.controller.radicale2"
 local fs = require("nixio.fs")
 
 local m = Map("radicale2", translate("Radicale 2.x"),


### PR DESCRIPTION
The "Authentication / Users" and "Storage" tab of luci-app-radicale2 show the following error messages (seen with OpenWrt 21.02.0) when loaded:

    /usr/lib/lua/luci/model/cbi/radicale2/auth.lua:3: attempt to index field 'controller' (a nil value)
    stack traceback:
        /usr/lib/lua/luci/model/cbi/radicale2/auth.lua:3: in function 'func'
        /usr/lib/lua/luci/cbi.lua:66: in function 'load'
        /usr/lib/lua/luci/dispatcher.lua:1353: in function '_cbi'
        /usr/lib/lua/luci/dispatcher.lua:1024: in function 'dispatch'
        /usr/lib/lua/luci/dispatcher.lua:479: in function </usr/lib/lua/luci/dispatcher.lua:478>

    /usr/lib/lua/luci/model/cbi/radicale2/storage.lua:3: attempt to index field 'controller' (a nil value)
    stack traceback:
        /usr/lib/lua/luci/model/cbi/radicale2/storage.lua:3: in function 'func'
        /usr/lib/lua/luci/cbi.lua:66: in function 'load'
        /usr/lib/lua/luci/dispatcher.lua:1353: in function '_cbi'
        /usr/lib/lua/luci/dispatcher.lua:1024: in function 'dispatch'
        /usr/lib/lua/luci/dispatcher.lua:479: in function </usr/lib/lua/luci/dispatcher.lua:478>

It looks like the `require` function is missing, and thus, loading `luci.controller.radicale2` fails.  With this pull request the tabs seems to work fine.

Both the error and the fix are already mentioned in #4879.

Note that I'm not really familiar with Lua, however, the change looks rather straightforward.

Fixes #4879 
