### PR TITLE
trivial fix of wrong varible name

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/olsrd.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/olsrd.js
@@ -86,7 +86,7 @@ return baseclass.extend({
 				    opts = {};
 
 				opts[dsn1] = { color: "00ff00", title: "LQ (%s)".format(host) };
-				opts[dns2] = { color: "0000ff", title: "NLQ (%s)".format(host), flip: true };
+				opts[dsn2] = { color: "0000ff", title: "NLQ (%s)".format(host), flip: true };
 
 				g.push({
 					title: "%H: Signal Quality (%s)".format(host), vlabel: "ETX",


### PR DESCRIPTION
This trivial patch will fix some issues affecting the display of collected olsrd statistics resp. graphs.
