### PR TITLE
luci-theme-bootstrap: fix bug in light theme

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -82,6 +82,10 @@
 	--border-color-delta-l-sign: 1;
 }
 
+:root[data-darkmode="false"] {
+    color-scheme: light;
+}
+
 /* Reset.less
  * Props to Eric Meyer (meyerweb.com) for his CSS reset file. We're using an adapted version here	that cuts out some of the reset HTML elements we will never need here (i.e., dfn, samp, etc).
  * ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- */


### PR DESCRIPTION
if a dark theme was selected in the OS, and a light one was forced or automatic in LuCI, then some elements (checkboxes, scrolls) were from the dark theme

**Selected BootrstrapLight in LuCI and dark theme in OS:**
>before:
![image](https://user-images.githubusercontent.com/30866426/140661666-d33b9a11-87de-43a9-8f5f-81c930d10929.png)
after:
![image](https://user-images.githubusercontent.com/30866426/140661711-52f297c3-cf1f-4c1f-8aa3-e4cf69f375cf.png)
