### PR TITLE
luci.mk: respect `version` file in package folders

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -74,7 +74,9 @@ LUCI_LIBRARYDIR = $(LUA_LIBRARYDIR)/luci
 # 1: everything expect po subdir or only po subdir
 define findrev
   $(shell \
-    if git log -1 >/dev/null 2>/dev/null; then \
+    if [ -f ./version ]; then \
+      cat ./version; \
+    elif git log -1 >/dev/null 2>/dev/null; then \
       set -- $$(git log -1 --format="%ct %h" --abbrev=7 -- $(if $(1),. ':(exclude)po',po)); \
       if [ -n "$$1" ]; then
         secs="$$(($$1 % 86400))"; \


### PR DESCRIPTION
LuCI generates package versions either by the last git commit or the
content of the `SOURCE_DATE_EPOCH` env variable. This commit allows to
use the content of a `version` file if present.

This should allow a better reproducibility when creating releases. The
`version` file per folder can be created by the (extended) maintenance
script which is used to generate OpenWrt releases.

Signed-off-by: Paul Spooren <mail@aparcar.org>