### PR TITLE
luci-mod-admin-full: hide arp-scan if not installed

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js
@@ -147,12 +147,7 @@ return view.extend({
 								'class': 'cbi-button cbi-button-action',
 								'click': ui.createHandlerFn(this, 'handleArpScan')
 							}, [ _('Arp-scan') ])
-						])] : E('p', {}, [
-							E('em', _('Missing ARP scan')), E('br'),
-							E('a', {
-								href: L.url('admin/system/opkg') + '?query=arp-scan'
-							}, _('Install `arp-scan`...'))
-						])
+						])] : E('p', {}, [])
 					),
 				])
 			]),


### PR DESCRIPTION
This should be less confusing for users.

Signed-off-by: Paul Spooren <mail@aparcar.org>