### PR TITLE
Correct Domain Tooltip

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -733,7 +733,7 @@ return view.extend({
 
 					o = s.taboption('basic', form.Value, 'domain',
 						_("Domain"),
-						_("Replaces [USERNAME] in Update-URL (URL-encoded)"));
+						_("Replaces [DOMAIN] in Update-URL (URL-encoded)"));
 					o.modalonly = true;
 					o.rmempty = false;
 


### PR DESCRIPTION
Correct wrong \[USERNAME\] tooltip to \[DOMAIN\]

Signed-off-by: Claudio Mezzasalma <claudio.mezzasalma@gmail.com>