### PR TITLE
luci-app-tinyproxy: Fix ConnectPort help text

### DIFF
--- a/applications/luci-app-tinyproxy/luasrc/model/cbi/tinyproxy.lua
+++ b/applications/luci-app-tinyproxy/luasrc/model/cbi/tinyproxy.lua
@@ -131,9 +131,8 @@ o.datatype = "ipaddr"
 
 
 o = s:taboption("filter", DynamicList, "ConnectPort", translate("Allowed connect ports"),
-	translate("List of allowed ports for the CONNECT method. A single value \"0\" allows all ports"))
+	translate("List of allowed ports for the CONNECT method. A single value \"0\" disable CONNECT altogether. Leave empty allow CONNECT all ports"))
 
-o.placeholder = 0
 o.datatype = "port"
 
 


### PR DESCRIPTION

ConnectPort
This option can be used to specify the ports allowed for the CONNECT method. If no `ConnectPort` line is found, then all ports are allowed. To disable CONNECT altogether, include a single ConnectPort line with a value of `0`.