### PR TITLE
https-dns-proxy support option use_http1

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -199,4 +199,7 @@ dscp.rmempty  = true
 ps = s3:option(Value, "proxy_server", translate("Proxy Server"))
 ps.rmempty  = true
 
+uh = s3:option(Flag, "use_http1",translate("Use Http1"))
+uh.rmempty = true
+
 return m


### PR DESCRIPTION
https-dns-proxy support option use_http1


Signed-off-by: zhaoruibin <zhaoruibin@aliyun.com>