### PR TITLE
luci-theme-bootstrap: fix overlay display failures

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2199,12 +2199,12 @@ div.cbi-value var.cbi-tooltip-container,
 	position: fixed;
 	top: 0;
 	bottom: 0;
-	left: -10000px;
-	right: 10000px;
+	/*left: -10000px;*/
+	/*right: 10000px;*/
 	background: rgba(0, 0, 0, 0.7);
 	z-index: 900;
-	overflow-y: scroll;
-	-webkit-overflow-scrolling: touch;
+	overflow: scroll;
+	/*-webkit-overflow-scrolling: touch;*/
 	transition: opacity .125s ease-in;
 	opacity: 0;
 }
@@ -2212,7 +2212,7 @@ div.cbi-value var.cbi-tooltip-container,
 #modal_overlay > .modal {
 	width: 90%;
 	margin: 5em auto;
-	display: flex;
+	display: table;
 	flex-wrap: wrap;
 	min-height: 32px;
 	max-width: 600px;


### PR DESCRIPTION
this fixes #5405 - you can verify these fixes by "inspect element" for the overlay elements, and modifying their CSS properties.

Fixed overlay display failures for users on mobile, or users who booted up in safe mode XD. Noticeable when vertical or horizontal real-estate is too small for the displayed overlay.

This failure is most evident when you "edit" an interface, or display your unsaved changes.

When content is wider than the screen view, the table hugs the (widest) content maximally, and the overlay window becomes scrollable.

Disabled `-webkit-overflow-scrolling`, `left`, and `right`, because both FF and Safari disable them as invalid anyway.

Signed-off-by: Paul Dee <systemcrash@users.noreply.github.com>