### PR TITLE
luci-base: show validation message in save error

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -601,7 +601,7 @@ var CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 				if (!silent) {
 					ui.showModal(_('Save error'), [
 						E('p', {}, [ _('An error occurred while saving the form:') ]),
-						E('p', {}, [ E('em', { 'style': 'white-space:pre' }, [ e.message ]) ]),
+						E('p', {}, [ E('em', { 'style': 'white-space:pre-wrap' }, [ e.message ]) ]),
 						E('div', { 'class': 'right' }, [
 							E('button', { 'class': 'cbi-button', 'click': ui.hideModal }, [ _('Dismiss') ])
 						])
@@ -1911,6 +1911,20 @@ var CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.AbstractVa
 	},
 
 	/**
+	 * Returns the current validation error for this input.
+	 *
+	 * @param {string} section_id
+	 * The configuration section ID
+	 *
+	 * @returns {string}
+	 * The validation error at this time
+	 */
+	getValidationError: function (section_id) {
+		var elem = this.getUIElement(section_id);
+		return elem ? elem.getValidationError() : '';
+	},
+
+	/**
 	 * Test whether the option element is currently active.
 	 *
 	 * An element is active when it is not hidden due to unsatisfied dependency
@@ -1971,7 +1985,9 @@ var CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.AbstractVa
 
 		if (active && !this.isValid(section_id)) {
 			var title = this.stripTags(this.title).trim();
-			return Promise.reject(new TypeError(_('Option "%s" contains an invalid input value.').format(title || this.option)));
+			var error = this.getValidationError(section_id);
+			return Promise.reject(new TypeError(
+				_('Option "%s" contains an invalid input value.').format(title || this.option) + ' ' + error));
 		}
 
 		if (fval != '' && fval != null) {
@@ -3877,7 +3893,9 @@ var CBIFlagValue = CBIValue.extend(/** @lends LuCI.form.FlagValue.prototype */ {
 
 			if (!this.isValid(section_id)) {
 				var title = this.stripTags(this.title).trim();
-				return Promise.reject(new TypeError(_('Option "%s" contains an invalid input value.').format(title || this.option)));
+				var error = this.getValidationError(section_id);
+				return Promise.reject(new TypeError(
+					_('Option "%s" contains an invalid input value.').format(title || this.option) + ' ' + error));
 			}
 
 			if (fval == this.default && (this.optional || this.rmempty))

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -156,6 +156,18 @@ var UIElement = baseclass.extend(/** @lends LuCI.ui.AbstractElement.prototype */
 	},
 
 	/**
+	 * Returns the current validation error
+	 *
+	 * @instance
+	 * @memberof LuCI.ui.AbstractElement
+	 * @returns {string}
+	 * The validation error at this time
+	 */
+	getValidationError: function() {
+		return this.validationError || '';
+	},
+
+	/**
 	 * Force validation of the current input value.
 	 *
 	 * Usually input validation is automatically triggered by various DOM events
@@ -243,10 +255,12 @@ var UIElement = baseclass.extend(/** @lends LuCI.ui.AbstractElement.prototype */
 
 		this.node.addEventListener('validation-success', L.bind(function(ev) {
 			this.validState = true;
+			this.validationError = '';
 		}, this));
 
 		this.node.addEventListener('validation-failure', L.bind(function(ev) {
 			this.validState = false;
+			this.validationError = ev.detail.message;
 		}, this));
 	},
 

--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -61,9 +61,15 @@ var Validator = baseclass.extend({
 			valid = this.vstack[0].apply(this, this.vstack[1]);
 
 		if (valid !== true) {
-			this.field.setAttribute('data-tooltip', _('Expecting: %s').format(this.error));
+			var message = _('Expecting: %s').format(this.error);
+			this.field.setAttribute('data-tooltip', message);
 			this.field.setAttribute('data-tooltip-style', 'error');
-			this.field.dispatchEvent(new CustomEvent('validation-failure', { bubbles: true }));
+			this.field.dispatchEvent(new CustomEvent('validation-failure', {
+				bubbles: true,
+				detail: {
+					message: message
+				}
+			}));
 			return false;
 		}
 
@@ -74,7 +80,12 @@ var Validator = baseclass.extend({
 			this.assert(false, valid);
 			this.field.setAttribute('data-tooltip', valid);
 			this.field.setAttribute('data-tooltip-style', 'error');
-			this.field.dispatchEvent(new CustomEvent('validation-failure', { bubbles: true }));
+			this.field.dispatchEvent(new CustomEvent('validation-failure', {
+				bubbles: true,
+				detail: {
+					message: valid
+				}
+			}));
 			return false;
 		}
 


### PR DESCRIPTION
When saving your changes with an invalid input field the message is always generic. I have added the validation message to the validation-failure event and now you get the precise message also in the save error popup.

### Generic Error
![generic error message](https://user-images.githubusercontent.com/60816858/137123890-4bd7630b-7902-4061-8034-8fd1bf513a7c.png)

### Custom Error
![custom validation message](https://user-images.githubusercontent.com/60816858/137123722-c1d05cca-a9a0-40be-bdff-e6bfc9a67848.png)

