### PR TITLE
Allow setting the MTU between 1280 and 9200

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -115,7 +115,7 @@ return network.registerProtocol('wireguard', {
 		// -- advanced --------------------------------------------------------------------
 
 		o = s.taboption('advanced', form.Value, 'mtu', _('MTU'), _('Optional. Maximum Transmission Unit of tunnel interface.'));
-		o.datatype = 'range(1280,1420)';
+		o.datatype = 'range(1280,9200)';
 		o.placeholder = '1420';
 		o.optional = true;
 


### PR DESCRIPTION
The default MTU of 1420 is suitable when the outter MTU is 1500
and the transport is UDP over IPv6. If you know that all your peers
are reachable using IPv4 only, you can easily gain 20 bytes and set
the wireguard MTU to 1440.

For internal networks, lab setups or maybe some Internet connections
allowing up to 9200 could be handy.

Signed-off-by: Simon Deziel <simon@sdeziel.info>