### PR TITLE
luci-proto-wireguard: add option to disable peer-section

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -151,6 +151,9 @@ return network.registerProtocol('wireguard', {
 			]);
 		};
 
+		o = ss.option(form.Flag, 'disabled', _('Peer disabled'), _('Enable / Disable peer. Restart wireguard interface to apply changes.'));
+		o.optional = true;
+
 		o = ss.option(form.Value, 'description', _('Description'), _('Optional. Description of peer.'));
 		o.placeholder = 'My Peer';
 		o.datatype = 'string';


### PR DESCRIPTION
Add luci option to [c4e9940](https://github.com/openwrt/openwrt/commit/c4e994011f56d30e031705c16c6b5c498c530852) which allows disabling a wireguard peer

Signed-off-by: Robert Walli <12079858+rwalli@users.noreply.github.com>