### PR TITLE
README: mark client side rendering as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ To install all its package definitions, run:
 
 You can browse the generated API documentation directly on Github.
 
- - [Server side Lua APIs](http://openwrt.github.io/luci/api/index.html)
  - [Client side JavaScript APIs](http://openwrt.github.io/luci/jsapi/index.html)
+ - [Server side Lua APIs](http://openwrt.github.io/luci/api/index.html) (**deprecated**)
 
 ## Development
 


### PR DESCRIPTION
New apps should always use the new JS API, make this more obvious.

Signed-off-by: Paul Spooren <mail@aparcar.org>