### PR TITLE
luci-mod-network: add dnsmasq log-facility option

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -275,8 +275,14 @@ return view.extend({
 
 		o = s.taboption('general', form.Flag, 'logqueries',
 			_('Log queries'),
-			_('Write received DNS queries to syslog.'));
+			_('Write received DNS queries to syslog by default, or log facility if defined.'));
 		o.optional = true;
+
+		o = s.taboption('general', form.Value, 'logfacility',
+			_('Log facility'),
+			_('File to log received DNS queries to. Leave empty to log to syslog.'));
+		o.optional = true;
+		o.depends('logqueries', '1');
 
 		o = s.taboption('general', form.DynamicList, 'server',
 			_('DNS forwardings'),


### PR DESCRIPTION
Linked OpenWrt PR: [#4864](https://github.com/openwrt/openwrt/pull/4864)
Add dnsmasq's log-facility option to luci-mod-network, which already
exists as a uci option. This allows the user to specify a custom file
location for queries to be written to, rather than the default syslog
when enabled via the log-queries option.

Signed-off-by: Matthew Hagan <mnhagan88@gmail.com>