### PR TITLE
Add support for SK-ECDSA-SHA2 keys to be uploaded in web interface

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js
@@ -22,7 +22,7 @@ var SSHPubkeyDecoder = baseclass.singleton({
 
 	decode: function(s)
 	{
-		var parts = s.trim().match(/^((?:(?:^|,)[^ =,]+(?:=(?:[^ ",]+|"(?:[^"\\]|\\.)*"))?)+ +)?(ssh-dss|ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp[0-9]+) +([^ ]+)( +.*)?$/);
+		var parts = s.trim().match(/^((?:(?:^|,)[^ =,]+(?:=(?:[^ ",]+|"(?:[^"\\]|\\.)*"))?)+ +)?(ssh-dss|ssh-rsa|ssh-ed25519|(sk-)?ecdsa-sha2-nistp[0-9]+) +([^ ]+)( +.*)?$/);
 
 		if (!parts)
 			return null;


### PR DESCRIPTION
Allow adding sk-ecdsa-sha2 keys, which are regular ECDSA-SHA2 keys with authentication by FIDO/U2F token.
Mine start with the following identifier: `sk-ecdsa-sha2-nistp256@openssh.com`.