### PR TITLE
luci-app-netdata: add application for netdata

### DIFF
--- a/applications/luci-app-netdata/Makefile
+++ b/applications/luci-app-netdata/Makefile
@@ -1,0 +1,11 @@
+# This is free software, licensed under the Apache License, Version 2.0 .
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for Netdata
+LUCI_DEPENDS:=+netdata
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-netdata/htdocs/luci-static/resources/view/netdata.js
+++ b/applications/luci-app-netdata/htdocs/luci-static/resources/view/netdata.js
@@ -1,0 +1,13 @@
+'use strict';
+'require view';
+
+return view.extend({
+    render: function() {
+        var ssl = '0';
+        var port = 19999;
+        return E('iframe', {
+            src: (ssl === '1' ? 'https' : 'http') + '://' + window.location.hostname + ':' + port,
+            style: 'width: 100%; min-height: 1200px; border: none; border-radius: 3px;',
+        })
+    }
+});

--- a/applications/luci-app-netdata/root/usr/share/luci/menu.d/luci-app-netdata.json
+++ b/applications/luci-app-netdata/root/usr/share/luci/menu.d/luci-app-netdata.json
@@ -1,0 +1,13 @@
+{
+    "admin/status/netdata": {
+        "title": "NetData",
+        "order": 55,
+        "action": {
+            "type": "view",
+            "path": "netdata"
+        },
+        "depends": {
+            "acl": [ "luci-mod-status-index" ]
+        }
+    }
+}


### PR DESCRIPTION
This luci app supports netdata.

Depends on [package/netdata](https://github.com/openwrt/packages/tree/master/admin/netdata) .

Signed-off-by: Pu Shen <shenpuvip@gmail.com>
