### PR TITLE
luci-mod-status: add diskfree info

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/25_diskfree.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/25_diskfree.js
@@ -1,0 +1,51 @@
+'use strict';
+'require baseclass';
+'require rpc';
+
+var callSystemInfo = rpc.declare({
+	object: 'system',
+	method: 'info'
+});
+
+function progressbar(value, max, byte) {
+	var vn = parseInt(value) || 0,
+	    mn = parseInt(max) || 100,
+	    fv = byte ? String.format('%1024.2mB', value) : value,
+	    fm = byte ? String.format('%1024.2mB', max) : max,
+	    pc = Math.floor((100 / mn) * vn);
+
+	return E('div', {
+		'class': 'cbi-progressbar',
+		'title': '%s / %s (%d%%)'.format(fv, fm, pc)
+	}, E('div', { 'style': 'width:%.2f%%'.format(pc) }));
+}
+
+return baseclass.extend({
+	title: _('Storage usage'),
+
+	load: function() {
+		return L.resolveDefault(callSystemInfo(), {});
+	},
+
+	render: function(systeminfo) {
+		var root = L.isObject(systeminfo.root) ? systeminfo.root : {},
+		    tmp = L.isObject(systeminfo.tmp) ? systeminfo.tmp : {};
+
+		var fields = [];
+		fields.push(_('Disk space'), root.used*1024, root.total*1024);
+		fields.push(_('Temp space'), tmp.used*1024, tmp.total*1024);
+
+		var table = E('table', { 'class': 'table' });
+
+		for (var i = 0; i < fields.length; i += 3) {
+			table.appendChild(E('tr', { 'class': 'tr' }, [
+				E('td', { 'class': 'td left', 'width': '33%' }, [ fields[i] ]),
+				E('td', { 'class': 'td left' }, [
+					(fields[i + 1] != null) ? progressbar(fields[i + 1], fields[i + 2], true) : '?'
+				])
+			]));
+		}
+
+		return table;
+	}
+});


### PR DESCRIPTION
Since commit https://git.openwrt.org/?p=project/procd.git;a=commit;h=8de12dec298898d133256fdaac584a26adae2cc5 we have the following information from `ubus call system info` for tmp and root filesystem available.
```
        "root": {
                "total": 175872,
                "free": 98896,
                "used": 76976,
                "avail": 98896
        },
        "tmp": {
                "total": 2010208,
                "free": 2008668,
                "used": 1540,
                "avail": 2008668
        }
```
The changes in procd are include with commit https://github.com/openwrt/openwrt/commit/507f50df0771935ee389d383c0543e36f914f949
I have copied the source from the `20_memory.js ` file and adapted it
![Screenshot_2021-11-24 st-dev-07 - Übersicht - LuCI](https://user-images.githubusercontent.com/553091/143220939-836330cd-d41d-4871-9dba-b0ccb020290d.png)
.
