### PR TITLE
luci-theme-bootstrap: fix log text legibility

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -682,11 +682,7 @@ input[type=file]:focus, input[type=checkbox]:focus, select:focus {
 input[disabled],
 button[disabled],
 select[disabled],
-textarea[disabled],
-input[readonly],
-button[readonly],
-select[readonly],
-textarea[readonly] {
+textarea[disabled] {
 	background-color: var(--background-color-medium);
 	color: var(--text-color-medium);
 	border-color: var(--border-color-low);
@@ -694,10 +690,11 @@ textarea[readonly] {
 	cursor: default;
 }
 
-select[readonly],
+input[readonly],
 textarea[readonly] {
-	pointer-events: auto;
-	cursor: auto;
+	background-color: var(--background-color-medium);
+	color: var(--text-color-high);
+	border-color: var(--border-color-low);
 }
 
 .cbi-optionals,


### PR DESCRIPTION
Increase the contrast of read-only text areas.

Signed-off-by: Teoh Han Hui <teohhanhui@gmail.com>

fixes https://github.com/openwrt/luci/pull/5366#issuecomment-938762102

p/s: [The `readonly` attribute is not valid on the `button` and `select` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly), so I've removed those.

