### PR TITLE
luci-mod-network: Disambiguate DNS config message

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -1883,7 +1883,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "إلغاء الارتباط عند الإقرار القليل"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr "تجاهل استجابات المنبع RFC1918"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -1855,7 +1855,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Дисоцииране при ниско потвърждение"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -1829,7 +1829,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -1871,8 +1871,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Descarta les respostes RFC1918 des de dalt"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Descarta les respostes RFC1918 des de dalt."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -1889,7 +1889,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Zrušit spojení při nízkém počtu ACK potvrzení"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr "Vyřadit upstream RFC1918 odpovědi."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -1944,8 +1944,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Trennung bei schlechtem Antwortverhalten"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Eingehende RFC1918-Antworten verwerfen"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Eingehende RFC1918-Antworten verwerfen."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -1862,8 +1862,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Αγνόησε τις απαντήσεις ανοδικής ροής RFC1918"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Αγνόησε τις απαντήσεις ανοδικής ροής RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -1852,7 +1852,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -1953,8 +1953,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Desasociarse en un reconocimiento bajo"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Descartar respuestas RFC1918 ascendentes"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Descartar respuestas RFC1918 ascendentes."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -1900,8 +1900,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Poista heikon kuittauksen yhteydet"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Hylkää ulkoverkosta tulevat RFC1918-vastaukset"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Hylkää ulkoverkosta tulevat RFC1918-vastaukset."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -1933,8 +1933,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Désassossier sur la reconnaissance basse (Low Acknowledgement)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Rejeter les réponses RFC1918 en amont"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Rejeter les réponses RFC1918 en amont."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -1850,7 +1850,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -1831,7 +1831,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -1905,8 +1905,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Hozzárendelés megszüntetése alacsony nyugtázásnál"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Külső RFC1918 válaszok elvetése"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Külső RFC1918 válaszok elvetése."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -1910,7 +1910,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Disconnetti client in caso di Acknowledgement scarso"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr "Scarta risposte RFC1918 upstream."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -1911,8 +1911,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "確認応答が不安定な場合、接続解除"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "アップストリームのRFC1918応答を破棄します"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "アップストリームのRFC1918応答を破棄します。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -1866,7 +1866,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -1829,7 +1829,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -1833,7 +1833,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -1869,8 +1869,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Forkast oppstrøms RFC1918 svar"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Forkast oppstrøms RFC1918 svar."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -1839,7 +1839,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -1927,8 +1927,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Rozłączaj przy niskim stanie ramek ACK"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Odrzuć wychodzące odpowiedzi RFC1918."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Odrzuć odpowiedzi nadrzędne zawierające adresy RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -1950,8 +1950,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Desassociar quando tiver baixa confirmação"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Descartar respostas RFC1918 a montante"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Descartar respostas RFC1918 a montante."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -1966,7 +1966,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Desassocie quando houver baixa confirmação de recebimento"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 "Descartar respostas dos servidores externos para redes privadas (RFC1918)."
 

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -1889,7 +1889,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Dezasociere la recunoaștere scăzută"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -1949,8 +1949,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Не ассоциировать при низком подтверждении"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Отбрасывать ответы внешней сети RFC1918."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Отбрасывать ответы восходящего потока, содержащие адреса RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -1849,7 +1849,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -1843,7 +1843,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
@@ -2185,7 +2185,7 @@ msgid ""
 "Enable automatic redirection of <abbr title=\"Hypertext Transfer Protocol"
 "\">HTTP</abbr> requests to <abbr title=\"Hypertext Transfer Protocol Secure"
 "\">HTTPS</abbr> port."
-msgstr ""
+msgstr "Avvisa uppströmssvar som innehåller RFC1918-adresser."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:960
 msgid ""

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -1820,7 +1820,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -1923,7 +1923,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Düşük Onayda İlişkilendirmeyi Kes"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr "Yukarı akış RFC1918 yanıtlarını yoksay."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -1932,8 +1932,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Роз'єднувати за низького підтвердження"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Відкидати висхідні RFC1918-відповіді"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Відкиньте відповіді вгору за течією, що містять адреси RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -1877,8 +1877,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "Hủy liên kết với xác nhận mức thấp"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "Hủy phản hồi ngược RFC1918"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "Hủy phản hồi ngược RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -1867,7 +1867,7 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "在低 Ack 应答时断开连接"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
 msgstr "丢弃 RFC1918 上行响应。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -1871,8 +1871,8 @@ msgid "Disassociate On Low Acknowledgement"
 msgstr "低確認(Low Acknowledgement)時取消連線"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:302
-msgid "Discard upstream RFC1918 responses."
-msgstr "丟棄上游RFC1918 虛擬IP網路的回應"
+msgid "Discard upstream responses containing <%s>RFC1918<%s> addresses."
+msgstr "丟棄上游RFC1918 虛擬IP網路的回應。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:198
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:723

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -299,7 +299,7 @@ return view.extend({
 
 		o = s.taboption('general', form.Flag, 'rebind_protection',
 			_('Rebind protection'),
-			_('Discard upstream RFC1918 responses.'));
+			_('Discard upstream responses containing <%s>RFC1918<%s> addresses.').format('a href="https://datatracker.ietf.org/doc/html/rfc1918" target="_blank" rel="noreferrer noopener"', '/a'));
 		o.rmempty = false;
 
 		o = s.taboption('general', form.Flag, 'rebind_localhost',


### PR DESCRIPTION
luci-mod-network: Disambiguate DNS config message

Responses themselves are not RFC1918, but the address types that they
contain may be.

Signed-off-by: Paul Dee <itsascambutmailmeanyway@gmail.com>