### PR TITLE
luci-proto-wireguard: display interface public key

### DIFF
--- a/protocols/luci-proto-wireguard/root/usr/libexec/rpcd/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/libexec/rpcd/luci.wireguard
@@ -16,6 +16,14 @@ local methods = {
 			return {keys = {priv = prv, pub = pub}}
 		end
 	},
+	getPublicAndPrivateKeyFromPrivate = {
+		args = {privkey = "privkey"},
+		call = function(args)
+			local pubkey = sys.exec("echo %s | wg pubkey 2>/dev/null" % util.shellquote(args.privkey)):sub(1, -2)
+
+			return {keys = {priv = args.privkey, pub = pubkey}}
+		end
+	},
 	generateQrCode = {
 		args = {privkey = "privkey", psk = "psk", allowed_ips = {"allowed_ips"}},
 		call = function(args)

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/acl.d/luci-wireguard.json
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/acl.d/luci-wireguard.json
@@ -5,6 +5,7 @@
 			"ubus": {
 				"luci.wireguard": [
 					"generateKeyPair",
+					"getPublicAndPrivateKeyFromPrivate",
 					"generateQrCode"
 				]
 			}


### PR DESCRIPTION
Signed-off-by: Paul Dee <systemcrash@users.noreply.github.com>

We have private keys, but ***the thing we need to share***, the public key, is completely absent from the `Interface` GUI.

FIXED.

Tested on 21.02.0
Cooperates with the "Generate Key" function below it. 

This PR also implicitly needs #5399 
