### PR TITLE
luci-app-https-dns-proxy: AhaDNS.com DoH servers

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ahadns-doh-chi.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ahadns-doh-chi.lua
@@ -1,0 +1,8 @@
+return {
+	name = "ahadns-doh-chi",
+	label = _("AhaDNS.com - Chicago (Block Malware + Ads)"),
+	resolver_url = "https://doh.chi.ahadns.net/dns-query",
+	bootstrap_dns = "193.29.62.196,2605:4840:3:c4::c4",
+	help_link = "https://ahadns.com/dns-over-https/",
+	help_link_text = "AhaDNS.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ahadns-doh-la.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ahadns-doh-la.lua
@@ -1,0 +1,8 @@
+return {
+	name = "ahadns-doh-la",
+	label = _("AhaDNS.com - Los Angeles (Block Malware + Ads)"),
+	resolver_url = "https://doh.la.ahadns.net/dns-query",
+	bootstrap_dns = "45.67.219.208,2a04:bdc7:100:70::70",
+	help_link = "https://ahadns.com/dns-over-https/",
+	help_link_text = "AhaDNS.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ahadns-doh-ny.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ahadns-doh-ny.lua
@@ -1,0 +1,8 @@
+return {
+	name = "ahadns-doh-ny",
+	label = _("AhaDNS.com - New York (Block Malware + Ads)"),
+	resolver_url = "https://doh.ny.ahadns.net/dns-query",
+	bootstrap_dns = "185.213.26.187,2a0d:5600:33:3::3",
+	help_link = "https://ahadns.com/dns-over-https/",
+	help_link_text = "AhaDNS.com"
+}


### PR DESCRIPTION
# AhaDNS.com
You can please add the **NEW DoH servers**:
- [DNS over HTTPS (DoH) – AhaDNS.com](https://ahadns.com/dns-over-https/)

A zero logging DNS with support for DNS-over-HTTPS (DoH) & DNS-over-TLS (DoT). Blocks ads, malware, trackers, viruses, ransomware, telemetry and more. No persistent logs. DNSSEC. By https://ahadns.com/
Server statistics can be seen at: https://statistics.ahadns.com/?server=all


@stangri 

**I don't know if it's okay.**

