### PR TITLE
ci: Only run github pages on the official repository

### DIFF
--- a/.github/workflows/jsdoc.yml
+++ b/.github/workflows/jsdoc.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy:
+    if: github.repository == 'openwrt/luci'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
I noticed this undesired actions running on the forked repository.

As I understand this, generating the 'gh-pages' branch is only meaningful in the official repository. I think this should fix it.
