### PR TITLE
luci-mod-admin-full: add arp-scan to network diagnostic

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
@@ -47,12 +47,19 @@ return view.extend({
 		return this.handleCommand('nslookup', [ addr ]);
 	},
 
+	handleArpScan: function(ev, cmd) {
+		var addr = ev.currentTarget.parentNode.previousSibling.value;
+
+		return this.handleCommand('arp-scan', [ '-l', '-I', addr]);
+	},
+
 	load: function() {
 		return Promise.all([
 			L.resolveDefault(fs.stat('/bin/ping6'), {}),
 			L.resolveDefault(fs.stat('/usr/bin/ping6'), {}),
 			L.resolveDefault(fs.stat('/bin/traceroute6'), {}),
 			L.resolveDefault(fs.stat('/usr/bin/traceroute6'), {}),
+			L.resolveDefault(fs.stat('/usr/bin/arp-scan'), {}),
 			uci.load('luci')
 		]);
 	},
@@ -60,6 +67,7 @@ return view.extend({
 	render: function(res) {
 		var has_ping6 = res[0].path || res[1].path,
 		    has_traceroute6 = res[2].path || res[3].path,
+		    has_arpscan = res[4].path,
 			dns_host = uci.get('luci', 'diag', 'dns') || 'openwrt.org',
 			ping_host = uci.get('luci', 'diag', 'ping') || 'openwrt.org',
 			route_host = uci.get('luci', 'diag', 'route') || 'openwrt.org';
@@ -68,7 +76,7 @@ return view.extend({
 			E('h2', {}, [ _('Network Utilities') ]),
 			E('table', { 'class': 'table' }, [
 				E('tr', { 'class': 'tr' }, [
-					E('td', { 'class': 'td left' }, [
+					E('td', { 'class': 'td left', 'width': '25%' }, [
 						E('input', {
 							'style': 'margin:5px 0',
 							'type': 'text',
@@ -91,7 +99,7 @@ return view.extend({
 						])
 					]),
 
-					E('td', { 'class': 'td left' }, [
+					E('td', { 'class': 'td left', 'width': '25%' }, [
 						E('input', {
 							'style': 'margin:5px 0',
 							'type': 'text',
@@ -114,7 +122,7 @@ return view.extend({
 						])
 					]),
 
-					E('td', { 'class': 'td left' }, [
+					E('td', { 'class': 'td left', 'width': '25%' }, [
 						E('input', {
 							'style': 'margin:5px 0',
 							'type': 'text',
@@ -126,7 +134,26 @@ return view.extend({
 								'click': ui.createHandlerFn(this, 'handleNslookup')
 							}, [ _('Nslookup') ])
 						])
-					])
+					]),
+
+					E('td', { 'class': 'td left', 'width': '25%' }, has_arpscan ? [
+						E('input', {
+							'style': 'margin:5px 0',
+							'type': 'text',
+							'value': 'br-lan'
+						}),
+						E('span', { 'class': 'diag-action' }, [
+							E('button', {
+								'class': 'cbi-button cbi-button-action',
+								'click': ui.createHandlerFn(this, 'handleArpScan')
+							}, [ _('Arp-scan') ])
+						])] : E('p', {}, [
+							E('em', _('Missing ARP scan')), E('br'),
+							E('a', {
+								href: L.url('admin/system/opkg') + '?query=arp-scan'
+							}, _('Install `arp-scan`...'))
+						])
+					),
 				])
 			]),
 			E('pre', { 'class': 'command-output', 'style': 'display:none' })

--- a/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
+++ b/modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json
@@ -58,7 +58,8 @@
 				"/usr/bin/ping": [ "exec" ],
 				"/usr/bin/ping6": [ "exec", "list" ],
 				"/usr/bin/traceroute": [ "exec" ],
-				"/usr/bin/traceroute6": [ "exec", "list" ]
+				"/usr/bin/traceroute6": [ "exec", "list" ],
+				"/usr/bin/arp-scan": [ "exec", "list" ]
 			},
 			"ubus": {
 				"file": [ "exec", "stat" ]


### PR DESCRIPTION
This is a JavaScript rewrite of the PR#5152

It adds the ability to perform ARP scans if the tool `arp-scan` is
installed.

Signed-off-by: Paul Spooren <mail@aparcar.org>