### PR TITLE
luci-mod-network: Clean up RADIUS strings in EAP options.

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -5847,27 +5847,27 @@ msgid "RX Rate / TX Rate"
 msgstr "معدل RX / معدل الإرسال"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "منفد محاسبة -راديوس"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radius- محاسبة- سر"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "خادم المحاسبة Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "منفذ مصادقة Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radius- المصادقة السرية"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "خادم مصادقة Radius"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -5766,27 +5766,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -5697,27 +5697,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -5772,27 +5772,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -5885,27 +5885,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Rychlost přijímání / vysílání"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Port pro Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Tajný klíč pro Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Server Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Výběr ověřování portů"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Tajný klíč pro Radius-Authentication"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Server Radius-Authentication"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -5955,27 +5955,27 @@ msgid "RX Rate / TX Rate"
 msgstr "RX-hastighed / TX-hastighed"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
-msgstr "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
+msgstr "RADIUS Accounting Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radius-Accounting-Hemmelighed"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
-msgstr "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
+msgstr "RADIUS Accounting Server"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Radius-godkendelse-port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radius-godkendelse-Hemmelighed"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Radius-godkendelse-server"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -6010,28 +6010,28 @@ msgid "RX Rate / TX Rate"
 msgstr "RX-Rate / TX-Rate"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
-msgstr "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
+msgstr "RADIUS Accounting Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radius-Accounting-Geheimnis"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
-msgstr "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
+msgstr "RADIUS Accounting Server"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
-msgstr "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
+msgstr "RADIUS Authentication Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radius-Authentifizierung-Geheimnis"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
-msgstr "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
+msgstr "RADIUS Authentication Server"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88
 msgid "Raw hex-encoded bytes. Leave empty unless your ISP require this"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -5778,27 +5778,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -5748,27 +5748,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -6036,27 +6036,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Tasa RX / TX"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Puerto de contabilidad Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Secreto de contabilidad Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Servidor de contabilidad Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Puerto de autentificación Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Secreto de autentificación Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Servidor de autentificación Radius"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -5891,27 +5891,27 @@ msgid "RX Rate / TX Rate"
 msgstr "RX-nopeus / TX-nopeus"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Radiustilastointi portti"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radiustilastointi salaisuus"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Radiustilastointi palvelin"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Radiustunnistus portti"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radiustunnistus salaisuus"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Radiustunnistus palvelin"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -5936,27 +5936,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Taux RX / Taux TX"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Port de la comptabilisation Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Secret de la comptabilisation Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Serveur de la comptabilisation Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Port de l'authentification Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Secret de l'authentification Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Serveur de l'authentification Radius"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -5720,27 +5720,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -5699,27 +5699,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -5901,27 +5901,27 @@ msgid "RX Rate / TX Rate"
 msgstr "RX-sebesség/TX-sebesség"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Radius-Elszámolás-Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radius-Elszámolás-Titok"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Radius-Elszámolás-Kiszolgáló"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Radius-Hitelesítés-Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radius-Hitelesítés-Titok"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Radius-Hitelesítés-Kiszolgáló"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -5855,27 +5855,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -5917,27 +5917,27 @@ msgid "RX Rate / TX Rate"
 msgstr "受信レート/送信レート"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Radiusアカウンティング-ポート"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radiusアカウンティング-秘密鍵"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Radiusアカウンティング-サーバー"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Radius認証-ポート"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radius認証-秘密鍵"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Radius認証-サーバー"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -5759,27 +5759,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -5697,27 +5697,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -5721,27 +5721,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -5787,28 +5787,28 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
-msgstr "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
+msgstr "RADIUS Accounting Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
-msgstr "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
+msgstr "RADIUS Accounting Secret"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
-msgstr "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
+msgstr "RADIUS Accounting Server"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
-msgstr "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
+msgstr "RADIUS Authentication Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
-msgstr "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
+msgstr "RADIUS Authentication Secret"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
-msgstr "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
+msgstr "RADIUS Authentication Server"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88
 msgid "Raw hex-encoded bytes. Leave empty unless your ISP require this"

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -5714,27 +5714,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -5984,27 +5984,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Szybkość: RX/TX"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Port Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Sekret Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Serwer Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Port Radius-Authentication"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Sekret Radius-Authentication"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Serwer Radius-Authentication"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -6033,27 +6033,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Taxa RX / Taxa TX"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Porta-Conta-Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Segredo-Conta-Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Servidor-Conta-Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Porta-Autenticação-Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Segredo-Autenticação-Radius"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Servidor-Autenticação-Radius"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -6057,27 +6057,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Taxa de RX / Taxa de TX"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Porta de contabilidade do RADIUS"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Segredo da contabilidade do RADIUS"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Servidor da contabilidade do RADIUS"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Porta de autenticação do RADIUS"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Segredo da autenticação do RADIUS"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Servidor da autenticação do RADIUS"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -5773,27 +5773,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Rată de recepție / Rată de transmisie"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -6007,27 +6007,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Скорость приёма / отправки"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Порт Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Секрет Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Сервер Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Порт Radius-Authentication"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Секрет Radius-Authentication"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Сервер Radius-Authentication"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -5735,27 +5735,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Rýchl. prijímania /odosielania"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -5721,27 +5721,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -5688,27 +5688,27 @@ msgid "RX Rate / TX Rate"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -5961,27 +5961,27 @@ msgid "RX Rate / TX Rate"
 msgstr "RX Oranı / TX Oranı"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Radius-Accounting-Bağlantı Noktası"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radius-Accounting-Sırrı"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Radius-Accounting-Sunucusu"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Radius-Kimlik Doğrulama-Bağlantı Noktası"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radius-Kimlik Doğrulama-Sırrı"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Radius-Kimlik Doğrulama-Sunucusu"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -5949,27 +5949,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Швидкість прийм./перед."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Порт Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Секрет Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Сервер Radius-Accounting"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Порт Radius-Authentication"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Секрет Radius-Authentication"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Сервер Radius-Authentication"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -5837,27 +5837,27 @@ msgid "RX Rate / TX Rate"
 msgstr "Tốc độ dữ liệu nhận/truyền"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr ""
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -5811,27 +5811,27 @@ msgid "RX Rate / TX Rate"
 msgstr "接收速率/发送速率"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Radius 计费端口"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radius 计费密钥"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Radius 计费服务器"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Radius 认证端口"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radius 认证密钥"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Radius 认证服务器"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -5811,27 +5811,27 @@ msgid "RX Rate / TX Rate"
 msgstr "接收速率 / 發送速率"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
