### PR TITLE
luci-app-https-dns-proxy: https-dns-proxy support option use_http1

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -199,4 +199,7 @@ dscp.rmempty  = true
 ps = s3:option(Value, "proxy_server", translate("Proxy Server"))
 ps.rmempty  = true
 
+uh = s3:option(Flag, "use_http1",translate("Use Http1"))
+uh.rmempty = true
+
 return m


### PR DESCRIPTION
https-dns-proxy support option use_http1
openwrt log this message when use some doh server
`
04:18:13 https-dns-proxy[13386]: [E] 1622459893.038372 https_client.c:102 CURLOPT_HTTP_VERSION error 1: Error
04:18:13 https-dns-proxy[13386]: [E] 1622459893.038413 https_client.c:104 Try to run application with -x argument!
`
https-dns-proxy configed this option fixed this issue.
we supported this option in luci interface.

Signed-off-by: Robin <zhaoruibin@aliyun.com>