### PR TITLE
fix openwrt2020 theme font issue when mixing latin and non-latin symbols

### DIFF
--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -15,6 +15,10 @@
  	src: url("GalanoGrotesqueW00-Regular.woff2") format("woff2");
 }
 
+:root[lang="bg"], :root[lang="ru"], :root[lang="uk"], :root[lang="de"], :root[lang="el"], :root[lang="he"]  {
+	--regular-font: "Helvetica";
+}
+
 /*
  * resets and base style
  */


### PR DESCRIPTION
GalanoGrotesque used by openwrt2020 theme does not support non-latin symbols
If latin and non-latin symbols are used together in one line it looks strange
because for latin symbols GalanoGrotesque is used but for non-latin symbols
fallback font is used (sans-serif)

This patch changes default font to Helvetica for the languages: bg, ru, uk, de, el, he.

Original patch was written by Jo-Philipp Wich

Closes #5580 (github issue)

Signed-off-by: Sergey V. Lobanov <sergey@lobanov.in>