### PR TITLE
luci-mod-system:  Update ACL to allow access to getLocaltime

### DIFF
--- a/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
@@ -3,7 +3,7 @@
 		"description": "Grant access to system configuration",
 		"read": {
 			"ubus": {
-				"luci": [ "getInitList", "getLEDs", "getTimezones", "getUSBDevices" ],
+				"luci": [ "getInitList", "getLEDs", "getTimezones", "getLocaltime", "getUSBDevices" ],
 				"system": [ "info" ]
 			},
 			"uci": [ "luci", "system" ]


### PR DESCRIPTION
  Recent changes require access to getLocaltime on the System->System page

Signed-off-by:  Gerry Rozema <gerryr@rozeware.com>