-msgid "Radius-Accounting-Port"
+msgid "RADIUS Accounting Port"
 msgstr "Radius-驗証帳號-埠"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
-msgid "Radius-Accounting-Secret"
+msgid "RADIUS Accounting Secret"
 msgstr "Radius-合法帳號-密碼"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
-msgid "Radius-Accounting-Server"
+msgid "RADIUS Accounting Server"
 msgstr "Radius-合法帳號-伺服器"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
-msgid "Radius-Authentication-Port"
+msgid "RADIUS Authentication Port"
 msgstr "Radius-驗証-埠"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
-msgid "Radius-Authentication-Secret"
+msgid "RADIUS Authentication Secret"
 msgstr "Radius-驗証-密碼"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
-msgid "Radius-Authentication-Server"
+msgid "RADIUS Authentication Server"
 msgstr "Radius-驗証-伺服器"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1393,47 +1393,50 @@ return view.extend({
 				}
 
 
-				o = ss.taboption('encryption', form.Value, 'auth_server', _('Radius-Authentication-Server'));
+				o = ss.taboption('encryption', form.Value, 'auth_server', _('RADIUS Authentication Server'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.datatype = 'host(0)';
 
-				o = ss.taboption('encryption', form.Value, 'auth_port', _('Radius-Authentication-Port'), _('Default %d').format(1812));
+				o = ss.taboption('encryption', form.Value, 'auth_port', _('RADIUS Authentication Port'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.datatype = 'port';
+				o.placeholder = '1812';
 
-				o = ss.taboption('encryption', form.Value, 'auth_secret', _('Radius-Authentication-Secret'));
+				o = ss.taboption('encryption', form.Value, 'auth_secret', _('RADIUS Authentication Secret'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.password = true;
 
-				o = ss.taboption('encryption', form.Value, 'acct_server', _('Radius-Accounting-Server'));
+				o = ss.taboption('encryption', form.Value, 'acct_server', _('RADIUS Accounting Server'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.datatype = 'host(0)';
 
-				o = ss.taboption('encryption', form.Value, 'acct_port', _('Radius-Accounting-Port'), _('Default %d').format(1813));
+				o = ss.taboption('encryption', form.Value, 'acct_port', _('RADIUS Accounting Port'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.datatype = 'port';
+				o.placeholder = '1813';
 
-				o = ss.taboption('encryption', form.Value, 'acct_secret', _('Radius-Accounting-Secret'));
+				o = ss.taboption('encryption', form.Value, 'acct_secret', _('RADIUS Accounting Secret'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.password = true;
 
-				o = ss.taboption('encryption', form.Value, 'dae_client', _('DAE-Client'));
+				o = ss.taboption('encryption', form.Value, 'dae_client', _('DAE-Client'), _('Dynamic Authorization Extension client.'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.datatype = 'host(0)';
 
-				o = ss.taboption('encryption', form.Value, 'dae_port', _('DAE-Port'), _('Default %d').format(3799));
+				o = ss.taboption('encryption', form.Value, 'dae_port', _('DAE-Port'), _('Dynamic Authorization Extension port.'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.datatype = 'port';
+				o.placeholder = '3799';
 
-				o = ss.taboption('encryption', form.Value, 'dae_secret', _('DAE-Secret'));
+				o = ss.taboption('encryption', form.Value, 'dae_secret', _('DAE-Secret'), _('Dynamic Authorization Extension secret.'));
 				add_dependency_permutations(o, { mode: ['ap', 'ap-wds'], encryption: ['wpa', 'wpa2', 'wpa3', 'wpa3-mixed'] });
 				o.rmempty = true;
 				o.password = true;


### PR DESCRIPTION
Plus placeholders for default ports. 

Signed-off-by: Paul Dee <systemcrash@users.noreply.github.com>