### PR TITLE
luci-app-statistics: ping module, Update MaxMissed data type

### DIFF
--- a/applications/luci-app-ddns/po/fi/ddns.po
+++ b/applications/luci-app-ddns/po/fi/ddns.po
@@ -1,23 +1,23 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-06-18 19:32+0000\n"
-"Last-Translator: Demian Wright <wright.demian+weblate@gmail.com>\n"
+"PO-Revision-Date: 2021-12-21 16:49+0000\n"
+"Last-Translator: Hannu Nyman <hannu.nyman@iki.fi>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsddns/fi/>\n"
 "Language: fi\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.7\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:430
 msgid "\"../\" not allowed in path for Security Reason."
-msgstr ""
+msgstr "\"../\" ei ole sallittu polussa turvallisuussyistä."
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:462
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:531
 msgid "Add new services..."
-msgstr ""
+msgstr "Lisää uusia palveluita..."
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:605
 msgid "Advanced Settings"
@@ -25,7 +25,7 @@ msgstr "Lisäasetukset"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:399
 msgid "Allow non-public IP's"
-msgstr ""
+msgstr "Salli ei-julkiset IP-osoitteet"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:604
 msgid "Basic Settings"
@@ -33,39 +33,47 @@ msgstr "Perusasetukset"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:884
 msgid "Bind Network"
-msgstr ""
+msgstr "Sido verkko"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:330
 msgid "Binding to a specific network not supported"
-msgstr ""
+msgstr "Sitomista tiettyyn verkkoon ei tueta"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:357
 msgid ""
 "BusyBox's nslookup and Wget do not support to specify the IP version to use "
 "for communication with DDNS Provider!"
 msgstr ""
+"BusyBoxin nslookup ja Wget eivät tue DDNS-palveluntarjoajan kanssa "
+"kommunikointiin käytettävän IP-version määrittämistä!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:368
 msgid ""
 "BusyBox's nslookup and hostip do not support to specify to use TCP instead "
 "of default UDP when requesting DNS server!"
 msgstr ""
+"BusyBoxin nslookup ja hostip eivät tue TCP:n käyttöä oletus-UDP:n sijasta "
+"DNS-palvelinta pyydettäessä!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:379
 msgid ""
 "BusyBox's nslookup in the current compiled version does not handle given DNS "
 "Servers correctly!"
 msgstr ""
+"BusyBoxin nslookup nykyisessä käännetyssä versiossa ei käsittele annettuja "
+"DNS-palvelimia oikein!"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:450
 msgid "Ca Certs path"
-msgstr ""
+msgstr "CaCerts -polku"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:451
 msgid ""
 "Ca Certs path that will be used to download services data. Set IGNORE to "
 "skip certificate validation."
 msgstr ""
+"Ca Certs -polku, jota käytetään palvelutietojen lataamiseen. Aseta IGNORE "
+"ohittaaksesi varmenteen vahvistuksen."
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:537
 msgid "Cancel"
@@ -73,7 +81,7 @@ msgstr "Peruuta"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:962
 msgid "Check Interval"
-msgstr ""
+msgstr "Tarkistusväli"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:977
 msgid "Check Unit"
@@ -82,7 +90,7 @@ msgstr ""
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:522
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:656
 msgid "Checking the service support..."
-msgstr ""
+msgstr "Tarkistetaan palvelutukea..."
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/status/include/70_ddns.js:27
 msgid "Configuration"
@@ -91,15 +99,15 @@ msgstr "Kokoonpano"
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:212
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:1124
 msgid "Configuration Error"
-msgstr ""
+msgstr "Määritysvirhe"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:541
 msgid "Create service"
-msgstr ""
+msgstr "Luo palvelu"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:412
 msgid "Current setting:"
-msgstr ""
+msgstr "Nykyinen asetus:"
 
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:196
 #: applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js:274

--- a/applications/luci-app-dockerman/po/pt/dockerman.po
+++ b/applications/luci-app-dockerman/po/pt/dockerman.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-05-10 09:32+0000\n"
+"PO-Revision-Date: 2021-12-18 11:12+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsdockerman/pt/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.7-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newcontainer.lua:604
 msgid "A list of kernel capabilities to add to the container"
@@ -322,6 +322,7 @@ msgstr "Descarregar"
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/networks.lua:79
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newnetwork.lua:32
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/volumes.lua:85
+#, fuzzy
 msgid "Driver"
 msgstr "Driver"
 

--- a/applications/luci-app-dockerman/po/sv/dockerman.po
+++ b/applications/luci-app-dockerman/po/sv/dockerman.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-12-14 02:53+0000\n"
+"PO-Revision-Date: 2021-12-19 22:52+0000\n"
 "Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsdockerman/sv/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.10-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newcontainer.lua:604
 msgid "A list of kernel capabilities to add to the container"
@@ -322,7 +322,7 @@ msgstr "Nedladdning"
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newnetwork.lua:32
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/volumes.lua:85
 msgid "Driver"
-msgstr "Driver"
+msgstr "Drivrutin"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua:263
 msgid "Duplicate/Edit"
@@ -674,7 +674,7 @@ msgstr "Pass-through (speglar fysisk enhet till ett enda MAC VLAN)"
 
 #: applications/luci-app-dockerman/luasrc/view/dockerman/container_file.htm:7
 msgid "Path"
-msgstr "Sökväg"
+msgstr "Genväg"
 
 #: applications/luci-app-dockerman/luasrc/view/dockerman/images_import.htm:54
 msgid "Please input new tag"

--- a/applications/luci-app-ksmbd/po/sv/ksmbd.po
+++ b/applications/luci-app-ksmbd/po/sv/ksmbd.po
@@ -1,14 +1,14 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-11-05 14:39+0000\n"
-"Last-Translator: Paul Dee <itsascambutmailmeanyway+weblate@gmail.com>\n"
+"PO-Revision-Date: 2021-12-19 22:52+0000\n"
+"Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsksmbd/sv/>\n"
 "Language: sv\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:87
 msgid "Allow guests"
@@ -91,7 +91,7 @@ msgstr "Nätverksdelningar"
 
 #: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:66
 msgid "Path"
-msgstr "Sökväg"
+msgstr "Genväg"
 
 #: applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js:61
 msgid ""

--- a/applications/luci-app-nut/po/pt/nut.po
+++ b/applications/luci-app-nut/po/pt/nut.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2020-10-02 14:41+0000\n"
+"PO-Revision-Date: 2021-12-18 11:12+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsnut/pt/>\n"
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.3-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:216
 msgid "Additional Shutdown Time(s)"
@@ -85,6 +85,7 @@ msgid "Don't lock port when starting driver"
 msgstr "Não bloquear a porta ao iniciar o driver"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:132
+#, fuzzy
 msgid "Driver"
 msgstr "Driver"
 

--- a/applications/luci-app-nut/po/sv/nut.po
+++ b/applications/luci-app-nut/po/sv/nut.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2021-12-16 12:03+0000\n"
+"PO-Revision-Date: 2021-12-19 22:52+0000\n"
 "Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsnut/sv/>\n"
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.10-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:216
 msgid "Additional Shutdown Time(s)"
@@ -84,7 +84,7 @@ msgstr "Lås inte porten när drivrutinen startas"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:132
 msgid "Driver"
-msgstr "Driver"
+msgstr "Drivrutin"
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:114
 msgid "Driver Configuration"

--- a/applications/luci-app-samba4/po/sv/samba4.po
+++ b/applications/luci-app-samba4/po/sv/samba4.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2021-11-05 14:38+0000\n"
-"Last-Translator: Paul Dee <itsascambutmailmeanyway+weblate@gmail.com>\n"
+"PO-Revision-Date: 2021-12-19 22:52+0000\n"
+"Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationssamba4/sv/>\n"
 "Language: sv\n"
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-samba4/htdocs/luci-static/resources/view/samba4.js:120
 msgid "Allow guests"
@@ -141,7 +141,7 @@ msgstr ""
 
 #: applications/luci-app-samba4/htdocs/luci-static/resources/view/samba4.js:99
 msgid "Path"
-msgstr "Sökväg"
+msgstr "Genväg"
 
 #: applications/luci-app-samba4/htdocs/luci-static/resources/view/samba4.js:94
 msgid ""

--- a/applications/luci-app-ser2net/po/pt/ser2net.po
+++ b/applications/luci-app-ser2net/po/pt/ser2net.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2020-05-02 10:22+0000\n"
+"PO-Revision-Date: 2021-12-18 11:12+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsser2net/pt/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.1-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/proxies.js:72
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/settings.js:71
@@ -48,6 +48,7 @@ msgid "Device"
 msgstr "Aparelho"
 
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js:15
+#, fuzzy
 msgid "Driver"
 msgstr "Driver"
 

--- a/applications/luci-app-ser2net/po/sv/ser2net.po
+++ b/applications/luci-app-ser2net/po/sv/ser2net.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-12-15 03:52+0000\n"
+"PO-Revision-Date: 2021-12-19 22:52+0000\n"
 "Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsser2net/sv/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.10-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/proxies.js:72
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/settings.js:71
@@ -49,7 +49,7 @@ msgstr "Enhet"
 
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js:15
 msgid "Driver"
-msgstr "Driver"
+msgstr "Drivrutin"
 
 #: applications/luci-app-ser2net/htdocs/luci-static/resources/view/ser2net/leds.js:23
 msgid "Duration"

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/ping.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/ping.js
@@ -34,9 +34,9 @@ return baseclass.extend({
 		o.depends('enable', '1');
 
 	    o=s.option(form.Value,'MaxMissed',_('Maximum Missed Packets'),
-		       _('When a host has not replied to this number of packets in a row, re-resolve the hostname in DNS.  Useful for dynamic DNS hosts.'));
-		o.placeholder = '10';
-		o.datatype = 'uinteger';
+		       _('When a host has not replied to this number of packets in a row, re-resolve the hostname in DNS.  Useful for dynamic DNS hosts.  Input -1 to disable.'));
+		o.placeholder = '-1';
+		o.datatype = 'and(min(-1),integer)'
 		o.optional = true;
 		o.depends('enable', '1');
 	},

--- a/applications/luci-app-vpn-policy-routing/po/sv/vpn-policy-routing.po
+++ b/applications/luci-app-vpn-policy-routing/po/sv/vpn-policy-routing.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-12-15 03:52+0000\n"
+"PO-Revision-Date: 2021-12-19 22:52+0000\n"
 "Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsvpn-policy-routing/sv/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.10-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:61
 msgid "%s (disabled)"
@@ -216,7 +216,7 @@ msgstr ""
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:374
 msgid "Path"
-msgstr "Sökväg"
+msgstr "Genväg"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:179
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:203

--- a/applications/luci-app-vpnbypass/po/pt/vpnbypass.po
+++ b/applications/luci-app-vpnbypass/po/pt/vpnbypass.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-05-02 20:06+0000\n"
+"PO-Revision-Date: 2021-12-18 11:12+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsvpnbypass/pt/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.7-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:150
 msgid "Disable"
@@ -128,7 +128,7 @@ msgstr "Parando o serviço %s"
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/view/vpnbypass/overview.js:27
 #: applications/luci-app-vpnbypass/root/usr/share/luci/menu.d/vpnbypass.json:3
 msgid "VPN Bypass"
-msgstr "Desvio de VPN"
+msgstr "Desviar o VPN"
 
 #~ msgid "%s (disabled)"
 #~ msgstr "%s (desativado)"

--- a/applications/luci-app-vpnbypass/po/sv/vpnbypass.po
+++ b/applications/luci-app-vpnbypass/po/sv/vpnbypass.po
@@ -1,14 +1,14 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2020-11-22 15:35+0000\n"
-"Last-Translator: PontusÖsterlindh <pontus@osterlindh.com>\n"
+"PO-Revision-Date: 2021-12-19 22:52+0000\n"
+"Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsvpnbypass/sv/>\n"
 "Language: sv\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.4-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:150
 msgid "Disable"
@@ -125,7 +125,7 @@ msgstr ""
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/view/vpnbypass/overview.js:27
 #: applications/luci-app-vpnbypass/root/usr/share/luci/menu.d/vpnbypass.json:3
 msgid "VPN Bypass"
-msgstr "VPN-förbikoppling"
+msgstr ""
 
 #~ msgid "%s (disabled)"
 #~ msgstr "%s (inaktiverad)"

--- a/applications/luci-app-watchcat/po/fi/watchcat.po
+++ b/applications/luci-app-watchcat/po/fi/watchcat.po
@@ -1,13 +1,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"PO-Revision-Date: 2021-12-21 16:49+0000\n"
+"Last-Translator: Hannu Nyman <hannu.nyman@iki.fi>\n"
+"Language-Team: Finnish <https://hosted.weblate.org/projects/openwrt/"
+"luciapplicationswatchcat/fi/>\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.10\n"
 
 #: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:82
 msgid ""
@@ -37,7 +40,7 @@ msgstr ""
 
 #: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:50
 msgid "Check Interval"
-msgstr ""
+msgstr "Tarkistusväli"
 
 #: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:71
 msgid "Force Reboot Delay"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2021-12-15 03:52+0000\n"
-"Last-Translator: Simona Iacob <s@zp1.net>\n"
+"PO-Revision-Date: 2021-12-21 08:58+0000\n"
+"Last-Translator: CRISTIAN ANDREI <cristianvdr@gmail.com>\n"
 "Language-Team: Romanian <https://hosted.weblate.org/projects/openwrt/luci/ro/"
 ">\n"
 "Language: ro\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
 "20)) ? 1 : 2;\n"
-"X-Generator: Weblate 4.10-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1513
 msgid "%.1f dB"
@@ -2605,27 +2605,27 @@ msgstr "Opțiuni suplimentare sstpc"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1529
 msgid "FT over DS"
-msgstr ""
+msgstr "FT peste DS"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1530
 msgid "FT over the Air"
-msgstr ""
+msgstr "FT pe calea aerului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1527
 msgid "FT protocol"
-msgstr ""
+msgstr "Protocolul FT"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:87
 msgid "Failed to change the system password."
-msgstr ""
+msgstr "Nu s-a reușit schimbarea parolei sistemului."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4159
 msgid "Failed to confirm apply within %ds, waiting for rollback…"
-msgstr ""
+msgstr "Nu a reușit să confirme aplicarea în %ds, așteptând rollback…"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:37
 msgid "Failed to execute \"/etc/init.d/%s %s\" action: %s"
-msgstr ""
+msgstr "Nu a reușit să execute acțiunea \"/etc/init.d/%s %s\": %s"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2708
 msgid "File"
@@ -2636,6 +2636,8 @@ msgid ""
 "File listing upstream resolvers, optionally domain-specific, e.g. "
 "<code>server=1.2.3.4</code>, <code>server=/domain/1.2.3.4</code>."
 msgstr ""
+"Fișier care enumeră rezolvatorii din amonte, opțional specific domeniului, "
+"de exemplu <code>server=1.2.3.4</code>, <code>server=/domain/1.2.3.4</code>."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2655
 msgid "File not accessible"
@@ -2647,7 +2649,7 @@ msgstr "Fișier în care se stochează informațiile de închiriere DHCP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:357
 msgid "File with upstream resolvers."
-msgstr ""
+msgstr "Fișier cu rezolvatori din amonte."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2846
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:506
@@ -2656,7 +2658,7 @@ msgstr "Numele fișierului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:492
 msgid "Filename of the boot image advertised to clients."
-msgstr ""
+msgstr "Numele de fișier al imaginii de pornire anunțate clienților."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:191
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:314
@@ -2673,26 +2675,28 @@ msgstr "Filtrați nefolosite"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:389
 msgid "Filtering for all slaves, no validation"
-msgstr ""
+msgstr "Filtrare pentru toți sclavii, fără validare"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:390
 msgid "Filtering for all slaves, validation only for active slave"
-msgstr ""
+msgstr "Filtrare pentru toți sclavii, validare numai pentru sclavul activ"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:391
 msgid "Filtering for all slaves, validation only for backup slaves"
-msgstr ""
+msgstr "Filtrare pentru toți sclavii, validare numai pentru sclavii de rezervă"
 
 #: modules/luci-compat/luasrc/model/network/proto_ncm.lua:65
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:23
 msgid "Finalizing failed"
-msgstr ""
+msgstr "Finalizarea a eșuat"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:150
 msgid ""
 "Find all currently attached filesystems and swap and replace configuration "
 "with defaults based on what was detected"
 msgstr ""
+"Găsiți toate sistemele de fișiere și swap atașate în prezent și înlocuiți "
+"configurația cu cea implicită pe baza a ceea ce a fost detectat"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:878
 msgid "Find and join network"
@@ -2720,7 +2724,7 @@ msgstr "Starea Firewall-ului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:176
 msgid "Firewall mark"
-msgstr ""
+msgstr "Marca Firewall"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1516
 msgid "Firmware File"
@@ -2758,7 +2762,7 @@ msgstr "Scriere…"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:232
 msgid "For QR-Code support please install the qrencode package!"
-msgstr ""
+msgstr "Pentru suport QR-Code vă rugăm să instalați pachetul qrencode!"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:536
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:686
@@ -2779,11 +2783,11 @@ msgstr "Forțați DHCP în această rețea chiar dacă este detectat un alt serv
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:682
 msgid "Force IGMP version"
-msgstr ""
+msgstr "Forțați versiunea IGMP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:689
 msgid "Force MLD version"
-msgstr ""
+msgstr "Forțați versiunea MLD"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1232
 msgid "Force TKIP"
@@ -2803,11 +2807,11 @@ msgstr "Forțați upgrade-ul"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:90
 msgid "Force use of NAT-T"
-msgstr ""
+msgstr "Forțați utilizarea NAT-T"
 
 #: modules/luci-base/luasrc/view/csrftoken.htm:8
 msgid "Form token mismatch"
-msgstr ""
+msgstr "Necorespundere între simboluri de formular"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:912
 msgid ""
@@ -2816,6 +2820,10 @@ msgid ""
 "Advertisement, Type 136\">NA</abbr> messages between the designated master "
 "interface and downstream interfaces."
 msgstr ""
+"Redirecționează mesajele <abbr title=\"Neighbour Discovery Protocol\">NDP</"
+"abbr> <abbr title=\"Neighbour Solicitation, Type 135\">NS</abbr> și <abbr "
+"title=\"Neighbour Advertisement, Type 136\">NA</abbr> între interfața "
+"principală desemnată și interfețele din aval."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:770
 msgid ""
@@ -2823,36 +2831,42 @@ msgid ""
 "messages received on the designated master interface to downstream "
 "interfaces."
 msgstr ""
+"Redirecționează mesajele <abbr title=\"Router Advertisement, ICMPv6 Type "
+"134\">RA</abbr> primite pe interfața principală desemnată către interfețele "
+"din downstream."
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:164
 msgid "Forward DHCP traffic"
-msgstr ""
+msgstr "Redirecționarea traficului DHCP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:878
 msgid ""
 "Forward DHCPv6 messages between the designated master interface and "
 "downstream interfaces."
 msgstr ""
+"Redirecționează mesajele DHCPv6 între interfața principală desemnată și "
+"interfețele din downstream."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:28
 msgid "Forward Error Correction Seconds (FECS)"
-msgstr ""
+msgstr "Secunde de corecție a erorilor înainte (FECS)"
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:161
 msgid "Forward broadcast traffic"
-msgstr ""
+msgstr "Redirecționarea traficului de difuzare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:527
 msgid "Forward delay"
-msgstr ""
+msgstr "Întârziere înainte"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:998
 msgid "Forward mesh peer traffic"
-msgstr ""
+msgstr "Redirecționarea traficului între omologi de plasă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:711
 msgid "Forward multicast packets as unicast packets on this device."
 msgstr ""
+"Redirecționează pachetele multicast ca pachete unicast pe acest dispozitiv."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1564
 msgid "Forwarding mode"
@@ -2867,6 +2881,8 @@ msgid ""
 "Further information about WireGuard interfaces and peers at <a href='http://"
 "wireguard.com'>wireguard.com</a>."
 msgstr ""
+"Mai multe informații despre interfețele WireGuard și peer la <a "
+"href='http://wireguard.com'>wireguard.com</a>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:128
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:184
@@ -2881,19 +2897,19 @@ msgstr "Doar GPRS"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:10
 msgid "GRE tunnel over IPv4"
-msgstr ""
+msgstr "Tunel GRE peste IPv4"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:10
 msgid "GRE tunnel over IPv6"
-msgstr ""
+msgstr "Tunel GRE peste IPv6"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:10
 msgid "GRETAP tunnel over IPv4"
-msgstr ""
+msgstr "Tunel GRETAP pe IPv4"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:10
 msgid "GRETAP tunnel over IPv6"
-msgstr ""
+msgstr "Tunel GRETAP peste IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:75
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:44
@@ -2928,7 +2944,7 @@ msgstr "Configurare generală"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:336
 msgid "General device options"
-msgstr ""
+msgstr "Opțiuni generale ale dispozitivului"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:150
 msgid "Generate Config"
@@ -2936,15 +2952,15 @@ msgstr "Generare configurare"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:116
 msgid "Generate Key"
-msgstr ""
+msgstr "Generarea cheii"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:236
 msgid "Generate New QR-Code"
-msgstr ""
+msgstr "Generarea unui nou cod QR"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid "Generate PMK locally"
-msgstr ""
+msgstr "Generarea locală a PMK"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:396
 msgid "Generate archive"
@@ -2952,7 +2968,7 @@ msgstr "Generați arhivă"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:251
 msgid "Generate new QR-Code"
-msgstr ""
+msgstr "Generarea unui nou cod QR-Code"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:79
 msgid "Given password confirmation did not match, password not changed!"
@@ -2976,7 +2992,7 @@ msgstr "Mergeți la actualizarea firmware-ului..."
 #: themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm:62
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:82
 msgid "Go to password configuration..."
-msgstr ""
+msgstr "Mergeți la configurarea parolei..."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:2617
 #: modules/luci-base/htdocs/luci-static/resources/form.js:3545
@@ -2987,7 +3003,7 @@ msgstr "Mergeți la pagina de configurare relevantă"
 
 #: modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json:37
 msgid "Grant access to DHCP configuration"
-msgstr ""
+msgstr "Acordarea accesului la configurația DHCP"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:22
 msgid "Grant access to DHCP status display"
@@ -2995,35 +3011,35 @@ msgstr "Acordați accesul la afișarea stării DHCP"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:31
 msgid "Grant access to DSL status display"
-msgstr ""
+msgstr "Acordarea accesului la afișarea stării DSL"
 
 #: protocols/luci-proto-openconnect/root/usr/share/rpcd/acl.d/luci-openconnect.json:3
 msgid "Grant access to LuCI OpenConnect procedures"
-msgstr ""
+msgstr "Acordarea accesului la procedurile LuCI OpenConnect"
 
 #: protocols/luci-proto-wireguard/root/usr/share/rpcd/acl.d/luci-wireguard.json:3
 msgid "Grant access to LuCI Wireguard procedures"
-msgstr ""
+msgstr "Acordarea accesului la procedurile LuCI Wireguard"
 
 #: modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json:20
 msgid "Grant access to SSH configuration"
-msgstr ""
+msgstr "Acordarea accesului la configurația SSH"
 
 #: modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json:12
 msgid "Grant access to basic LuCI procedures"
-msgstr ""
+msgstr "Acordarea accesului la procedurile de bază ale LuCI"
 
 #: modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json:79
 msgid "Grant access to crontab configuration"
-msgstr ""
+msgstr "Acordă acces la configurația crontab"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json:70
 msgid "Grant access to firewall status"
-msgstr ""
+msgstr "Acordarea accesului la starea firewall-ului"
 
 #: modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json:132
 msgid "Grant access to flash operations"
-msgstr ""
+msgstr "Acordarea accesului la operațiunile flash"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:3
 msgid "Grant access to main status display"
@@ -3031,55 +3047,55 @@ msgstr "Acordați accesul la afișarea principală a stării"
 
 #: protocols/luci-proto-modemmanager/root/usr/share/rpcd/acl.d/luci-proto-modemmanager.json:3
 msgid "Grant access to mmcli"
-msgstr ""
+msgstr "Acordă acces la mmcli"
 
 #: modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json:100
 msgid "Grant access to mount configuration"
-msgstr ""
+msgstr "Acordarea accesului la configurația de montare"
 
 #: modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json:3
 msgid "Grant access to network configuration"
-msgstr ""
+msgstr "Acordarea accesului la configurația rețelei"
 
 #: modules/luci-mod-network/root/usr/share/rpcd/acl.d/luci-mod-network.json:50
 msgid "Grant access to network diagnostic tools"
-msgstr ""
+msgstr "Acordarea accesului la instrumentele de diagnosticare a rețelei"
 
 #: modules/luci-base/root/usr/share/rpcd/acl.d/luci-base.json:36
 msgid "Grant access to network status information"
-msgstr ""
+msgstr "Acordarea accesului la informațiile privind starea rețelei"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json:13
 msgid "Grant access to process status"
-msgstr ""
+msgstr "Acordarea accesului la starea procesului"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json:3
 msgid "Grant access to realtime statistics"
-msgstr ""
+msgstr "Acordarea accesului la statistici în timp real"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json:47
 msgid "Grant access to routing status"
-msgstr ""
+msgstr "Acordarea accesului la starea de rutare"
 
 #: modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json:57
 msgid "Grant access to startup configuration"
-msgstr ""
+msgstr "Acordarea accesului la configurația de pornire"
 
 #: modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json:3
 msgid "Grant access to system configuration"
-msgstr ""
+msgstr "Acordarea accesului la configurația sistemului"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json:30
 msgid "Grant access to system logs"
-msgstr ""
+msgstr "Acordarea accesului la jurnalele de sistem"
 
 #: modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json:43
 msgid "Grant access to uHTTPd configuration"
-msgstr ""
+msgstr "Acordă acces la configurația uHTTPd"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json:61
 msgid "Grant access to wireless channel status"
-msgstr ""
+msgstr "Acordarea accesului la starea canalului fără fir"
 
 #: modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status-index.json:40
 msgid "Grant access to wireless status display"
@@ -3087,24 +3103,24 @@ msgstr "Acordați accesul la afișarea stării wireless"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:66
 msgid "Group Password"
-msgstr ""
+msgstr "Parolă de grup"
 
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:22
 msgid "Guest"
-msgstr ""
+msgstr "Invitat"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:81
 msgid "HE.net password"
-msgstr ""
+msgstr "Parola HE.net"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:73
 msgid "HE.net username"
-msgstr ""
+msgstr "HE.net nume de utilizator HE.net"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js:9
 #: modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json:64
 msgid "HTTP(S) Access"
-msgstr ""
+msgstr "Acces HTTP(S)"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:46
 msgid "Hang Up"
@@ -3112,11 +3128,11 @@ msgstr "Închideți"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Header Error Code Errors (HEC)"
-msgstr ""
+msgstr "Erori de cod de eroare de antet (HEC)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/heartbeat.js:5
 msgid "Heartbeat interval (kernel: heartbeat)"
-msgstr ""
+msgstr "Intervalul de bătaie a inimii (kernel: heartbeat)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:522
 msgid "Hello interval"
@@ -3136,7 +3152,7 @@ msgstr "Ascunde <abbr title=\"Extended Service Set Identifier\">ESSID</abbr>"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:246
 msgid "Hide QR-Code"
-msgstr ""
+msgstr "Ascundeți codul QR"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:293
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:332
@@ -3145,7 +3161,7 @@ msgstr "Ascundeți legăturile goale"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:956
 msgid "High"
-msgstr ""
+msgstr "Înaltă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:57
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2158
@@ -3156,15 +3172,15 @@ msgstr "Gazdă"
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:171
 msgid "Host expiry timeout"
-msgstr ""
+msgstr "Timpul de expirare a gazdei"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:507
 msgid "Host requests this filename from the boot server."
-msgstr ""
+msgstr "Gazda solicită acest nume de fișier de la serverul de pornire."
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88
 msgid "Host-Uniq tag content"
-msgstr ""
+msgstr "Conținutul etichetei Host-Uniq"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:38
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:558
@@ -3189,35 +3205,39 @@ msgid ""
 "redundant for hostnames already configured with static leases, but it can be "
 "useful to rebind an FQDN."
 msgstr ""
+"Numele de gazdă sunt utilizate pentru a lega un nume de domeniu de o adresă "
+"IP. Această setare este redundantă pentru numele de gazde deja configurate "
+"cu contracte de închiriere statice, dar poate fi utilă pentru a reconecta un "
+"FQDN."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/timer.js:19
 msgid "How long (in milliseconds) the LED should be off"
-msgstr ""
+msgstr "Cât timp (în milisecunde) trebuie să fie stins LED-ul"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/timer.js:13
 msgid "How long (in milliseconds) the LED should be on"
-msgstr ""
+msgstr "Cât timp (în milisecunde) trebuie să rămână aprins LED-ul"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
 msgid "Human-readable counters"
-msgstr ""
+msgstr "Cât timp (în milisecunde) trebuie să rămână aprins LED-ul"
 
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:24
 msgid "Hybrid"
-msgstr ""
+msgstr "Hibrid"
 
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan.js:53
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:48
 msgid "ID used to uniquely identify the VXLAN"
-msgstr ""
+msgstr "ID utilizat pentru a identifica în mod unic VXLAN-ul"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:208
 msgid "IEEE 802.3ad Dynamic link aggregation (802.3ad, 4)"
-msgstr ""
+msgstr "IEEE 802.3ad Agregarea dinamică a legăturilor (802.3ad, 4)"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:75
 msgid "IKE DH Group"
-msgstr ""
+msgstr "Grupul IKE DH"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:135
 msgid "IP Addresses"
@@ -3225,15 +3245,15 @@ msgstr "Adrese IP"
 
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:81
 msgid "IP Protocol"
-msgstr ""
+msgstr "Protocolul IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:258
 msgid "IP Sets"
-msgstr ""
+msgstr "Seturi IP"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:126
 msgid "IP Type"
-msgstr ""
+msgstr "Tip IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:562
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:178
@@ -3244,7 +3264,7 @@ msgstr "Adresa IP"
 #: modules/luci-base/htdocs/luci-static/resources/network.js:10
 #: modules/luci-compat/luasrc/model/network.lua:28
 msgid "IP address is invalid"
-msgstr ""
+msgstr "Adresa IP este invalidă"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:13
 #: modules/luci-compat/luasrc/model/network.lua:31
@@ -3253,11 +3273,11 @@ msgstr "Adresa IP lipsește"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:588
 msgid "IP set"
-msgstr ""
+msgstr "Set IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:295
 msgid "IP sets"
-msgstr ""
+msgstr "Seturi IP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:431
 msgid "IPs to override with NXDOMAIN"
@@ -3284,7 +3304,7 @@ msgstr "Vecinii IPv4"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:251
 msgid "IPv4 Routing"
-msgstr ""
+msgstr "Rutarea IPv4"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:120
 msgid "IPv4 Rules"
@@ -3292,7 +3312,7 @@ msgstr "Reguli IPv4"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:29
 msgid "IPv4 Upstream"
-msgstr ""
+msgstr "Conexiune IPv4 externă"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:178
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:39
@@ -3304,7 +3324,7 @@ msgstr "Adresa IPv4"
 
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:29
 msgid "IPv4 assignment length"
-msgstr ""
+msgstr "Lungimea alocării IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:181
 msgid "IPv4 broadcast"
@@ -3321,7 +3341,7 @@ msgstr "Masca de rețea IPv4"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:305
 msgid "IPv4 network in address/netmask notation"
-msgstr ""
+msgstr "Rețea IPv4 în notație adresă/mască de rețea"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:128
 msgid "IPv4 only"
@@ -3343,11 +3363,11 @@ msgstr "IPv4+IPv6"
 #: modules/luci-compat/luasrc/model/network/proto_ipip.lua:9
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:10
 msgid "IPv4-in-IPv4 (RFC2003)"
-msgstr ""
+msgstr "IPv4-în-IPv4 (RFC2003)"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:127
 msgid "IPv4/IPv6 (both - defaults to IPv4)"
-msgstr ""
+msgstr "IPv4/IPv6 (ambele - valoarea implicită este IPv4)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js:91
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js:114
@@ -3371,7 +3391,7 @@ msgstr "Firewall IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:669
 msgid "IPv6 MTU"
-msgstr ""
+msgstr "IPv6 MTU"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:262
 msgid "IPv6 Neighbours"
@@ -3379,15 +3399,15 @@ msgstr "Vecini IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:635
 msgid "IPv6 RA Settings"
-msgstr ""
+msgstr "Setări IPv6 RA"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:261
 msgid "IPv6 Routing"
-msgstr ""
+msgstr "Rutarea IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:120
 msgid "IPv6 Rules"
-msgstr ""
+msgstr "Rutarea IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:634
 msgid "IPv6 Settings"
@@ -3395,11 +3415,11 @@ msgstr "Setări IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1463
 msgid "IPv6 ULA-Prefix"
-msgstr ""
+msgstr "IPv6 ULA-Prefixul"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:29
 msgid "IPv6 Upstream"
-msgstr ""
+msgstr "Conexiune IPv6 externă"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:183
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:58
@@ -3410,11 +3430,11 @@ msgstr "Adresa IPv6"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:978
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:27
 msgid "IPv6 assignment hint"
-msgstr ""
+msgstr "Indicație de atribuire IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:973
 msgid "IPv6 assignment length"
-msgstr ""
+msgstr "Lungimea alocării IPv6"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:188
 msgid "IPv6 gateway"
@@ -3422,7 +3442,7 @@ msgstr "Poartă de acces IPv6"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:310
 msgid "IPv6 network in address/netmask notation"
-msgstr ""
+msgstr "Rețeaua IPv6 în notație adresă/mască de rețea"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:129
 msgid "IPv6 only"
@@ -3430,7 +3450,7 @@ msgstr "Doar IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1022
 msgid "IPv6 preference"
-msgstr ""
+msgstr "Preferința IPv6"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:53
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:59
@@ -3439,7 +3459,7 @@ msgstr "Prefix IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:995
 msgid "IPv6 prefix filter"
-msgstr ""
+msgstr "Filtru de prefix IPv6"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:57
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:63
@@ -3449,23 +3469,23 @@ msgstr "Lungimea prefixului IPv6"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:192
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:57
 msgid "IPv6 routed prefix"
-msgstr ""
+msgstr "Prefix rutat IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:966
 msgid "IPv6 source routing"
-msgstr ""
+msgstr "Rutarea la sursă IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1018
 msgid "IPv6 suffix"
-msgstr ""
+msgstr "Sufixul IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:705
 msgid "IPv6 suffix (hex)"
-msgstr ""
+msgstr "Sufixul IPv6 (hexagonal)"
 
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:51
 msgid "IPv6 support"
-msgstr ""
+msgstr "Suport IPv6"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:101
 msgid "IPv6-PD"
@@ -3492,31 +3512,35 @@ msgstr "Identitate"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:203
 msgid "If available, the client's \"PresharedKey\""
-msgstr ""
+msgstr "Dacă este disponibil, \"PresharedKey\" al clientului"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:96
 msgid "If checked, 1DES is enabled"
-msgstr ""
+msgstr "Dacă este bifat, 1DES este activat"
 
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:51
 msgid "If checked, adds \"+ipv6\" to the pppd options"
-msgstr ""
+msgstr "Dacă este bifat, adaugă \"+ipv6\" la opțiunile pppd"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:93
 msgid "If checked, encryption is disabled"
-msgstr ""
+msgstr "Dacă este bifat, criptarea este dezactivată"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:995
 msgid ""
 "If set, downstream subnets are only allocated from the given IPv6 prefix "
 "classes."
 msgstr ""
+"Dacă este setat, subrețelele din aval sunt alocate numai din clasele de "
+"prefixe IPv6 date."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:254
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:360
 msgid ""
 "If specified, mount the device by its UUID instead of a fixed device node"
 msgstr ""
+"Dacă este specificat, montați dispozitivul după UUID-ul său în loc de un nod "
+"de dispozitiv fix"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:267
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:376
@@ -3524,18 +3548,22 @@ msgid ""
 "If specified, mount the device by the partition label instead of a fixed "
 "device node"
 msgstr ""
+"Dacă este specificat, montați dispozitivul după UUID-ul său în loc de un nod "
+"de dispozitiv fix"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:208
 msgid ""
 "If there are any unsaved changes for this client, please save the "
 "configuration before generating a QR-Code"
 msgstr ""
+"Dacă există modificări nesalvate pentru acest client, vă rugăm să salvați "
+"configurația înainte de a genera un cod QR"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:929
 #: protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js:64
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:122
 msgid "If unchecked, no default route is configured"
-msgstr ""
+msgstr "Dacă nu este bifat, nu este configurată nicio rută implicită"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:933
 #: protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js:68
@@ -3551,6 +3579,12 @@ msgid ""
 "slow process as the swap-device cannot be accessed with the high datarates "
 "of the <abbr title=\"Random Access Memory\">RAM</abbr>."
 msgstr ""
+"În cazul în care memoria fizică este insuficientă, datele neutilizate pot fi "
+"transferate temporar pe un dispozitiv de swap, ceea ce duce la o cantitate "
+"mai mare de <abbr title=\"Random Access Memory\">RAM</abbr> utilizabilă. "
+"Fiți atenți la faptul că schimbul de date este un proces foarte lent, "
+"deoarece dispozitivul swap nu poate fi accesat cu vitezele mari de date ale "
+"<abbr title=\"Random Access Memory\">RAM</abbr>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:363
 msgid "Ignore <code>/etc/hosts</code>"
@@ -3562,7 +3596,7 @@ msgstr "Ignorați interfața"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:352
 msgid "Ignore resolv file"
-msgstr ""
+msgstr "Ignoră fișierul resolv"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:447
 msgid "Image"
@@ -3574,17 +3608,20 @@ msgstr "Verificarea imaginii a eșuat:"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:68
 msgid "In"
-msgstr ""
+msgstr "În"
 
 #: modules/luci-base/luasrc/view/csrftoken.htm:13
 msgid ""
 "In order to prevent unauthorized access to the system, your request has been "
 "blocked. Click \"Continue »\" below to return to the previous page."
 msgstr ""
+"Pentru a preveni accesul neautorizat la sistem, cererea dumneavoastră a fost "
+"blocată. Faceți clic pe \"Continuare »\" de mai jos pentru a reveni la "
+"pagina anterioară."
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:136
 msgid "In seconds"
-msgstr ""
+msgstr "În secunde"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:156
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js:128
@@ -3593,7 +3630,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js:101
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:124
 msgid "Inactivity timeout"
-msgstr ""
+msgstr "Timpul de inactivitate"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/bandwidth.js:267
 msgid "Inbound:"
@@ -3612,25 +3649,25 @@ msgstr ""
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:102
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:107
 msgid "Incoming checksum"
-msgstr ""
+msgstr "Suma de control de intrare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:144
 msgid "Incoming interface"
-msgstr ""
+msgstr "Interfață de intrare"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:92
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:97
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
 msgid "Incoming key"
-msgstr ""
+msgstr "Cheia de intrare"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:102
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:107
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:104
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:109
 msgid "Incoming serialization"
-msgstr ""
+msgstr "Serializare de intrare"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:186
 msgid "Info"
@@ -3642,7 +3679,7 @@ msgstr "Informație"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:456
 msgid "Ingress QoS mapping"
-msgstr ""
+msgstr "Maparea QoS de intrare"
 
 #: modules/luci-compat/luasrc/model/network/proto_ncm.lua:67
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:25
@@ -3659,27 +3696,27 @@ msgstr "Script-uri de inițializare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1650
 msgid "Inner certificate constraint (Domain)"
-msgstr ""
+msgstr "Constrângerea certificatului interior (Domeniu)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1647
 msgid "Inner certificate constraint (SAN)"
-msgstr ""
+msgstr "Constrângerea certificatului interior (SAN)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1644
 msgid "Inner certificate constraint (Subject)"
-msgstr ""
+msgstr "Constrângerea certificatului intern (Subiect)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1653
 msgid "Inner certificate constraint (Wildcard)"
-msgstr ""
+msgstr "Constrângerea certificatului interior (Wildcard)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:300
 msgid "Install protocol extensions..."
-msgstr ""
+msgstr "Instalați extensiile de protocol..."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:541
 msgid "Instance"
-msgstr ""
+msgstr "Instanța"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2026
 msgid ""
@@ -3691,7 +3728,7 @@ msgstr ""
 
 #: modules/luci-compat/luasrc/view/cbi/map.htm:43
 msgid "Insufficient permissions to read UCI configuration."
-msgstr ""
+msgstr "Permisiuni insuficiente pentru a citi configurația UCI."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:41
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:180
@@ -3702,11 +3739,11 @@ msgstr "Interfață"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:718
 msgid "Interface \"%h\" is already marked as designated master."
-msgstr ""
+msgstr "Interfața \"%h\" este deja marcată ca maestru desemnat."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:62
 msgid "Interface %q device auto-migrated from %q to %q."
-msgstr ""
+msgstr "Dispozitivul interfeței %q a migrat automat de la %q la %q."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:981
 msgid "Interface Configuration"
@@ -3715,7 +3752,7 @@ msgstr "Configurarea interfeței"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:111
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:151
 msgid "Interface has %d pending changes"
-msgstr ""
+msgstr "Interfața are %d modificări în așteptare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:92
 msgid "Interface is disabled"
@@ -3768,7 +3805,7 @@ msgstr "Eroare internă de server"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:285
 msgid "Interval For Sending Learning Packets"
-msgstr ""
+msgstr "Interval pentru trimiterea pachetelor de învățare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:556
 msgid ""
@@ -3776,10 +3813,13 @@ msgid ""
 "value, an administrator may tune the number of IGMP messages on the subnet; "
 "larger values cause IGMP Queries to be sent less often"
 msgstr ""
+"Interval în cențiecunde între interogările generale multicast. Prin variația "
+"acestei valori, un administrator poate regla numărul de mesaje IGMP din "
+"subrețea; valorile mai mari determină trimiterea mai rar a interogărilor IGMP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:522
 msgid "Interval in seconds for STP hello packets"
-msgstr ""
+msgstr "Interval în secunde pentru pachetele de salut STP"
 
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:192
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:42
@@ -3791,48 +3831,50 @@ msgstr "Nu este valid"
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:93
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:74
 msgid "Invalid APN provided"
-msgstr ""
+msgstr "APN nevalabil furnizat"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:33
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:36
 msgid "Invalid Base64 key string"
-msgstr ""
+msgstr "Șir de chei Base64 nevalabil"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:78
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:83
 msgid "Invalid TOS value, expected 00..FF or inherit"
-msgstr ""
+msgstr "Valoare TOS invalidă, așteptată 00..FF sau moștenire"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:83
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:88
 msgid "Invalid Traffic Class value, expected 00..FF or inherit"
-msgstr ""
+msgstr "Valoare nevalidă a clasei de trafic, așteptată 00..FF sau moștenire"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:287
 msgid "Invalid VLAN ID given! Only IDs between %d and %d are allowed."
-msgstr ""
+msgstr "ID-ul VLAN invalid dat! Sunt permise numai ID-uri între %d și %d."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:296
 msgid "Invalid VLAN ID given! Only unique IDs are allowed"
-msgstr ""
+msgstr "ID-ul VLAN invalid dat! Sunt permise numai ID-uri unice"
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:403
 msgid "Invalid argument"
-msgstr ""
+msgstr "Argument nevalabil"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:46
 msgid ""
 "Invalid bearer list. Possibly too many bearers created. This protocol "
 "supports one and only one bearer."
 msgstr ""
+"Listă de purtători invalidă. Posibil prea mulți purtători creați. Acest "
+"protocol acceptă un singur purtător."
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:402
 msgid "Invalid command"
-msgstr ""
+msgstr "Comandă invalidă"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:153
 msgid "Invalid hexadecimal value"
-msgstr ""
+msgstr "Valoare hexazecimală invalidă"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:12
 #: themes/luci-theme-bootstrap/htdocs/luci-static/resources/view/bootstrap/sysauth.js:39
@@ -3843,7 +3885,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:191
 msgid "Invert match"
-msgstr ""
+msgstr "Inversarea meciului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1148
 msgid "Isolate Clients"
@@ -3877,7 +3919,7 @@ msgstr "Conectarea la rețea: %q"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:171
 msgid "Jump to rule"
-msgstr ""
+msgstr "Salt la regulă"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:228
 msgid "Keep settings and retain the current configuration"
@@ -3909,14 +3951,14 @@ msgstr "Cheie #%d"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:94
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:99
 msgid "Key for incoming packets (optional)."
-msgstr ""
+msgstr "Cheia pentru pachetele primite (opțional)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
 msgid "Key for outgoing packets (optional)."
-msgstr ""
+msgstr "Cheia pentru pachetele de ieșire (opțional)."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:54
 msgid "Kill"
@@ -3925,15 +3967,15 @@ msgstr "Opriți"
 #: modules/luci-compat/luasrc/model/network/proto_ppp.lua:21
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/l2tp.js:10
 msgid "L2TP"
-msgstr ""
+msgstr "L2TP"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/l2tp.js:40
 msgid "L2TP Server"
-msgstr ""
+msgstr "Server L2TP"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:269
 msgid "LACPDU Packets"
-msgstr ""
+msgstr "Pachete LACPDU"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:130
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js:102
@@ -3942,7 +3984,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js:75
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:98
 msgid "LCP echo failure threshold"
-msgstr ""
+msgstr "Pragul de eșec al ecoului LCP"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:143
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js:115
@@ -3951,7 +3993,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js:88
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:111
 msgid "LCP echo interval"
-msgstr ""
+msgstr "Intervalul de ecou LCP"
 
 #: modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json:115
 msgid "LED Configuration"
@@ -3959,7 +4001,7 @@ msgstr "Configurarea LED-urilor"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1558
 msgid "LLC"
-msgstr ""
+msgstr "LLC"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:267
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:376
@@ -3976,23 +4018,23 @@ msgstr "Limba și stilul interfeței"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:575
 msgid "Last member interval"
-msgstr ""
+msgstr "Intervalul ultimului membru"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:23
 msgid "Latency"
-msgstr ""
+msgstr "Latență"
 
 #: protocols/luci-proto-hnet/htdocs/luci-static/resources/protocol/hnet.js:21
 msgid "Leaf"
-msgstr ""
+msgstr "Frunză"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:707
 msgid "Learn"
-msgstr ""
+msgstr "Învățați"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Learn routes"
-msgstr ""
+msgstr "Învățați rutele"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:348
 msgid "Lease file"
@@ -4014,14 +4056,14 @@ msgstr "Timp de închiriere rămas"
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:47
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:50
 msgid "Leave empty to autodetect"
-msgstr ""
+msgstr "Lăsați gol pentru autodetecție"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:40
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:39
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6to4.js:39
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:45
 msgid "Leave empty to use the current WAN address"
-msgstr ""
+msgstr "Lăsați gol pentru a utiliza adresa WAN curentă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:944
 msgid ""
@@ -4044,40 +4086,42 @@ msgstr "Limită"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:24
 msgid "Line Attenuation (LATN)"
-msgstr ""
+msgstr "Atenuarea liniei (LATN)"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:18
 msgid "Line Mode"
-msgstr ""
+msgstr "Modul linie"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:17
 msgid "Line State"
-msgstr ""
+msgstr "Stare de linie"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:19
 msgid "Line Uptime"
-msgstr ""
+msgstr "Timp de funcționare a liniei"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:125
 msgid "Link Aggregation (Channel Bonding)"
-msgstr ""
+msgstr "Agregarea legăturilor (Channel Bonding)"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:349
 msgid "Link Monitoring"
-msgstr ""
+msgstr "Monitorizarea legăturii"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/netdev.js:24
 msgid "Link On"
-msgstr ""
+msgstr "conexiune stabilită"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:432
 msgid "List of IP addresses to convert into NXDOMAIN responses."
-msgstr ""
+msgstr "Lista de adrese IP care trebuie convertite în răspunsuri NXDOMAIN."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:296
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:580
 msgid "List of IP sets to populate with the specified domain IPs."
 msgstr ""
+"Listă de seturi IP care trebuie completate cu IP-urile de domeniu "
+"specificate."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1555
 msgid ""
@@ -4087,6 +4131,12 @@ msgid ""
 "from the R0KH that the STA used during the Initial Mobility Domain "
 "Association."
 msgstr ""
+"Lista de R0KH-uri din același domeniu de mobilitate. <br />Format: MAC-"
+"address, NAS-Identifier, cheie pe 128 de biți ca șir hexagonal. <br /"
+">Această listă este utilizată pentru a pune în corespondență R0KH-ID (NAS "
+"Identifier) cu o adresă MAC de destinație atunci când se solicită cheia PMK-"
+"R1 de la R0KH pe care STA a utilizat-o în timpul asocierii inițiale a "
+"domeniului de mobilitate."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1559
 msgid ""
@@ -4096,22 +4146,28 @@ msgid ""
 "R0KH. This is also the list of authorized R1KHs in the MD that can request "
 "PMK-R1 keys."
 msgstr ""
+"Lista de R1KH-uri din același domeniu de mobilitate. <br />Format: Adresa "
+"MAC, R1KH-ID sub formă de 6 octeți cu două puncte, cheie de 128 de biți sub "
+"formă de șir hexagonal. <br />Această listă este utilizată pentru a corela "
+"R1KH-ID cu o adresă MAC de destinație atunci când se trimite cheia PMK-R1 de "
+"la R0KH. Aceasta este, de asemenea, lista R1KH-urilor autorizate din MD care "
+"pot solicita chei PMK-R1."
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:82
 msgid "List of SSH key files for auth"
-msgstr ""
+msgstr "Lista de fișiere de chei SSH pentru autentificare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:312
 msgid "List of domains to allow RFC1918 responses for."
-msgstr ""
+msgstr "Lista domeniilor pentru care se permit răspunsurile RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
 msgid "List of domains to force to an IP address."
-msgstr ""
+msgstr "Lista domeniilor care trebuie forțate la o adresă IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283
 msgid "List of upstream resolvers to forward queries to."
-msgstr ""
+msgstr "Lista de rezolvatori din upstream către care se transmit interogările."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:130
 msgid "Listen Port"
@@ -4124,6 +4180,8 @@ msgstr "Interfețe de ascultare"
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:17
 msgid "Listen only on the given interface or, if unspecified, on all"
 msgstr ""
+"Ascultă numai pe interfața dată sau, dacă nu este specificat, pe toate "
+"interfețele"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:333
 msgid ""
@@ -4135,7 +4193,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:438
 msgid "Listening port for inbound DNS queries."
-msgstr ""
+msgstr "Port de ascultare pentru interogările DNS de intrare."
 
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:106
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:54
@@ -4148,11 +4206,11 @@ msgstr "Încărcare medie"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:238
 msgid "Loading QR-Code..."
-msgstr ""
+msgstr "Încărcare QR-Code..."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2973
 msgid "Loading directory contents…"
-msgstr ""
+msgstr "Încărcarea conținutului directorului…"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:1949
 #: modules/luci-base/luasrc/view/view.htm:4
@@ -4164,20 +4222,20 @@ msgstr "Se încarcă vizualizarea…"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:870
 msgid "Local"
-msgstr ""
+msgstr "Locală"
 
 #: protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js:77
 msgid "Local IP address"
-msgstr ""
+msgstr "Adresa IP locală"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:12
 #: modules/luci-compat/luasrc/model/network.lua:30
 msgid "Local IP address is invalid"
-msgstr ""
+msgstr "Adresa IP locală nu este validă"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:86
 msgid "Local IP address to assign"
-msgstr ""
+msgstr "Adresa IP locală de atribuit"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:46
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:46
@@ -4192,7 +4250,7 @@ msgstr "Adresa IPv4 locală"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:890
 msgid "Local IPv6 DNS server"
-msgstr ""
+msgstr "Server DNS IPv6 local"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:46
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:53
@@ -4213,7 +4271,7 @@ msgstr "Ora locală"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:996
 msgid "Local ULA"
-msgstr ""
+msgstr "ULA locală"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:273
 msgid "Local domain"
@@ -4222,6 +4280,8 @@ msgstr "Domeniu local"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:274
 msgid "Local domain suffix appended to DHCP names and hosts file entries."
 msgstr ""
+"Sufixul domeniului local adăugat la numele DHCP și la intrările din fișierul "
+"hosts."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:269
 msgid "Local server"
@@ -4233,15 +4293,15 @@ msgstr "Doar serviciu local"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:391
 msgid "Localise queries"
-msgstr ""
+msgstr "Localizați interogările"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2026
 msgid "Lock to BSSID"
-msgstr ""
+msgstr "Blocare la BSSID"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:184
 msgid "Log output level"
-msgstr ""
+msgstr "Nivelul de ieșire a jurnalului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:277
 msgid "Log queries"
@@ -4257,11 +4317,14 @@ msgid ""
 "Logical network from which to select the local endpoint if local IPv6 "
 "address is empty and no WAN IPv6 is available (optional)."
 msgstr ""
+"Rețea logică din care se selectează punctul final local în cazul în care "
+"adresa IPv6 locală este goală și nu este disponibil niciun IPv6 WAN "
+"(opțional)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:57
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:62
 msgid "Logical network to which the tunnel will be added (bridged) (optional)."
-msgstr ""
+msgstr "Rețeaua logică la care va fi adăugat tunelul (punte) (opțional)."
 
 #: modules/luci-base/luasrc/view/sysauth.htm:38
 #: themes/luci-theme-bootstrap/htdocs/luci-static/resources/view/bootstrap/sysauth.js:44
@@ -4274,11 +4337,11 @@ msgstr "Deconectare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:628
 msgid "Loose filtering"
-msgstr ""
+msgstr "Filtrare în vrac"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:31
 msgid "Loss of Signal Seconds (LOSS)"
-msgstr ""
+msgstr "Secunde de pierdere a semnalului (LOSS)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:669
 msgid "Lowest leased address as offset from the network address."
@@ -4299,7 +4362,7 @@ msgstr "Filtru de adrese MAC"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:253
 msgid "MAC Address For The Actor"
-msgstr ""
+msgstr "Adresa MAC pentru actor"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:347
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1403
@@ -4324,17 +4387,17 @@ msgstr "Filtru MAC"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1091
 msgid "MAC-List"
-msgstr ""
+msgstr "Listă-MAC"
 
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:16
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:13
 msgid "MAP / LW4over6"
-msgstr ""
+msgstr "MAP / LW4peste6"
 
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:62
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:7
 msgid "MAP rule is invalid"
-msgstr ""
+msgstr "Regula MAP nu este valabilă"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:223
 msgid "MD5"
@@ -4347,15 +4410,15 @@ msgstr "MHz"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:354
 msgid "MII"
-msgstr ""
+msgstr "MII"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:422
 msgid "MII / ETHTOOL ioctls"
-msgstr ""
+msgstr "MII / ETHTOOL ioctls"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:395
 msgid "MII Interval"
-msgstr ""
+msgstr "Intervalul MII"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:580
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1447
@@ -4370,6 +4433,8 @@ msgid ""
 "Make sure to clone the root filesystem using something like the commands "
 "below:"
 msgstr ""
+"Asigurați-vă că clonați sistemul de fișiere rădăcină folosind ceva de genul "
+"comenzilor de mai jos:"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:122
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:114
@@ -4379,7 +4444,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:58
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js:71
 msgid "Manual"
-msgstr ""
+msgstr "Manual"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3872
 msgid "Master"
@@ -4387,11 +4452,11 @@ msgstr "Principal"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:811
 msgid "Max <abbr title=\"Router Advertisement\">RA</abbr> interval"
-msgstr ""
+msgstr "Intervalul maxim <abbr title=\"Router Advertisement\">RA</abbr>"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:22
 msgid "Max. Attainable Data Rate (ATTNDR)"
-msgstr ""
+msgstr "Max. Rata de date realizabilă (ATTNDR)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:451
 msgid "Max. DHCP leases"
@@ -4407,7 +4472,7 @@ msgstr "Numărul maxim de interogări simultane"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:532
 msgid "Maximum age"
-msgstr ""
+msgstr "Vârsta maximă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1180
 msgid "Maximum allowed Listen Interval"
@@ -4423,13 +4488,13 @@ msgstr "Numărul maxim de interogări DNS simultane."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:459
 msgid "Maximum allowed size of EDNS0 UDP packets."
-msgstr ""
+msgstr "Dimensiunea maximă permisă a pachetelor UDP EDNS0."
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:126
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:118
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:106
 msgid "Maximum amount of seconds to wait for the modem to become ready"
-msgstr ""
+msgstr "Numărul maxim de secunde de așteptare pentru ca modemul să fie pregătit"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:674
 msgid "Maximum number of leased addresses."
@@ -4437,13 +4502,15 @@ msgstr "Numărul maxim de adrese închiriate."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:542
 msgid "Maximum snooping table size"
-msgstr ""
+msgstr "Dimensiunea maximă a tabelului de snooping"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:811
 msgid ""
 "Maximum time allowed between sending unsolicited <abbr title=\"Router "
 "Advertisement, ICMPv6 Type 134\">RA</abbr>. Default is 600 seconds."
 msgstr ""
+"Timpul maxim permis între trimiterea de <abbr title=\"Router Advertisement, "
+"ICMPv6 Type 134\">RA</abbr>. Valoarea implicită este de 600 de secunde."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:947
 msgid "Maximum transmit power"
@@ -4477,27 +4544,27 @@ msgstr "Memorie utilizată (%)"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3875
 msgid "Mesh"
-msgstr ""
+msgstr "Plasă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:156
 msgid "Mesh ID"
-msgstr ""
+msgstr "ID-ul plasei"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:995
 msgid "Mesh Id"
-msgstr ""
+msgstr "ID-ul plasei"
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:404
 msgid "Method not found"
-msgstr ""
+msgstr "Metoda nu a fost găsită"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:350
 msgid "Method of link monitoring"
-msgstr ""
+msgstr "Metoda de monitorizare a legăturii"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:419
 msgid "Method to determine link status"
-msgstr ""
+msgstr "Metoda de determinare a stării legăturii"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:79
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:189
@@ -4507,43 +4574,47 @@ msgstr "Metrică"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
 msgid "Min <abbr title=\"Router Advertisement\">RA</abbr> interval"
-msgstr ""
+msgstr "Minim <abbr title=\"Router Advertisement\">RA</abbr> interval"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:661
 msgid "Minimum ARP validity time"
-msgstr ""
+msgstr "Timpul minim de valabilitate ARP"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:237
 msgid "Minimum Number of Links"
-msgstr ""
+msgstr "Numărul minim de legături"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:661
 msgid ""
 "Minimum required time in seconds before an ARP entry may be replaced. "
 "Prevents ARP cache thrashing."
 msgstr ""
+"Timpul minim necesar în secunde înainte ca o intrare ARP să poată fi "
+"înlocuită. Împiedică distrugerea cache-ului ARP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:818
 msgid ""
 "Minimum time allowed between sending unsolicited <abbr title=\"Router "
 "Advertisement, ICMPv6 Type 134\">RA</abbr>. Default is 200 seconds."
 msgstr ""
+"Timpul minim permis între trimiterea de <abbr title=\"Router Advertisement, "
+"ICMPv6 Type 134\">RA</abbr>. Valoarea implicită este de 200 de secunde."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:204
 msgid "Mirror monitor port"
-msgstr ""
+msgstr "Portul monitorului oglindă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:203
 msgid "Mirror source port"
-msgstr ""
+msgstr "Port sursă oglindă"
 
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:9
 msgid "Mobile Data"
-msgstr ""
+msgstr "Date mobile"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1515
 msgid "Mobility Domain"
-msgstr ""
+msgstr "Domeniul de mobilitate"
 
 #: modules/luci-compat/luasrc/view/cbi/wireless_modefreq.htm:154
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:434
@@ -4563,7 +4634,7 @@ msgstr "Model"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:43
 msgid "Modem bearer teardown in progress."
-msgstr ""
+msgstr "Demontarea suportului modemului este în curs."
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:42
 msgid ""
@@ -4575,7 +4646,7 @@ msgstr ""
 
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:73
 msgid "Modem default"
-msgstr ""
+msgstr "Modem implicit"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:73
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:82
@@ -4583,7 +4654,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js:73
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:57
 msgid "Modem device"
-msgstr ""
+msgstr "Dispozitiv modem"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:41
 msgid "Modem disconnection in progress. Please wait."
@@ -4592,30 +4663,30 @@ msgstr "Deconectarea modemului este în curs. Vă rugăm așteptați."
 #: modules/luci-compat/luasrc/model/network/proto_ncm.lua:66
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:24
 msgid "Modem information query failed"
-msgstr ""
+msgstr "Interogarea informațiilor privind modemul a eșuat"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:126
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:118
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:106
 msgid "Modem init timeout"
-msgstr ""
+msgstr "Timp de așteptare pentru inițializarea modemului"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:44
 msgid "Modem is disabled."
-msgstr ""
+msgstr "Modemul este dezactivat."
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:52
 msgid "ModemManager"
-msgstr ""
+msgstr "ModemManager"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3876
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1078
 msgid "Monitor"
-msgstr ""
+msgstr "Monitor"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:31
 msgid "More Characters"
-msgstr ""
+msgstr "Mai multe caractere"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:2559
 msgid "More…"
@@ -4633,17 +4704,19 @@ msgstr "Puncte de montare"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:229
 msgid "Mount Points - Mount Entry"
-msgstr ""
+msgstr "Puncte de montare - Intrare montare"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:340
 msgid "Mount Points - Swap Entry"
-msgstr ""
+msgstr "Puncte de montare - Intrare schimb"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:228
 msgid ""
 "Mount Points define at which point a memory device will be attached to the "
 "filesystem"
 msgstr ""
+"Punctele de montare definesc punctul în care un dispozitiv de memorie va fi "
+"atașat la sistemul de fișiere"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:154
 msgid "Mount attached devices"
@@ -4651,58 +4724,58 @@ msgstr "Montați dispozitivele atașate"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:162
 msgid "Mount filesystems not specifically configured"
-msgstr ""
+msgstr "Montarea sistemelor de fișiere care nu sunt configurate în mod specific"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:331
 msgid "Mount options"
-msgstr ""
+msgstr "Opțiuni de montare"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:292
 msgid "Mount point"
-msgstr ""
+msgstr "Punct de montare"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:158
 msgid "Mount swap not specifically configured"
-msgstr ""
+msgstr "Montarea swap nu este configurată în mod specific"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:223
 msgid "Mounted file systems"
-msgstr ""
+msgstr "Sisteme de fișiere montate"
 
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:152
 msgid "Move down"
-msgstr ""
+msgstr "Mutarea în jos"
 
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:151
 msgid "Move up"
-msgstr ""
+msgstr "Mutarea în sus"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:89
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:94
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:91
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:96
 msgid "Multicast"
-msgstr ""
+msgstr "Multicast"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:705
 msgid "Multicast routing"
-msgstr ""
+msgstr "Rutarea multicast"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:711
 msgid "Multicast to unicast"
-msgstr ""
+msgstr "Multicast către unicast"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1510
 msgid "NAS ID"
-msgstr ""
+msgstr "NAS ID"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:87
 msgid "NAT-T Mode"
-msgstr ""
+msgstr "NAT-T Mod"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/464xlat.js:41
 msgid "NAT64 Prefix"
-msgstr ""
+msgstr "Prefixul NAT64"
 
 #: modules/luci-compat/luasrc/model/network/proto_ncm.lua:26
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:31
@@ -4711,15 +4784,15 @@ msgstr "NCM"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:921
 msgid "NDP-Proxy slave"
-msgstr ""
+msgstr "Sclav NDP-Proxy"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:72
 msgid "NT Domain"
-msgstr ""
+msgstr "Domeniul NT"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:289
 msgid "NTP server candidates"
-msgstr ""
+msgstr "Serverele NTP candidate"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:2597
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:3822
@@ -4740,7 +4813,7 @@ msgstr "Navigare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:653
 msgid "Neighbour cache validity"
-msgstr ""
+msgstr "Valabilitatea cache-ului de vecinătate"
 
 #: modules/luci-base/root/usr/share/luci/menu.d/luci-base.json:45
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1023
@@ -4763,11 +4836,11 @@ msgstr "Utilitare de rețea"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:491
 msgid "Network boot image"
-msgstr ""
+msgstr "Imagine de pornire în rețea"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:392
 msgid "Network bridge configuration migration"
-msgstr ""
+msgstr "Migrarea configurației punților de rețea"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:343
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1409
@@ -4785,7 +4858,7 @@ msgstr "Dispozitivul de rețea nu este prezent"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:426
 msgid "Network ifname configuration migration"
-msgstr ""
+msgstr "Migrarea configurației rețelei ifname"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:57
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:62
@@ -4805,10 +4878,12 @@ msgid ""
 "Never forward matching domains and subdomains, resolve from DHCP or hosts "
 "files only."
 msgstr ""
+"Nu redirecționați niciodată domeniile și subdomeniile care corespund, "
+"rezolvați numai din DHCP sau din fișierele hosts."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1149
 msgid "New interface for \"%s\" can not be created: %s"
-msgstr ""
+msgstr "Nu se poate crea o nouă interfață pentru \"%s\": %s"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1100
 msgid "New interface name…"
@@ -4838,15 +4913,15 @@ msgstr "Fără criptare"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:139
 msgid "No Host Routes"
-msgstr ""
+msgstr "Fără rute gazdă"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:89
 msgid "No NAT-T"
-msgstr ""
+msgstr "Fără NAT-T"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:79
 msgid "No RX signal"
-msgstr ""
+msgstr "Fără semnal RX"
 
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:87
 #: themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm:70
@@ -4861,7 +4936,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:69
 msgid "No client associated"
-msgstr ""
+msgstr "Niciun client asociat"
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:406
 msgid "No data received"
@@ -4870,7 +4945,7 @@ msgstr "Nu s-au primit date"
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:683
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:690
 msgid "No enforcement"
-msgstr ""
+msgstr "Nu se aplică"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:229
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:232
@@ -4879,11 +4954,11 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:241
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:244
 msgid "No entries available"
-msgstr ""
+msgstr "Fără intrări disponibile"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2913
 msgid "No entries in this directory"
-msgstr ""
+msgstr "Fără intrări în acest director"
 
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:82
 msgid "No files found"
@@ -4894,7 +4969,7 @@ msgstr "Nu s-au găsit fișiere"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:88
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:93
 msgid "No host route"
-msgstr ""
+msgstr "Fără rută gazdă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:732
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:142
@@ -4906,20 +4981,20 @@ msgstr "Nu există informații disponibile"
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:63
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:8
 msgid "No matching prefix delegation"
-msgstr ""
+msgstr "Fără delegație de prefix corespunzătoare"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:142
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:145
 msgid "No more slaves available"
-msgstr ""
+msgstr "Nu mai sunt sclavi disponibili"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:189
 msgid "No more slaves available, can not save interface"
-msgstr ""
+msgstr "Nu mai sunt sclavi disponibili, nu se poate salva interfața"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:412
 msgid "No negative cache"
-msgstr ""
+msgstr "Fără memorie cache negativă"
 
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:69
 #: themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm:59
@@ -4929,25 +5004,25 @@ msgstr "Nu este setată nicio parolă!"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:177
 msgid "No peers defined yet"
-msgstr ""
+msgstr "Nu sunt definiți încă colegi"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:140
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:277
 msgid "No public keys present yet."
-msgstr ""
+msgstr "Fără chei publice prezente încă."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:91
 msgid "No rules in this chain."
-msgstr ""
+msgstr "Nu există reguli în acest lanț."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:385
 msgid "No validation or filtering"
-msgstr ""
+msgstr "Nu există validare sau filtrare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:153
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1191
 msgid "No zone assigned"
-msgstr ""
+msgstr "Nici o zonă atribuită"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:58
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:84
@@ -4959,7 +5034,7 @@ msgstr "Zgomot"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:26
 msgid "Noise Margin (SNR)"
-msgstr ""
+msgstr "Marja de zgomot (SNR)"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js:272
 msgid "Noise:"
@@ -4967,11 +5042,11 @@ msgstr "Zgomot:"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:34
 msgid "Non Pre-emptive CRC errors (CRC_P)"
-msgstr ""
+msgstr "Erori CRC non-preemptive (CRC_P)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:325
 msgid "Non-wildcard"
-msgstr ""
+msgstr "Fără-wildcard"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:159
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:183
@@ -5006,11 +5081,11 @@ msgstr "Nu este prezent"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:102
 msgid "Not started on boot"
-msgstr ""
+msgstr "Nu a început la pornire"
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:409
 msgid "Not supported"
-msgstr ""
+msgstr "Neacceptat"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1679
 msgid ""
@@ -5030,27 +5105,29 @@ msgstr "Aviz"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js:138
 msgid "Nslookup"
-msgstr ""
+msgstr "Nslookup"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:333
 msgid "Number of IGMP membership reports"
-msgstr ""
+msgstr "Numărul de rapoarte de apartenență IGMP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:473
 msgid "Number of cached DNS entries, 10000 is maximum, 0 is no caching."
 msgstr ""
+"Numărul de intrări DNS stocate în memoria cache, 10000 este maxim, 0 "
+"înseamnă că nu există memorie cache."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:311
 msgid "Number of peer notifications after failover event"
-msgstr ""
+msgstr "Numărul de notificări de la partener după un eveniment de failover"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:69
 msgid "Obfuscated Group Password"
-msgstr ""
+msgstr "Parolă de grup obscurizată"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:61
 msgid "Obfuscated Password"
-msgstr ""
+msgstr "Parolă obscurizată"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:118
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:110
@@ -5061,7 +5138,7 @@ msgstr ""
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js:67
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:93
 msgid "Obtain IPv6 address"
-msgstr ""
+msgstr "Obținerea adresei IPv6"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/none.js:19
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:352
@@ -5070,7 +5147,7 @@ msgstr "Oprit"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/timer.js:18
 msgid "Off-State Delay"
-msgstr ""
+msgstr "Întârziere off-state"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/none.js:19
 msgid "On"
@@ -5078,11 +5155,11 @@ msgstr "Pornit"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/timer.js:12
 msgid "On-State Delay"
-msgstr ""
+msgstr "Întârziere în stare activă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:109
 msgid "On-link"
-msgstr ""
+msgstr "Pornit de pe link"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:671
 msgid "One of hostname or MAC address must be specified!"
@@ -5099,7 +5176,7 @@ msgstr "Unul sau mai multe câmpuri conțin valori invalide!"
 
 #: modules/luci-compat/luasrc/view/cbi/map.htm:32
 msgid "One or more invalid/required values on tab"
-msgstr ""
+msgstr "Una sau mai multe valori invalide/necesare pe filă"
 
 #: modules/luci-compat/luasrc/view/cbi/nullsection.htm:19
 #: modules/luci-compat/luasrc/view/cbi/ucisection.htm:24
@@ -5109,11 +5186,15 @@ msgstr "Unul sau mai multe câmpuri obligatorii nu au nicio valoare!"
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:702
 msgid "Only allow communication with non-isolated bridge ports when enabled"
 msgstr ""
+"Permite comunicarea cu porturile de punte neizolate numai atunci când este "
+"activată"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:231
 msgid ""
 "Only if current active slave fails and the primary slave is up (failure, 2)"
 msgstr ""
+"Numai în cazul în care sclavul activ curent eșuează și sclavul primar este "
+"activ (eșec, 2)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:472
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:19
@@ -5123,11 +5204,11 @@ msgstr "Deschideți lista..."
 #: modules/luci-compat/luasrc/model/network/proto_openconnect.lua:9
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:64
 msgid "OpenConnect (CISCO AnyConnect)"
-msgstr ""
+msgstr "OpenConnect (CISCO AnyConnect)"
 
 #: protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js:12
 msgid "OpenFortivpn"
-msgstr ""
+msgstr "OpenFortivpn"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:724
 msgid ""
@@ -5135,18 +5216,25 @@ msgid ""
 "configured and active, otherwise disable <abbr title=\"Neighbour Discovery "
 "Protocol\">NDP</abbr> proxying."
 msgstr ""
+"Funcționează în <em>modul releu</em> dacă o interfață master desemnată este "
+"configurată și activă, în caz contrar dezactivează proxierea <abbr title="
+"\"Neighbour Discovery Protocol\">NDP</abbr>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:723
 msgid ""
 "Operate in <em>relay mode</em> if a designated master interface is "
 "configured and active, otherwise fall back to <em>server mode</em>."
 msgstr ""
+"Funcționează în <em>modul releu</em> dacă o interfață master desemnată este "
+"configurată și activă, în caz contrar revine la <em>modul server</em>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:725
 msgid ""
 "Operate in <em>relay mode</em> if an upstream IPv6 prefix is present, "
 "otherwise disable service."
 msgstr ""
+"Funcționează în modul <em>relay</em> dacă este prezent un prefix IPv6 în "
+"amonte, altfel dezactivează serviciul."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:940
 msgid "Operating frequency"
@@ -5155,11 +5243,11 @@ msgstr "Frecvență de operare"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:1990
 #: modules/luci-base/htdocs/luci-static/resources/form.js:3898
 msgid "Option \"%s\" contains an invalid input value."
-msgstr ""
+msgstr "Opțiunea \"%s\" conține o valoare de intrare invalidă."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:2003
 msgid "Option \"%s\" must not be empty."
-msgstr ""
+msgstr "Opțiunea \"%s\" nu trebuie să fie goală."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4074
 msgid "Option changed"
@@ -5182,6 +5270,8 @@ msgid ""
 "Optional. 32-bit mark for outgoing encrypted packets. Enter value in hex, "
 "starting with <code>0x</code>."
 msgstr ""
+"Opțional. Marca de 32 de biți pentru pachetele criptate de ieșire. "
+"Introduceți valoarea în hexazecimal, începând cu <code>0x</code>."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1018
 msgid ""
@@ -5190,30 +5280,39 @@ msgid ""
 "server, use the suffix (like '::1') to form the IPv6 address ('a:b:c:d::1') "
 "for the interface."
 msgstr ""
+"Opțional. Valori permise: \"eui64\", \"random\", valoare fixă, cum ar fi \"::"
+"1\" sau \"::1:2\". Atunci când prefixul IPv6 (cum ar fi \"a:b:c:d::\") este "
+"primit de la un server delegant, se utilizează sufixul (cum ar fi \"::1\") "
+"pentru a forma adresa IPv6 (\"a:b:c:d::1\") pentru interfață."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:265
 msgid ""
 "Optional. Base64-encoded preshared key. Adds in an additional layer of "
 "symmetric-key cryptography for post-quantum resistance."
 msgstr ""
+"Opțional. Cheia preîmpărțită codificată în baza 64. Adaugă un strat "
+"suplimentar de criptografie cu cheie simetrică pentru rezistență post-"
+"cuantice."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:274
 msgid "Optional. Create routes for Allowed IPs for this peer."
-msgstr ""
+msgstr "Opțional. Creează rute pentru IP-uri permise pentru acest peer."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:184
 msgid "Optional. Description of peer."
-msgstr ""
+msgstr "Opțional. Descriere a partenerului."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:139
 msgid "Optional. Do not create host routes to peers."
-msgstr ""
+msgstr "Opțional. Nu creați rute gazdă către parteneri."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:276
 msgid ""
 "Optional. Host of peer. Names are resolved prior to bringing up the "
 "interface."
 msgstr ""
+"Opțional. Gazda omologului. Numele sunt rezolvate înainte de a aduce "
+"interfața."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:270
 msgid ""
@@ -5221,24 +5320,30 @@ msgid ""
 "the tunnel. Usually the peer's tunnel IP addresses and the networks the peer "
 "routes through the tunnel."
 msgstr ""
+"Opțional. Adresele IP și prefixele pe care acest peer are voie să le "
+"utilizeze în interiorul tunelului. De obicei, adresele IP de tunel ale "
+"omologului și rețelele pe care omologul le direcționează prin tunel."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:144
 msgid "Optional. Maximum Transmission Unit of tunnel interface."
-msgstr ""
+msgstr "Opțional. Unitatea maximă de transmisie a interfeței de tunel."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:280
 msgid "Optional. Port of peer."
-msgstr ""
+msgstr "Opțional. Portul partenerului."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:284
 msgid ""
 "Optional. Seconds between keep alive messages. Default is 0 (disabled). "
 "Recommended value if this device is behind a NAT is 25."
 msgstr ""
+"Opțional. Secunde între mesajele de menținere în viață. Valoarea implicită "
+"este 0 (dezactivat). Valoarea recomandată dacă acest dispozitiv se află în "
+"spatele unui NAT este 25."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:130
 msgid "Optional. UDP port used for outgoing and incoming packets."
-msgstr ""
+msgstr "Opțional. Port UDP utilizat pentru pachetele de ieșire și de intrare."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:72
 msgid "Options"
@@ -5251,10 +5356,14 @@ msgid ""
 "\" for default route. <code>0.0.0.0</code> means \"the address of the system "
 "running dnsmasq\"."
 msgstr ""
+"Opțiuni pentru Network-ID. (Notă: are nevoie și de Network-ID.) De exemplu, "
+"\"<code>42,192.168.1.4</code>\" pentru serverul NTP, \"<code>3,192.168.4."
+"4</code>\" pentru ruta implicită. <code>0.0.0.0.0</code> înseamnă \"adresa "
+"sistemului care rulează dnsmasq\"."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:119
 msgid "Options:"
-msgstr ""
+msgstr "Opțiuni:"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:348
 msgid "Other:"
@@ -5273,46 +5382,46 @@ msgstr "Ieşire:"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:103
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:108
 msgid "Outgoing checksum"
-msgstr ""
+msgstr "Suma de control ieșită"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:155
 msgid "Outgoing interface"
-msgstr ""
+msgstr "Interfață de ieșire"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:96
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:101
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:98
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:103
 msgid "Outgoing key"
-msgstr ""
+msgstr "Cheie de ieșire"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:103
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:108
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:105
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:110
 msgid "Outgoing serialization"
-msgstr ""
+msgstr "Serializare de ieșire"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:50
 msgid "Output Interface"
-msgstr ""
+msgstr "Interfața de ieșire"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:59
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:165
 msgid "Output zone"
-msgstr ""
+msgstr "Zona de ieșire"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:16
 msgid "Overlap"
-msgstr ""
+msgstr "Suprapunere"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:955
 msgid "Override IPv4 routing table"
-msgstr ""
+msgstr "Suprascrie tabelul de rutare IPv4"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:960
 msgid "Override IPv6 routing table"
-msgstr ""
+msgstr "Suprascrie tabelul de rutare IPv6"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:64
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:69
@@ -5329,7 +5438,7 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:110
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:62
 msgid "Override MTU"
-msgstr ""
+msgstr "Suprascrieți MTU"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:74
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:79
@@ -5337,7 +5446,7 @@ msgstr ""
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan.js:67
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:62
 msgid "Override TOS"
-msgstr ""
+msgstr "Anulare TOS"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:69
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:74
@@ -5347,11 +5456,11 @@ msgstr ""
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan.js:62
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:57
 msgid "Override TTL"
-msgstr ""
+msgstr "Anulare TTL"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1152
 msgid "Override default interface name"
-msgstr ""
+msgstr "Suprascrieți numele implicit al interfeței"
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:167
 msgid "Override the gateway in DHCP responses"
@@ -5362,10 +5471,12 @@ msgid ""
 "Override the netmask sent to clients. Normally it is calculated from the "
 "subnet that is served."
 msgstr ""
+"Suprascrieți masca de rețea trimisă clienților. În mod normal, aceasta este "
+"calculată din subrețeaua care este servită."
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:179
 msgid "Override the table used for internal routes"
-msgstr ""
+msgstr "Suprascrieți tabelul utilizat pentru rutele interne"
 
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:3
 msgid "Overview"
@@ -5373,7 +5484,7 @@ msgstr "Prezentare generală"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2756
 msgid "Overwrite existing file \"%s\" ?"
-msgstr ""
+msgstr "Suprascrieți fișierul existent \"%s\" ?"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:70
 msgid "Owner"
@@ -5381,7 +5492,7 @@ msgstr "Proprietar"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:109
 msgid "PAP/CHAP (both)"
-msgstr ""
+msgstr "PAP/CHAP (ambele)"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:111
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:120
@@ -5394,7 +5505,7 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:94
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:46
 msgid "PAP/CHAP password"
-msgstr ""
+msgstr "Parola PAP/CHAP"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:109
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:115
@@ -5407,11 +5518,11 @@ msgstr ""
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:89
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:44
 msgid "PAP/CHAP username"
-msgstr ""
+msgstr "Nume de utilizator PAP/CHAP"
 
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:114
 msgid "PDP Type"
-msgstr ""
+msgstr "Tip PDP"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:69
 msgid "PID"
@@ -5422,16 +5533,16 @@ msgstr "PID"
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:98
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:79
 msgid "PIN"
-msgstr ""
+msgstr "PIN"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:21
 #: modules/luci-compat/luasrc/model/network.lua:39
 msgid "PIN code rejected"
-msgstr ""
+msgstr "Cod PIN respins"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1550
 msgid "PMK R1 Push"
-msgstr ""
+msgstr "PMK R1 Împingeți"
 
 #: modules/luci-compat/luasrc/model/network/proto_ppp.lua:13
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js:43
@@ -5460,27 +5571,27 @@ msgstr "PPP prin SSH"
 #: modules/luci-compat/luasrc/model/network/proto_ppp.lua:15
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js:28
 msgid "PPtP"
-msgstr ""
+msgstr "PPtP"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:73
 msgid "PSID offset"
-msgstr ""
+msgstr "Decalaj PSID"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:70
 msgid "PSID-bits length"
-msgstr ""
+msgstr "PSID-bits lungime"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1502
 msgid "PTM/EFM (Packet Transfer Mode)"
-msgstr ""
+msgstr "PTM/EFM (Modul de transfer al pachetelor)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:254
 msgid "PXE/TFTP Settings"
-msgstr ""
+msgstr "Setări PXE/TFTP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1466
 msgid "Packet Steering"
-msgstr ""
+msgstr "Direcționarea pachetelor"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 msgid "Packets"
@@ -5488,17 +5599,17 @@ msgstr "Pachete"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:277
 msgid "Packets To Transmit Before Moving To Next Slave"
-msgstr ""
+msgstr "Pachete de transmis înainte de a trece la următorul sclav"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:153
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1191
 msgid "Part of zone %q"
-msgstr ""
+msgstr "Parte din zonă %q"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:438
 msgctxt "MACVLAN mode"
 msgid "Pass-through (Mirror physical device to single MAC VLAN)"
-msgstr ""
+msgstr "Pass-through (dispozitiv fizic în oglindă pentru un singur MAC VLAN)"
 
 #: modules/luci-base/luasrc/view/sysauth.htm:29
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1672
@@ -5520,22 +5631,22 @@ msgstr "Parola cheii private"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1662
 msgid "Password of inner Private Key"
-msgstr ""
+msgstr "Parola cheii private interioare"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:31
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:33
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:35
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:37
 msgid "Password strength"
-msgstr ""
+msgstr "Puterea parolei"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:117
 msgid "Password2"
-msgstr ""
+msgstr "Parola2"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:260
 msgid "Paste or drag SSH key file…"
-msgstr ""
+msgstr "Lipiți sau trageți fișierul cu cheia SSH…"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1583
 msgid "Path to CA-Certificate"
@@ -5551,15 +5662,15 @@ msgstr "Calea către cheia privată"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1641
 msgid "Path to inner CA-Certificate"
-msgstr ""
+msgstr "Cale de acces la certificatul CA intern"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1656
 msgid "Path to inner Client-Certificate"
-msgstr ""
+msgstr "Calea de acces la certificatul intern"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1659
 msgid "Path to inner Private Key"
-msgstr ""
+msgstr "Cale către cheia privată interioară"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2732
 msgid "Paused"
@@ -5581,24 +5692,24 @@ msgstr "Maxim:"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:89
 msgid "Peer IP address to assign"
-msgstr ""
+msgstr "Adresa IP a omologului care urmează să fie atribuită"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:613
 msgid "Peer MAC address"
-msgstr ""
+msgstr "Adresa MAC a colegului"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:14
 #: modules/luci-compat/luasrc/model/network.lua:32
 msgid "Peer address is missing"
-msgstr ""
+msgstr "Adresa MAC a partenerului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:594
 msgid "Peer device name"
-msgstr ""
+msgstr "Numele dispozitivului partener"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:181
 msgid "Peer disabled"
-msgstr ""
+msgstr "Partener dezactivat"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:162
 msgid "Peers"
@@ -5606,14 +5717,14 @@ msgstr "Perechi"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:80
 msgid "Perfect Forward Secrecy"
-msgstr ""
+msgstr "Secretul avansat perfect"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:103
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:108
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:105
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:110
 msgid "Perform outgoing packets serialization (optional)."
-msgstr ""
+msgstr "Efectuați serializarea pachetelor de ieșire (opțional)."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/reboot.js:34
 msgid "Perform reboot"
@@ -5625,11 +5736,11 @@ msgstr "Efectuați resetarea"
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:407
 msgid "Permission denied"
-msgstr ""
+msgstr "Permisiune refuzată"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:284
 msgid "Persistent Keep Alive"
-msgstr ""
+msgstr "Persistentă Keep Alive"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js:290
 msgid "Phy Rate:"
@@ -5643,7 +5754,7 @@ msgstr "Setări fizice"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js:91
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js:101
 msgid "Ping"
-msgstr ""
+msgstr "Ping"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:49
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:50
@@ -5672,7 +5783,7 @@ msgstr "Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:702
 msgid "Port isolation"
-msgstr ""
+msgstr "Izolarea portului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:280
 msgid "Port status:"
@@ -5680,31 +5791,31 @@ msgstr "Starea portului:"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:507
 msgid "Potential negation of: %s"
-msgstr ""
+msgstr "Negație potențială a: %s"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:37
 msgid "Power Management Mode"
-msgstr ""
+msgstr "Modul de gestionare a energiei"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:35
 msgid "Pre-emptive CRC errors (CRCP_P)"
-msgstr ""
+msgstr "Erori CRC preemptive (CRCP_P)"
 
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:74
 msgid "Prefer LTE"
-msgstr ""
+msgstr "Preferați LTE"
 
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:75
 msgid "Prefer UMTS"
-msgstr ""
+msgstr "Preferați UMTS"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:33
 msgid "Prefix Delegated"
-msgstr ""
+msgstr "Prefix Delegat"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:186
 msgid "Prefix suppressor"
-msgstr ""
+msgstr "Prefix supresor"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:265
 msgid "Preshared Key"
@@ -5720,6 +5831,8 @@ msgid ""
 "Presume peer to be dead after given amount of LCP echo failures, use 0 to "
 "ignore failures"
 msgstr ""
+"Presupune că omologul este mort după un anumit număr de eșecuri de ecou LCP, "
+"utilizați 0 pentru a ignora eșecurile"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1148
 msgid "Prevents client-to-client communication"
@@ -5727,22 +5840,26 @@ msgstr "Împiedică comunicarea între clienți"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:213
 msgid "Primary Slave"
-msgstr ""
+msgstr "Sclav primar"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:170
 msgctxt "VLAN port state"
 msgid "Primary VLAN ID"
-msgstr ""
+msgstr "ID VLAN primar"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:230
 msgid ""
 "Primary becomes active slave when it comes back up if speed and duplex "
 "better than current slave (better, 1)"
 msgstr ""
+"Primarul devine sclav activ atunci când revine dacă viteza și duplexul sunt "
+"mai bune decât cele ale sclavului curent (mai bune, 1)"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:229
 msgid "Primary becomes active slave whenever it comes back up (always, 0)"
 msgstr ""
+"Primarul devine sclav activ ori de câte ori revine în funcțiune ("
+"întotdeauna, 0)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:508
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:129
@@ -5767,7 +5884,7 @@ msgstr "Procese"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:67
 msgid "Prot."
-msgstr ""
+msgstr "Prot."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:80
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:554
@@ -5788,6 +5905,8 @@ msgid ""
 "Provide a DHCPv6 server on this interface and reply to DHCPv6 solicitations "
 "and requests."
 msgstr ""
+"Furnizați un server DHCPv6 pe această interfață și răspundeți la "
+"solicitările și cererile DHCPv6."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:883
 msgid "Provide new network"
@@ -5795,7 +5914,7 @@ msgstr "Furnizați o nouă rețea"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1077
 msgid "Pseudo Ad-Hoc (ahdemo)"
-msgstr ""
+msgstr "Pseudo Ad-Hoc (ahdemo)"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:102
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:261
@@ -5809,15 +5928,21 @@ msgid ""
 "device, paste an OpenSSH compatible public key line or drag a <code>.pub</"
 "code> file into the input field."
 msgstr ""
+"Cheile publice permit autentificarea SSH fără parolă, cu o securitate mai "
+"mare în comparație cu utilizarea parolelor simple. Pentru a încărca o nouă "
+"cheie pe dispozitiv, inserați o linie de cheie publică compatibilă cu "
+"OpenSSH sau trageți un fișier <code>.pub</code> în câmpul de introducere."
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:192
 msgid "Public prefix routed to this device for distribution to clients."
 msgstr ""
+"Prefixul public direcționat către acest dispozitiv în vederea distribuirii "
+"către clienți."
 
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:9
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:27
 msgid "QMI Cellular"
-msgstr ""
+msgstr "QMI Celular"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:189
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:219
@@ -5830,7 +5955,7 @@ msgstr "Calitate"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:427
 msgid "Query all available upstream resolvers."
-msgstr ""
+msgstr "Interoghează toți rezolvatorii din amonte disponibili."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:556
 msgid "Query interval"
@@ -5838,23 +5963,23 @@ msgstr "Interval de interogare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:561
 msgid "Query response interval"
-msgstr ""
+msgstr "Intervalul de răspuns la interogare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1538
 msgid "R0 Key Lifetime"
-msgstr ""
+msgstr "R0 Durata de viață a cheii"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1544
 msgid "R1 Key Holder"
-msgstr ""
+msgstr "R1 Titularul cheii"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:88
 msgid "RFC3947 NAT-T mode"
-msgstr ""
+msgstr "Modul RFC3947 NAT-T"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1003
 msgid "RSSI threshold for joining"
-msgstr ""
+msgstr "Pragul RSSI pentru aderare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:967
 msgid "RTS/CTS Threshold"
@@ -5875,31 +6000,33 @@ msgstr "Rată de recepție / Rată de transmisie"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1416
 msgid "Radius-Accounting-Port"
-msgstr ""
+msgstr "Radius-Contabilitate-Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1421
 msgid "Radius-Accounting-Secret"
-msgstr ""
+msgstr "Radius-Contabilitate-Secret"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1411
 msgid "Radius-Accounting-Server"
-msgstr ""
+msgstr "Radius-Contabilitate-Server"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1401
 msgid "Radius-Authentication-Port"
-msgstr ""
+msgstr "Radius-Autentificare-Port"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1406
 msgid "Radius-Authentication-Secret"
-msgstr ""
+msgstr "Radius-Autentificare-Secret"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1396
 msgid "Radius-Authentication-Server"
-msgstr ""
+msgstr "Radius-Autentificare-Server"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:88
 msgid "Raw hex-encoded bytes. Leave empty unless your ISP require this"
 msgstr ""
+"Octeți brute codificați în format hexazecimal. Lăsați gol, cu excepția "
+"cazului în care ISP-ul dumneavoastră solicită acest lucru"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:345
 msgid "Read <code>/etc/ethers</code> to configure the DHCP server."
@@ -5939,11 +6066,11 @@ msgstr "Repornește sistemul de operare al dispozitivului dumneavoastră"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/netdev.js:26
 msgid "Receive"
-msgstr ""
+msgstr "Primiți"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:135
 msgid "Recommended. IP addresses of the WireGuard interface."
-msgstr ""
+msgstr "Recomandat. Adresele IP ale interfeței WireGuard."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:504
 msgid "Reconnect this interface"
@@ -5969,7 +6096,7 @@ msgstr "Releu"
 #: modules/luci-compat/luasrc/model/network/proto_relay.lua:157
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:36
 msgid "Relay Bridge"
-msgstr ""
+msgstr "Releu punte"
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:154
 msgid "Relay between networks"
@@ -5978,7 +6105,7 @@ msgstr "Releu între rețele"
 #: modules/luci-compat/luasrc/model/network/proto_relay.lua:12
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:64
 msgid "Relay bridge"
-msgstr ""
+msgstr "Releu punte"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:50
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:49
@@ -5990,16 +6117,16 @@ msgstr "Adresa IPv4 de la distanță"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:42
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:40
 msgid "Remote IPv4 address or FQDN"
-msgstr ""
+msgstr "Adresa IPv4 la distanță sau FQDN"
 
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:40
 msgid "Remote IPv6 address"
-msgstr ""
+msgstr "Adresa IPv6 la distanță"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:42
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:42
 msgid "Remote IPv6 address or FQDN"
-msgstr ""
+msgstr "Adresa IPv6 la distanță sau FQDN"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:907
 msgid "Remove"
@@ -6007,7 +6134,7 @@ msgstr "Eliminați"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1292
 msgid "Remove related device settings from the configuration"
-msgstr ""
+msgstr "Îndepărtarea din configurație a setărilor dispozitivelor aferente"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2002
 msgid "Replace wireless configuration"
@@ -6015,29 +6142,29 @@ msgstr "Înlocuiți configurația wireless"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:17
 msgid "Request IPv6-address"
-msgstr ""
+msgstr "Solicitarea adresei IPv6"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:23
 msgid "Request IPv6-prefix of length"
-msgstr ""
+msgstr "Solicită un prefix IPv6 de lungime"
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:408
 msgid "Request timeout"
-msgstr ""
+msgstr "Timpul de așteptare a cererii"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:100
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:105
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:102
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:107
 msgid "Require incoming checksum (optional)."
-msgstr ""
+msgstr "Solicită suma de control de intrare (opțional)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:102
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:107
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:104
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:109
 msgid "Require incoming packets serialization (optional)."
-msgstr ""
+msgstr "Solicită serializarea pachetelor primite (opțional)."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1682
 msgid "Required"
@@ -6046,14 +6173,17 @@ msgstr "Necesar"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:34
 msgid "Required for certain ISPs, e.g. Charter with DOCSIS 3"
 msgstr ""
+"Necesar pentru anumiți furnizori de servicii de internet, de exemplu Charter "
+"cu DOCSIS 3"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:93
 msgid "Required. Base64-encoded private key for this interface."
 msgstr ""
+"Este necesar. Cheia privată codificată în baza 64 pentru această interfață."
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:261
 msgid "Required. Base64-encoded public key of peer."
-msgstr ""
+msgstr "Este necesar. Cheia publică codificată în baza 64 a omologului."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1312
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1313
@@ -6064,7 +6194,7 @@ msgstr "Necesită hostapd"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1319
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1320
 msgid "Requires hostapd with EAP Suite-B support"
-msgstr ""
+msgstr "Necesită hostapd cu suport EAP Suite-B"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1317
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1318
@@ -6073,17 +6203,17 @@ msgstr "Necesită hostapd cu suport EAP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1321
 msgid "Requires hostapd with OWE support"
-msgstr ""
+msgstr "Necesită hostapd cu suport OWE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1315
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1316
 msgid "Requires hostapd with SAE support"
-msgstr ""
+msgstr "Necesită hostapd cu suport SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1310
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1311
 msgid "Requires hostapd with WEP support"
-msgstr ""
+msgstr "Necesită hostapd cu suport WEP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1326
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1327
@@ -6092,36 +6222,36 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1341
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1342
 msgid "Requires wpa-supplicant"
-msgstr ""
+msgstr "Necesită wpa-supplicant"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1333
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1334
 msgid "Requires wpa-supplicant with EAP Suite-B support"
-msgstr ""
+msgstr "Necesită wpa-supplicant cu suport EAP Suite-B"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1331
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1332
 msgid "Requires wpa-supplicant with EAP support"
-msgstr ""
+msgstr "Necesită wpa-supplicant cu suport EAP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1335
 msgid "Requires wpa-supplicant with OWE support"
-msgstr ""
+msgstr "Necesită wpa-supplicant cu suport OWE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1329
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1330
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1345
 msgid "Requires wpa-supplicant with SAE support"
-msgstr ""
+msgstr "Necesită wpa-supplicant cu suport SAE"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1324
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1325
 msgid "Requires wpa-supplicant with WEP support"
-msgstr ""
+msgstr "Necesită wpa-supplicant cu suport WEP"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:226
 msgid "Reselection policy for primary slave"
-msgstr ""
+msgstr "Politica de realegere pentru sclavul primar"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2204
 #: modules/luci-base/luasrc/view/sysauth.htm:39
@@ -6178,6 +6308,8 @@ msgid ""
 "Return answers to DNS queries matching the subnet from which the query was "
 "received if multiple IPs are available."
 msgstr ""
+"Returnează răspunsuri la interogările DNS care corespund subrețelei din care "
+"a fost primită interogarea, dacă sunt disponibile mai multe IP-uri."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:385
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:386
@@ -6186,11 +6318,11 @@ msgstr "Arată / ascunde parola"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:625
 msgid "Reverse path filter"
-msgstr ""
+msgstr "Filtru de cale inversă"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4090
 msgid "Revert"
-msgstr ""
+msgstr "Reveniți"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4175
 msgid "Revert changes"
@@ -6198,15 +6330,15 @@ msgstr "Restabilește la schimbările anterioare"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4357
 msgid "Revert request failed with status <code>%h</code>"
-msgstr ""
+msgstr "Cererea de revenire a eșuat cu statusul <code>%h</code>"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4337
 msgid "Reverting configuration…"
-msgstr ""
+msgstr "Refacerea configurației…"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:551
 msgid "Robustness"
-msgstr ""
+msgstr "Robustețe"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:485
 msgid ""
@@ -6214,28 +6346,33 @@ msgid ""
 "<em>TFTP server root</em> turn on the TFTP server and serve files from "
 "<em>TFTP server root</em>."
 msgstr ""
+"Directorul root pentru fișierele servite prin TFTP. <em>Activați serverul "
+"TFTP</em> și <em>serverul TFTP root</em> porniți serverul TFTP și serviți "
+"fișiere din <em>TFTP server root</em>."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:297
 msgid "Root preparation"
-msgstr ""
+msgstr "Root preparare"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:204
 msgid "Round-Robin policy (balance-rr, 0)"
-msgstr ""
+msgstr "Politica Round-Robin (balance-rr, 0)"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:274
 msgid "Route Allowed IPs"
-msgstr ""
+msgstr "Rutarea IP-urilor permise"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:45
 msgid "Route type"
-msgstr ""
+msgstr "Tipul de rută"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:825
 msgid ""
 "Router Lifetime published in <abbr title=\"Router Advertisement, ICMPv6 Type "
 "134\">RA</abbr> messages. Maximum is 9000 seconds."
 msgstr ""
+"Router Lifetime publicat în mesajele <abbr title=\"Router Advertisement, "
+"ICMPv6 Type 134\">RA</abbr>. Maximul este de 9000 de secunde."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/password.js:46
 #: modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json:26
@@ -6247,13 +6384,15 @@ msgstr "Parola routerului"
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:248
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:15
 msgid "Routing"
-msgstr ""
+msgstr "Rutarea"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:28
 msgid ""
 "Routing defines over which interface and gateway a certain host or network "
 "can be reached."
 msgstr ""
+"Rutarea definește interfața și gateway-ul prin care se poate ajunge la o "
+"anumită gazdă sau rețea."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:218
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js:198
@@ -6263,11 +6402,13 @@ msgstr "Regula"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/routes.js:136
 msgid "Rule type"
-msgstr ""
+msgstr "Tipul de regulă"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:335
 msgid "Run a filesystem check before mounting the device"
 msgstr ""
+"Executați o verificare a sistemului de fișiere înainte de a monta "
+"dispozitivul"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:335
 msgid "Run filesystem check"
@@ -6275,7 +6416,7 @@ msgstr "Verifică sistemul de fișiere"
 
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2365
 msgid "Runtime error"
-msgstr ""
+msgstr "Eroare de execuție"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:224
 msgid "SHA256"
@@ -6284,7 +6425,7 @@ msgstr "SHA256"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:59
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:271
 msgid "SNR"
-msgstr ""
+msgstr "SNR"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/dropbear.js:10
 #: modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json:38
@@ -6293,15 +6434,15 @@ msgstr "Acces SSH"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:70
 msgid "SSH server address"
-msgstr ""
+msgstr "Adresa serverului SSH"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:74
 msgid "SSH server port"
-msgstr ""
+msgstr "Portul serverului SSH"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:58
 msgid "SSH username"
-msgstr ""
+msgstr "Nume de utilizator SSH"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:283
 #: modules/luci-mod-system/root/usr/share/luci/menu.d/luci-mod-system.json:51
@@ -6318,15 +6459,15 @@ msgstr "SSID"
 
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:9
 msgid "SSTP"
-msgstr ""
+msgstr "SSTP"
 
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:41
 msgid "SSTP Server"
-msgstr ""
+msgstr "Serverul SSTP"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:339
 msgid "SWAP"
-msgstr ""
+msgstr "SWAP"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:3075
 #: modules/luci-base/htdocs/luci-static/resources/luci.js:2199
@@ -6346,7 +6487,7 @@ msgstr "Salvați și aplicați"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:602
 msgid "Save error"
-msgstr ""
+msgstr "Salvează eroarea"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:434
 msgid "Save mtdblock"
@@ -6375,7 +6516,7 @@ msgstr "Secțiune eliminată"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:331
 msgid "See \"mount\" manpage for details"
-msgstr ""
+msgstr "Vezi pagina de manual \"mount\" pentru detalii"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:283
 msgid ""
@@ -6396,16 +6537,20 @@ msgstr "Selectează fișier…"
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:320
 msgid "Selects the transmit hash policy to use for slave selection"
 msgstr ""
+"Selectează politica de hașurare a transmiterii care urmează să fie utilizată "
+"pentru selectarea sclavilor"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:768
 msgid ""
 "Send <abbr title=\"Router Advertisement, ICMPv6 Type 134\">RA</abbr> "
 "messages advertising this device as IPv6 router."
 msgstr ""
+"Trimite mesaje <abbr title=\"Router Advertisement, ICMPv6 Type 134\">RA</"
+"abbr> care anunță acest dispozitiv ca router IPv6."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:650
 msgid "Send ICMP redirects"
-msgstr ""
+msgstr "Trimiteți redirecționări ICMP"
 
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:143
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/ppp.js:115
@@ -6417,6 +6562,8 @@ msgid ""
 "Send LCP echo requests at the given interval in seconds, only effective in "
 "conjunction with failure threshold"
 msgstr ""
+"Trimite cereri de ecou LCP la intervalul dat în secunde, eficient numai în "
+"combinație cu pragul de eșec"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:24
 msgid "Send the hostname of this device"
@@ -6428,7 +6575,7 @@ msgstr "Adresa serverului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:512
 msgid "Server name"
-msgstr ""
+msgstr "Numele serverului"
 
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pppoe.js:50
 msgid "Service Name"
@@ -6455,12 +6602,17 @@ msgstr "Setați Static"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:921
 msgid "Set interface as NDP-Proxy external slave. Default is off."
 msgstr ""
+"Setați interfața ca sclav extern NDP-Proxy. Valoarea implicită este "
+"dezactivată."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1230
 msgid ""
 "Set interface properties regardless of the link carrier (If set, carrier "
 "sense events do not invoke hotplug handlers)."
 msgstr ""
+"Setați proprietățile interfeței indiferent de purtătorul de legătură (dacă "
+"este setat, evenimentele de detectare a purtătorului nu invocă gestionarii "
+"hotplug)."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:302
 msgid "Set same MAC Address to all slaves"
@@ -6472,6 +6624,10 @@ msgid ""
 "options of sent <abbr title=\"Router Advertisement\">RA</abbr> messages. "
 "When enabled, clients will perform stateless IPv6 address autoconfiguration."
 msgstr ""
+"Setați indicatorul de configurare a adresei autonome în opțiunile de "
+"informații despre prefix din mesajele <abbr title=\"Router Advertisement\""
+">RA</abbr> trimise. Atunci când este activat, clienții vor efectua "
+"autoconfigurarea adreselor IPv6 fără stare."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:719
 msgid ""
@@ -6483,11 +6639,11 @@ msgstr ""
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:306
 msgid "Set to currently active slave (active, 1)"
-msgstr ""
+msgstr "Setat la sclavul activ în prezent (activ, 1)"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:307
 msgid "Set to first slave added to the bond (follow, 2)"
-msgstr ""
+msgstr "Setați la primul sclav adăugat la legătură (urmați, 2)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:646
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:662
@@ -6498,12 +6654,12 @@ msgstr "Setați serverul DHCP"
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:55
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:23
 msgid "Setting PLMN failed"
-msgstr ""
+msgstr "Setarea PLMN a eșuat"
 
 #: modules/luci-compat/luasrc/model/network/proto_ncm.lua:68
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:26
 msgid "Setting operation mode failed"
-msgstr ""
+msgstr "A eșuat setarea modului de funcționare"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js:11
 msgid "Settings"
@@ -6511,11 +6667,11 @@ msgstr "Setări"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:916
 msgid "Setup routes for proxied IPv6 neighbours."
-msgstr ""
+msgstr "Configurarea rutelor pentru vecinii IPv6 proxi."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:30
 msgid "Severely Errored Seconds (SES)"
-msgstr ""
+msgstr "Secunde cu erori grave (SES)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:210
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:37
@@ -6529,16 +6685,16 @@ msgstr "Preambul scurt"
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:470
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:18
 msgid "Show current backup file list"
-msgstr ""
+msgstr "Afișați lista curentă de fișiere de rezervă"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:293
 msgid "Show empty chains"
-msgstr ""
+msgstr "Afișați lanțurile goale"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:276
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:338
 msgid "Show raw counters"
-msgstr ""
+msgstr "Afișarea contoarelor brute"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:510
 msgid "Shutdown this interface"
@@ -6563,7 +6719,7 @@ msgstr "Semnal / Zgomot"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:25
 msgid "Signal Attenuation (SATN)"
-msgstr ""
+msgstr "Atenuarea semnalului (SATN)"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:136
 msgid "Signal Refresh Rate"
@@ -6580,16 +6736,16 @@ msgstr "Mărime"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:472
 msgid "Size of DNS query cache"
-msgstr ""
+msgstr "Dimensiunea cache-ului de interogare DNS"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:207
 msgid "Size of the ZRam device in megabytes"
-msgstr ""
+msgstr "Dimensiunea dispozitivului ZRam în megabytes"
 
 #: modules/luci-compat/luasrc/view/cbi/footer.htm:18
 #: modules/luci-compat/luasrc/view/cbi/simpleform.htm:57
 msgid "Skip"
-msgstr ""
+msgstr "Sari"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:257
 msgid "Skip from backup files that are equal to those in /rom"
@@ -6598,33 +6754,33 @@ msgstr "Omiteți din fișierele de rezervă care sunt egale cu cele din /rom"
 #: themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm:40
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:46
 msgid "Skip to content"
-msgstr ""
+msgstr "Sari la conținut"
 
 #: themes/luci-theme-openwrt-2020/luasrc/view/themes/openwrt2020/header.htm:39
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:45
 msgid "Skip to navigation"
-msgstr ""
+msgstr "Sari la navigare"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:180
 msgid "Slave Interfaces"
-msgstr ""
+msgstr "Interfețe slave"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3008
 #: modules/luci-compat/luasrc/model/network.lua:1428
 msgid "Software VLAN"
-msgstr ""
+msgstr "VLAN software"
 
 #: modules/luci-compat/luasrc/view/cbi/header.htm:5
 msgid "Some fields are invalid, cannot save values!"
-msgstr ""
+msgstr "Unele câmpuri sunt invalide, nu se pot salva valorile!"
 
 #: modules/luci-base/luasrc/view/error404.htm:9
 msgid "Sorry, the object you requested was not found."
-msgstr ""
+msgstr "Ne pare rău, obiectul pe care l-ați solicitat nu a fost găsit."
 
 #: modules/luci-base/luasrc/view/error500.htm:9
 msgid "Sorry, the server encountered an unexpected error."
-msgstr ""
+msgstr "Ne pare rău, serverul a întâmpinat o eroare neașteptată."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:442
 msgid ""
@@ -6647,19 +6803,24 @@ msgstr "Sursă"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:57
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:57
 msgid "Source interface"
-msgstr ""
+msgstr "Interfață sursă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:499
 msgid ""
 "Special <abbr title=\"Preboot eXecution Environment\">PXE</abbr> boot "
 "options for Dnsmasq."
 msgstr ""
+"Opțiuni speciale de pornire <abbr title=\"Preboot eXecution Environment\""
+">PXE</abbr> pentru Dnsmasq."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:899
 msgid ""
 "Specifies a fixed list of DNS search domains to announce via DHCPv6. If left "
 "unspecified, the local device DNS search domain will be announced."
 msgstr ""
+"Specifică o listă fixă de domenii de căutare DNS care trebuie anunțate prin "
+"DHCPv6. Dacă nu este specificat, se va anunța domeniul de căutare DNS al "
+"dispozitivului local."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:883
 msgid ""
@@ -6667,32 +6828,39 @@ msgid ""
 "If left unspecified, the device will announce itself as IPv6 DNS server "
 "unless the <em>Local IPv6 DNS server</em> option is disabled."
 msgstr ""
+"Specifică o listă fixă de adrese de server DNS IPv6 care trebuie anunțate "
+"prin DHCPv6. Dacă nu este specificat, dispozitivul se va anunța pe sine ca "
+"server DNS IPv6, cu excepția cazului în care opțiunea <em>Server DNS IPv6 "
+"local</em> este dezactivată."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:343
 msgid ""
 "Specifies that duplicate frames (received on inactive ports) should be "
 "dropped or delivered"
 msgstr ""
+"Specifică faptul că cadrele duplicate (primite pe porturi inactive) trebuie "
+"să fie abandonate sau livrate"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:359
 msgid "Specifies the ARP link monitoring frequency in milliseconds"
-msgstr ""
+msgstr "Specifică frecvența de monitorizare a legăturii ARP în milisecunde"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:367
 msgid "Specifies the IP addresses to use for ARP monitoring"
 msgstr ""
+"Specifică adresele IP care urmează să fie utilizate pentru monitorizarea ARP"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:396
 msgid "Specifies the MII link monitoring frequency in milliseconds"
-msgstr ""
+msgstr "Specifică frecvența de monitorizare a legăturii MII în milisecunde"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:261
 msgid "Specifies the aggregation selection logic to use"
-msgstr ""
+msgstr "Specifică logica de selecție a agregării care trebuie utilizată"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:292
 msgid "Specifies the directory the device is attached to"
-msgstr ""
+msgstr "Specifică directorul la care este atașat dispozitivul"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:792
 msgid ""
@@ -6700,24 +6868,34 @@ msgid ""
 "messages, for example to instruct clients to request further information via "
 "stateful DHCPv6."
 msgstr ""
+"Specifică steagurile trimise în mesajele <abbr title=\"Router Advertisement\""
+">RA</abbr>, de exemplu pentru a instrui clienții să solicite informații "
+"suplimentare prin DHCPv6 cu stare."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:254
 msgid ""
 "Specifies the mac-address for the actor in protocol packet exchanges "
 "(LACPDUs). If empty, masters' mac address defaults to system default"
 msgstr ""
+"Specifică adresa mac pentru actorul din schimburile de pachete de protocol "
+"(LACPDU). Dacă este goală, adresa mac a maeștrilor este cea implicită din "
+"sistem"
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:175
 msgid ""
 "Specifies the maximum amount of failed ARP requests until hosts are presumed "
 "to be dead"
 msgstr ""
+"Specifică numărul maxim de cereri ARP eșuate până când se presupune că "
+"gazdele sunt moarte"
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:171
 msgid ""
 "Specifies the maximum amount of seconds after which hosts are presumed to be "
 "dead"
 msgstr ""
+"Specifică numărul maxim de cereri ARP eșuate până când se presupune că "
+"gazdele sunt moarte"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:947
 msgid ""
@@ -6725,72 +6903,96 @@ msgid ""
 "on regulatory requirements and wireless usage, the actual transmit power may "
 "be reduced by the driver."
 msgstr ""
+"Specifică puterea maximă de transmisie pe care o poate utiliza radioul fără "
+"fir. În funcție de cerințele de reglementare și de utilizarea wireless, "
+"puterea de transmisie reală poate fi redusă de către driver."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:238
 msgid ""
 "Specifies the minimum number of links that must be active before asserting "
 "carrier"
 msgstr ""
+"Specifică numărul minim de legături care trebuie să fie active înainte de "
+"afirmarea purtătorului"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:202
 msgid "Specifies the mode to be used for this bonding interface"
 msgstr ""
+"Specifică modul care urmează să fie utilizat pentru această interfață de "
+"bonding"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:334
 msgid ""
 "Specifies the number of IGMP membership reports to be issued after a "
 "failover event in 200ms intervals"
 msgstr ""
+"Specifică numărul de rapoarte de apartenență IGMP care urmează să fie emise "
+"după un eveniment de failover la intervale de 200ms"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:278
 msgid ""
 "Specifies the number of packets to transmit through a slave before moving to "
 "the next one"
 msgstr ""
+"Specifică numărul de pachete care trebuie transmise prin intermediul unui "
+"sclav înainte de a trece la următorul"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:312
 msgid ""
 "Specifies the number of peer notifications (gratuitous ARPs and unsolicited "
 "IPv6 Neighbor Advertisements) to be issued after a failover event"
 msgstr ""
+"Specifică numărul de notificări peer (ARP-uri gratuite și anunțuri de "
+"vecinătate IPv6 nesolicitate) care urmează să fie emise după un eveniment de "
+"failover"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:286
 msgid ""
 "Specifies the number of seconds between instances where the bonding driver "
 "sends learning packets to each slaves peer switch"
 msgstr ""
+"Specifică numărul de secunde dintre instanțele în care driverul de bonding "
+"trimite pachete de învățare către fiecare comutator pereche de sclavi"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:375
 msgid "Specifies the quantity of ARP IP targets that must be reachable"
-msgstr ""
+msgstr "Specifică numărul de ținte IP ARP care trebuie să fie accesibile"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:270
 msgid ""
 "Specifies the rate in which the link partner will be asked to transmit "
 "LACPDU packets"
 msgstr ""
+"Specifică rata la care partenerului de legătură i se va cere să transmită "
+"pachete LACPDU"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:227
 msgid ""
 "Specifies the reselection policy for the primary slave when failure of the "
 "active slave or recovery of the primary slave occurs"
 msgstr ""
+"Specifică politica de reselecție pentru sclavul principal atunci când are "
+"loc o defecțiune a sclavului activ sau o recuperare a sclavului principal"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:246
 msgid "Specifies the system priority"
-msgstr ""
+msgstr "Specifică prioritatea sistemului"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:404
 msgid ""
 "Specifies the time in milliseconds to wait before disabling a slave after a "
 "link failure detection"
 msgstr ""
+"Specifică timpul în milisecunde care trebuie așteptat înainte de a dezactiva "
+"un sclav după detectarea unei defecțiuni a legăturii"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:412
 msgid ""
 "Specifies the time in milliseconds to wait before enabling a slave after a "
 "link recovery detection"
 msgstr ""
+"Specifică timpul în milisecunde care trebuie așteptat înainte de a activa un "
+"sclav după o detectare a recuperării legăturii"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:494
 msgid ""
@@ -6798,46 +7000,60 @@ msgid ""
 "wireless networks, choose the associated interface as network in the "
 "wireless settings."
 msgstr ""
+"Specifică porturile cablate care trebuie atașate la această punte. Pentru a "
+"atașa rețelele fără fir, alegeți interfața asociată ca rețea în setările "
+"fără fir."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:383
 msgid ""
 "Specifies whether ARP probes and replies should be validated or non-ARP "
 "traffic should be filtered for link monitoring"
 msgstr ""
+"Specifică dacă sondele și răspunsurile ARP trebuie validate sau dacă "
+"traficul non-ARP trebuie filtrat pentru monitorizarea legăturii"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:303
 msgid ""
 "Specifies whether active-backup mode should set all slaves to the same MAC "
 "address at enslavement"
 msgstr ""
+"Specifică dacă modul de rezervă activă trebuie să seteze toți servanții la "
+"aceeași adresă MAC în momentul aservirii"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:420
 msgid ""
 "Specifies whether or not miimon should use MII or ETHTOOL ioctls vs. "
 "netif_carrier_ok()"
 msgstr ""
+"Specifică dacă miimon ar trebui să utilizeze sau nu ioctls MII sau ETHTOOL "
+"vs. netif_carrier_ok()"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:295
 msgid ""
 "Specifies whether to shuffle active flows across slaves based on the load"
 msgstr ""
+"Specifică dacă se amestecă fluxurile active între sclavi pe baza încărcăturii"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:181
 msgid ""
 "Specifies which slave interfaces should be attached to this bonding interface"
 msgstr ""
+"Specifică ce interfețe slave ar trebui să fie atașate la această interfață "
+"de bonding"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:214
 msgid ""
 "Specifies which slave is the primary device. It will always be the active "
 "slave while it is available"
 msgstr ""
+"Specifică care sclav este dispozitivul principal. Acesta va fi întotdeauna "
+"sclavul activ cât timp este disponibil"
 
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:63
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan.js:67
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:62
 msgid "Specify a TOS (Type of Service)."
-msgstr ""
+msgstr "Specificați un TOS ( Tip de serviciu)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:74
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:79
@@ -6847,6 +7063,9 @@ msgid ""
 "header inherits the value of the inner header) or an hexadecimal value "
 "<code>00..FF</code> (optional)."
 msgstr ""
+"Specificați un TOS (Type of Service). Poate fi <code>inherit</code> (antetul "
+"exterior moștenește valoarea antetului interior) sau o valoare hexazecimală "
+"<code>00..FF</code> (opțional)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:74
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:74
@@ -6855,6 +7074,8 @@ msgid ""
 "Specify a TTL (Time to Live) for the encapsulating packet other than the "
 "default (64) (optional)."
 msgstr ""
+"Specificați un TTL (Time to Live) pentru pachetul de încapsulare, altul "
+"decât cel implicit (64) (opțional)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:69
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:58
@@ -6864,6 +7085,8 @@ msgid ""
 "Specify a TTL (Time to Live) for the encapsulating packet other than the "
 "default (64)."
 msgstr ""
+"Specificați un TTL (Time to Live) pentru pachetul de încapsulare, altul "
+"decât cel implicit (64)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:84
 msgid ""
@@ -6871,6 +7094,9 @@ msgid ""
 "inherits the value of the inner header) or an hexadecimal value <code>00.."
 "FF</code> (optional)."
 msgstr ""
+"Specificați o clasă de trafic. Poate fi <code>inherit</code> (antetul "
+"exterior moștenește valoarea antetului interior) sau o valoare hexazecimală "
+"<code>00..FF</code> (opțional)."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:64
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:69
@@ -6880,12 +7106,16 @@ msgid ""
 "Specify an MTU (Maximum Transmission Unit) other than the default (1280 "
 "bytes) (optional)."
 msgstr ""
+"Specificați o unitate MTU (Maximum Transmission Unit) diferită de cea "
+"implicită (1280 octeți) (opțional)."
 
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:53
 msgid ""
 "Specify an MTU (Maximum Transmission Unit) other than the default (1280 "
 "bytes)."
 msgstr ""
+"Specificați o unitate MTU (Maximum Transmission Unit) diferită de cea "
+"implicită (1280 octeți)."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2019
 msgid "Specify the secret encryption key here."
@@ -6893,7 +7123,7 @@ msgstr "Specificați aici cheia secretă de criptare."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:657
 msgid "Stale neighbour cache timeout"
-msgstr ""
+msgstr "Timpul de expirare a memoriei cache a vecinilor învechite"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:669
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:99
@@ -6955,6 +7185,10 @@ msgid ""
 "to DHCP clients. They are also required for non-dynamic interface "
 "configurations where only hosts with a corresponding lease are served."
 msgstr ""
+"Leasingurile statice sunt utilizate pentru a atribui clienților DHCP adrese "
+"IP fixe și nume de gazdă simbolice. De asemenea, acestea sunt necesare "
+"pentru configurațiile de interfață nedinamice în care sunt deservite numai "
+"gazdele cu un contract de închiriere corespunzător."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "Station inactivity limit"
@@ -7014,30 +7248,32 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js:46
 msgid "Swap free"
-msgstr ""
+msgstr "Schimba liber"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:139
 #: modules/luci-mod-network/root/usr/share/luci/menu.d/luci-mod-network.json:3
 msgid "Switch"
-msgstr ""
+msgstr "Comutați"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:172
 msgid "Switch %q"
-msgstr ""
+msgstr "Comută %q"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:150
 msgid ""
 "Switch %q has an unknown topology - the VLAN settings might not be accurate."
 msgstr ""
+"Comutatorul %q are o topologie necunoscută - este posibil ca setările VLAN "
+"să nu fie corecte."
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3008
 #: modules/luci-compat/luasrc/model/network.lua:1426
 msgid "Switch VLAN"
-msgstr ""
+msgstr "Comutator VLAN"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3005
 msgid "Switch port"
-msgstr ""
+msgstr "Port de comutare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:560
 msgid "Switch protocol"
@@ -7047,7 +7283,7 @@ msgstr "Schimbă protocolul"
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:104
 #: modules/luci-compat/luasrc/view/cbi/ipaddr.htm:26
 msgid "Switch to CIDR list notation"
-msgstr ""
+msgstr "Treceți la notarea listei CIDR"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2692
 msgid "Symbolic link"
@@ -7149,7 +7385,7 @@ msgstr "Terminați"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:201
 msgid "The \"PublicKey\" of that wg interface"
-msgstr ""
+msgstr "\"PublicKey\" al interfeței wg respective"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:832
 msgid ""
@@ -7157,6 +7393,9 @@ msgid ""
 "<abbr title=\"Router Advertisement, ICMPv6 Type 134\">RA</abbr> messages. "
 "Minimum is 1280 bytes."
 msgstr ""
+"<abbr title=\"Maximum Transmission Unit\">MTU</abbr> care trebuie publicat "
+"în mesajele <abbr title=\"Router Advertisement, ICMPv6 Type 134\">RA</abbr>. "
+"Valoarea minimă este de 1280 octeți."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:794
 msgid ""
@@ -7184,19 +7423,24 @@ msgstr ""
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:84
 msgid "The <em>block mount</em> command failed with code %d"
-msgstr ""
+msgstr "Comanda <em>block mount</em> a eșuat cu codul %d"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:947
 msgid ""
 "The DNS server entries in the local resolv.conf are primarily sorted by the "
 "weight specified here"
 msgstr ""
+"Intrările serverului DNS din fișierul local resolv.conf sunt sortate în "
+"primul rând în funcție de ponderea specificată aici"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:77
 msgid ""
 "The HE.net endpoint update configuration changed, you must now use the plain "
 "username instead of the user ID!"
 msgstr ""
+"Configurația de actualizare a punctului final HE.net s-a schimbat, acum "
+"trebuie să folosiți numele de utilizator simplu în loc de ID-ul de "
+"utilizator!"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:680
 msgid "The IP address %h is already used by another static lease"
@@ -7213,6 +7457,8 @@ msgstr "Adresa IP a serverului de pornire"
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan.js:40
 msgid "The IPv4 address or the fully-qualified domain name of the remote end."
 msgstr ""
+"Adresa IPv4 sau numele de domeniu complet calificat al terminalului la "
+"distanță."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:42
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:42
@@ -7220,22 +7466,29 @@ msgstr ""
 msgid ""
 "The IPv4 address or the fully-qualified domain name of the remote tunnel end."
 msgstr ""
+"Adresa IPv4 sau numele de domeniu complet calificat al capătului de tunel la "
+"distanță."
 
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:40
 msgid "The IPv6 address or the fully-qualified domain name of the remote end."
 msgstr ""
+"Adresa IPv6 sau numele de domeniu complet calificat al terminalului la "
+"distanță."
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:42
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:42
 msgid ""
 "The IPv6 address or the fully-qualified domain name of the remote tunnel end."
 msgstr ""
+"Adresa IPv6 sau numele de domeniu complet calificat al capătului de tunel la "
+"distanță."
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:53
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:59
 msgid ""
 "The IPv6 prefix assigned to the provider, usually ends with <code>::</code>"
 msgstr ""
+"Prefixul IPv6 atribuit furnizorului, de obicei se termină cu <code>::</code>"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/timer.js:7
 msgid "The LED blinks with the configured on/off frequency"
@@ -7269,13 +7522,15 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:586
 msgid "The MTU must not exceed the parent device MTU of %d bytes"
-msgstr ""
+msgstr "MTU nu trebuie să depășească MTU-ul dispozitivului părinte de %d octeți"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:210
 msgid ""
 "The QR-Code works per wg interface, it will be refreshed with every button "
 "click and transfers the following information:"
 msgstr ""
+"Codul QR-Code funcționează prin interfața wg, va fi reîmprospătat la fiecare "
+"apăsare de buton și transferă următoarele informații:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:864
 msgid "The VLAN ID must be unique"
@@ -7326,6 +7581,8 @@ msgid ""
 "The device file of the memory or partition (<abbr title=\"for example\">e.g."
 "</abbr> <code>/dev/sda1</code>)"
 msgstr ""
+"Fișierul de dispozitiv al memoriei sau partiției (<abbr title=\"for example\""
+">de exemplu</abbr> <code>/dev/sda1</code>)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:450
 msgid "The device name \"%s\" is already taken"
@@ -7366,6 +7623,8 @@ msgstr "Următoarele reguli sunt în prezent active pe acest sistem."
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/led-trigger/heartbeat.js:7
 msgid "The frequency is in direct proportion to 1-minute average CPU load."
 msgstr ""
+"Frecvența este direct proporțională cu sarcina medie de 1 minut a "
+"procesorului."
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/static.js:154
 msgid "The gateway address must not be a local IP address"
@@ -7373,13 +7632,15 @@ msgstr "Adresa porții de acces nu trebuie să fie o adresă IP locală"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:166
 msgid "The given SSH public key has already been added."
-msgstr ""
+msgstr "Cheia publică SSH dată a fost deja adăugată."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:172
 msgid ""
 "The given SSH public key is invalid. Please supply proper public RSA or "
 "ECDSA keys."
 msgstr ""
+"Cheia publică SSH furnizată nu este valabilă. Vă rugăm să furnizați chei "
+"publice RSA sau ECDSA corespunzătoare."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:513
 msgid "The hostname of the boot server"
@@ -7399,17 +7660,20 @@ msgid ""
 "The length of the IPv4 prefix in bits, the remainder is used in the IPv6 "
 "addresses."
 msgstr ""
+"Lungimea prefixului IPv4 în biți, restul este utilizat în adresele IPv6."
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:57
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:63
 msgid "The length of the IPv6 prefix in bits"
-msgstr ""
+msgstr "Lungimea prefixului IPv6 în biți"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:202
 msgid ""
 "The list of this client's \"AllowedIPs\" or \"0.0.0.0/0, ::/0\" if not "
 "configured"
 msgstr ""
+"Lista \"AllowedIPs\" a acestui client sau \"0.0.0.0.0/0, ::/0\" dacă nu este "
+"configurată"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:165
 msgid "The local IPv4 address"
@@ -7420,7 +7684,7 @@ msgstr "Adresa IPv4 locală"
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:44
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan.js:44
 msgid "The local IPv4 address over which the tunnel is created (optional)."
-msgstr ""
+msgstr "Adresa IPv4 locală pe care se creează tunelul (opțional)."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:171
 msgid "The local IPv4 netmask"
@@ -7430,7 +7694,7 @@ msgstr "Masca de rețea IPv4 locală"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:53
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:44
 msgid "The local IPv6 address over which the tunnel is created (optional)."
-msgstr ""
+msgstr "Adresa IPv6 locală pe care se creează tunelul (opțional)."
 
 #: themes/luci-theme-bootstrap/htdocs/luci-static/resources/view/bootstrap/sysauth.js:59
 msgid "The login request failed with error: %h"
@@ -7444,6 +7708,12 @@ msgid ""
 "\"leave latency\" of the network. A reduced value results in reduced time to "
 "detect the loss of the last member of a group"
 msgstr ""
+"Timpul maxim de răspuns în cențiecunde introdus în interogările specifice "
+"grupului trimise ca răspuns la mesajele de părăsire a grupului. Este, de "
+"asemenea, perioada de timp dintre mesajele de interogare specifice grupului. "
+"Această valoare poate fi ajustată pentru a modifica \"latența de părăsire\" "
+"a rețelei. O valoare redusă are ca rezultat reducerea timpului de detectare "
+"a pierderii ultimului membru al unui grup"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:561
 msgid ""
@@ -7452,12 +7722,19 @@ msgid ""
 "IGMP messages on the subnet; larger values make the traffic less bursty, as "
 "host responses are spread out over a larger interval"
 msgstr ""
+"Timpul maxim de răspuns în cențiecunde introdus în interogările generale "
+"periodice. Prin variația acestei valori, un administrator poate regla "
+"caracterul exploziv al mesajelor IGMP în subrețea; valorile mai mari fac "
+"traficul mai puțin exploziv, deoarece răspunsurile gazdelor sunt distribuite "
+"pe un interval mai mare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:851
 msgid ""
 "The maximum hops to be published in <abbr title=\"Router Advertisement\">RA</"
 "abbr> messages. Maximum is 255 hops."
 msgstr ""
+"Numărul maxim de salturi care urmează să fie publicate în mesajele <abbr "
+"title=\"Router Advertisement\">RA</abbr>. Maximul este de 255 de salturi."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2010
 msgid "The network name is already used"
@@ -7472,6 +7749,13 @@ msgid ""
 "segments. Often there is by default one Uplink port for a connection to the "
 "next greater network like the internet and other ports for a local network."
 msgstr ""
+"Porturile de rețea de pe acest dispozitiv pot fi combinate în mai multe "
+"<abbr title=\"Virtual Local Area Network\">VLAN</abbr>s în care "
+"calculatoarele pot comunica direct între ele. <abbr title=\"Virtual Local "
+"Area Network\">VLAN</abbr>s sunt adesea utilizate pentru a separa diferite "
+"segmente de rețea. Adesea, există în mod implicit un port Uplink pentru o "
+"conexiune la o rețea mai mare, cum ar fi internetul, și alte porturi pentru "
+"o rețea locală."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:569
 msgid "The query response interval must be lower than the query interval value"
@@ -7494,6 +7778,10 @@ msgid ""
 "network. If a network is expected to be lossy, the robustness value may be "
 "increased. IGMP is robust to (Robustness-1) packet losses"
 msgstr ""
+"Valoarea de robustețe permite reglarea în funcție de pierderea de pachete "
+"preconizată în rețea. În cazul în care se așteaptă ca o rețea să aibă "
+"pierderi, valoarea robusteții poate fi mărită. IGMP este robust la "
+"(Robustness-1) pierderi de pachete"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1370
 msgid "The selected %s mode is incompatible with %s encryption"
@@ -7569,7 +7857,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1443
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1455
 msgid "The value is overridden by configuration. Original: %s"
-msgstr ""
+msgstr "Valoarea este suprascrisă de configurare. Original: %s"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:736
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:768
@@ -7594,15 +7882,15 @@ msgstr ""
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:49
 msgid "This IPv4 address of the relay"
-msgstr ""
+msgstr "Această adresă IPv4 a releului"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1624
 msgid "This authentication type is not applicable to the selected EAP method."
-msgstr ""
+msgstr "Acest tip de autentificare nu se aplică la metoda EAP selectată."
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:57
 msgid "This does not look like a valid PEM file"
-msgstr ""
+msgstr "Acesta nu pare a fi un fișier PEM valid"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:454
 #: modules/luci-mod-system/luasrc/model/cbi/admin_system/backupfiles.lua:16
@@ -7611,12 +7899,18 @@ msgid ""
 "include during sysupgrade. Modified files in /etc/config/ and certain other "
 "configurations are automatically preserved."
 msgstr ""
+"Aceasta este o listă de tipare globulare de shell pentru potrivirea "
+"fișierelor și directoarelor care trebuie incluse în timpul actualizării "
+"sistemului. Fișierele modificate în /etc/config/ și anumite alte "
+"configurații sunt păstrate automat."
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:81
 msgid ""
 "This is either the \"Update Key\" configured for the tunnel or the account "
 "password if no update key has been configured"
 msgstr ""
+"Aceasta este fie \"Cheia de actualizare\" configurată pentru tunel, fie "
+"parola contului, dacă nu a fost configurată nicio cheie de actualizare"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:116
 msgid ""
@@ -7631,6 +7925,8 @@ msgid ""
 "This is the local endpoint address assigned by the tunnel broker, it usually "
 "ends with <code>...:2/64</code>"
 msgstr ""
+"Aceasta este adresa locală a punctului final atribuită de către brokerul de "
+"tunel, de obicei se termină cu <code>...:2/64</code>"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:266
 msgid "This is the only DHCP server in the local network."
@@ -7644,15 +7940,20 @@ msgstr "Acesta este numele de utilizator simplu pentru conectarea la cont"
 msgid ""
 "This is the prefix routed to you by the tunnel broker for use by clients"
 msgstr ""
+"Acesta este prefixul care vă este direcționat de către brokerul de tunel "
+"pentru a fi utilizat de clienți"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:29
 msgid "This is the system crontab in which scheduled tasks can be defined."
 msgstr ""
+"Acesta este crontab de sistem în care pot fi definite sarcinile programate."
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:50
 msgid ""
 "This is usually the address of the nearest PoP operated by the tunnel broker"
 msgstr ""
+"Aceasta este de obicei adresa celui mai apropiat PoP operat de către "
+"brokerul de tunel"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/processes.js:65
 msgid ""
@@ -7667,6 +7968,8 @@ msgstr ""
 msgid ""
 "This option cannot be used because the ca-bundle package is not installed."
 msgstr ""
+"Această opțiune nu poate fi utilizată deoarece pachetul ca-bundle nu este "
+"instalat."
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:2256
 #: modules/luci-base/htdocs/luci-static/resources/form.js:2566
@@ -7685,7 +7988,7 @@ msgstr "Timp în milisecunde"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:527
 msgid "Time in seconds to spend in listening and learning states"
-msgstr ""
+msgstr "Timp în secunde pentru a petrece în stări de ascultare și învățare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1166
 msgid "Time interval for rekeying GTK"
@@ -7702,10 +8005,14 @@ msgstr "Expirare în secunde"
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:513
 msgid "Timeout in seconds for learned MAC addresses in the forwarding database"
 msgstr ""
+"Timeout în secunde pentru adresele MAC învățate în baza de date de "
+"redirecționare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:532
 msgid "Timeout in seconds until topology updates on link loss"
 msgstr ""
+"Timeout în secunde până la actualizarea topologiei în cazul pierderii "
+"legăturii"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:144
 msgid "Timezone"
@@ -7727,7 +8034,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1491
 msgid "Tone"
-msgstr ""
+msgstr "Tonalitate"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js:35
 msgid "Total Available"
@@ -7737,7 +8044,7 @@ msgstr "Total disponibil"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js:114
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/diagnostics.js:124
 msgid "Traceroute"
-msgstr ""
+msgstr "Traseu de urmărire"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:54
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:65
@@ -7748,7 +8055,7 @@ msgstr "Trafic"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:79
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:84
 msgid "Traffic Class"
-msgstr ""
+msgstr "Clasa de trafic"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:387
 msgid "Transfer"
@@ -7760,7 +8067,7 @@ msgstr "Transmite"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:319
 msgid "Transmit Hash Policy"
-msgstr ""
+msgstr "Politica de transmitere a hașurilor"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js:75
 msgid "Trigger"
@@ -7772,7 +8079,7 @@ msgstr "Mod de declanșare"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:69
 msgid "Tunnel ID"
-msgstr ""
+msgstr "ID-ul tunelului"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:3011
 #: modules/luci-compat/luasrc/model/network.lua:1431
@@ -7783,7 +8090,7 @@ msgstr "Interfață de tunel"
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:55
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:76
 msgid "Tunnel Link"
-msgstr ""
+msgstr "Tunel de legătură"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1400
 msgid "Tunnel device"
@@ -7815,7 +8122,7 @@ msgstr "Doar UMTS"
 #: modules/luci-compat/luasrc/model/network/proto_3g.lua:10
 #: protocols/luci-proto-3g/htdocs/luci-static/resources/protocol/3g.js:43
 msgid "UMTS/GPRS/EV-DO"
-msgstr ""
+msgstr "UMTS/GPRS/EV-DO"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:254
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:360
@@ -7827,58 +8134,58 @@ msgstr "UUID"
 #: modules/luci-compat/luasrc/model/network.lua:34
 #: modules/luci-compat/luasrc/model/network.lua:35
 msgid "Unable to determine device name"
-msgstr ""
+msgstr "Nu se poate determina numele dispozitivului"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:18
 #: modules/luci-compat/luasrc/model/network.lua:36
 msgid "Unable to determine external IP address"
-msgstr ""
+msgstr "Nu se poate determina adresa IP externă"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:19
 #: modules/luci-compat/luasrc/model/network.lua:37
 msgid "Unable to determine upstream interface"
-msgstr ""
+msgstr "Nu se poate determina interfața în flux ascendent"
 
 #: modules/luci-base/luasrc/view/error404.htm:11
 msgid "Unable to dispatch"
-msgstr ""
+msgstr "Imposibilitatea de a expedia"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:9
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js:15
 msgid "Unable to load log data:"
-msgstr ""
+msgstr "Nu se pot încărca datele din jurnal:"
 
 #: modules/luci-compat/luasrc/model/network/proto_modemmanager.lua:54
 #: modules/luci-compat/luasrc/model/network/proto_qmi.lua:54
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:22
 msgid "Unable to obtain client ID"
-msgstr ""
+msgstr "Nu se poate obține ID-ul clientului"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:221
 msgid "Unable to obtain mount information"
-msgstr ""
+msgstr "Imposibilitatea de a obține informații despre montare"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:307
 msgid "Unable to reset ip6tables counters: %s"
-msgstr ""
+msgstr "Imposibil de resetat contoarele ip6tables: %s"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:305
 msgid "Unable to reset iptables counters: %s"
-msgstr ""
+msgstr "Imposibilitatea de a reseta contoarele iptables: %s"
 
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:61
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:7
 msgid "Unable to resolve AFTR host name"
-msgstr ""
+msgstr "Nu se poate rezolva numele gazdei AFTR"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:20
 #: modules/luci-compat/luasrc/model/network.lua:38
 msgid "Unable to resolve peer host name"
-msgstr ""
+msgstr "Nu se poate rezolva numele de gazdă al partenerului"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js:313
 msgid "Unable to restart firewall: %s"
-msgstr ""
+msgstr "Nu se poate reporni firewall-ul: %s"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/crontab.js:22
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:370
@@ -7888,15 +8195,15 @@ msgstr "Nu se poate salva conținutul: %s"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:32
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
+msgstr "Secunde indisponibile (UAS)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1291
 msgid "Unconfigure"
-msgstr ""
+msgstr "Neconfigurați"
 
 #: modules/luci-base/htdocs/luci-static/resources/fs.js:102
 msgid "Unexpected reply data format"
-msgstr ""
+msgstr "Format neașteptat al datelor de răspuns"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1463
 msgid ""
@@ -7905,6 +8212,10 @@ msgid ""
 "analogous to IPv4 private network addressing. This prefix is randomly "
 "generated at first install."
 msgstr ""
+"Adresa locală unică - în intervalul <code>fc00::/7</code>. De obicei, numai "
+"în cadrul &#8216;local&#8217; jumătății <code>fd00::/8</code>. ULA pentru "
+"IPv6 este analogă cu adresarea rețelei private IPv4. Acest prefix este "
+"generat în mod aleatoriu la prima instalare."
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2111
 #: modules/luci-compat/luasrc/model/network.lua:971
@@ -7914,16 +8225,16 @@ msgstr "Necunoscut"
 
 #: protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js:47
 msgid "Unknown and unsupported connection method."
-msgstr ""
+msgstr "Metodă de conectare necunoscută și neacceptată."
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2420
 #: modules/luci-compat/luasrc/model/network.lua:1138
 msgid "Unknown error (%s)"
-msgstr ""
+msgstr "Eroare necunoscută (%s)"
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:412
 msgid "Unknown error code"
-msgstr ""
+msgstr "Cod de eroare necunoscut"
 
 #: modules/luci-base/htdocs/luci-static/resources/network.js:2108
 #: modules/luci-base/htdocs/luci-static/resources/protocol/none.js:6
@@ -7934,11 +8245,11 @@ msgstr "Neadministrate"
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:195
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:217
 msgid "Unmount"
-msgstr ""
+msgstr "Demontează"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js:115
 msgid "Unnamed key"
-msgstr ""
+msgstr "Cheie fără nume"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4010
 msgid "Unsaved Changes"
@@ -7946,12 +8257,12 @@ msgstr "Modificări nesalvate"
 
 #: modules/luci-base/htdocs/luci-static/resources/rpc.js:410
 msgid "Unspecified error"
-msgstr ""
+msgstr "Eroare nespecificată"
 
 #: modules/luci-compat/luasrc/model/network/proto_4x6.lua:64
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:9
 msgid "Unsupported MAP type"
-msgstr ""
+msgstr "Tip MAP neacceptat"
 
 #: modules/luci-compat/luasrc/model/network/proto_ncm.lua:69
 #: protocols/luci-proto-ncm/htdocs/luci-static/resources/protocol/ncm.js:27
@@ -7964,11 +8275,11 @@ msgstr "Tipul de protocol nesuportat."
 
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:151
 msgid "Up"
-msgstr ""
+msgstr "Sus"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:411
 msgid "Up Delay"
-msgstr ""
+msgstr "Până la întârziere"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:3897
 msgid "Upload"
@@ -8011,18 +8322,26 @@ msgid ""
 "assigned with a name in the form <em>wifinet#</em> and the network will be "
 "restarted to apply the updated configuration."
 msgstr ""
+"La apăsarea butonului \"Continue\", secțiunilor anonime \"wifi-iface\" li se "
+"va atribui un nume de forma <em>wifinet#</em>, iar rețeaua va fi repornită "
+"pentru a aplica configurația actualizată."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:394
 msgid ""
 "Upon pressing \"Continue\", bridges configuration will be updated and the "
 "network will be restarted to apply the updated configuration."
 msgstr ""
+"La apăsarea butonului \" Continuare \", configurația punților va fi "
+"actualizată, iar rețeaua va fi repornită pentru a aplica configurația "
+"actualizată."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:428
 msgid ""
 "Upon pressing \"Continue\", ifname options will get renamed and the network "
 "will be restarted to apply the updated configuration."
 msgstr ""
+"La apăsarea butonului \"Continue\", opțiunile ifname vor fi redenumite, iar "
+"rețeaua va fi repornită pentru a aplica configurația actualizată."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:422
 msgid "Upstream resolvers will be queried in the order of the resolv file."
@@ -8050,7 +8369,7 @@ msgstr "Utilizați poarta de acces a DHCP"
 #: protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js:68
 #: protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js:132
 msgid "Use DNS servers advertised by peer"
-msgstr ""
+msgstr "Utilizați serverele DNS anunțate de către partenerul de rețea"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:623
 msgid "Use ISO/IEC 3166 alpha2 country codes."
@@ -8063,44 +8382,46 @@ msgstr "Folosește codurile de țară ISO/IEC 3166 alpha2."
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:67
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:84
 msgid "Use MTU on tunnel interface"
-msgstr ""
+msgstr "Utilizați MTU pe interfața tunelului"
 
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:85
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:65
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6to4.js:49
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/map.js:80
 msgid "Use TTL on tunnel interface"
-msgstr ""
+msgstr "Utilizați TTL pe interfața de tunel"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:322
 msgid "Use XOR of hardware MAC addresses (layer2)"
-msgstr ""
+msgstr "Utilizați XOR de adrese MAC hardware (layer2)"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:323
 msgid "Use XOR of hardware MAC addresses and IP addresses (layer2+3)"
-msgstr ""
+msgstr "Utilizarea XOR a adreselor MAC hardware și a adreselor IP (layer2+3)"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:325
 msgid ""
 "Use XOR of hardware MAC addresses and IP addresses, rely on skb_flow_dissect "
 "(encap2+3)"
 msgstr ""
+"Utilizați XOR de adrese hardware MAC și adrese IP, bazați-vă pe "
+"skb_flow_dissect (encap2+3)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:294
 msgid "Use as external overlay (/overlay)"
-msgstr ""
+msgstr "Utilizare ca suprapunere externă (/overlay)"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:293
 msgid "Use as root filesystem (/)"
-msgstr ""
+msgstr "Utilizați ca sistem de fișiere rădăcină (/)"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:34
 msgid "Use broadcast flag"
-msgstr ""
+msgstr "Utilizați indicatorul de difuzare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1226
 msgid "Use builtin IPv6-management"
-msgstr ""
+msgstr "Utilizați managementul IPv6 încorporat"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:937
 msgid "Use custom DNS servers"
@@ -8127,10 +8448,12 @@ msgid ""
 "Use legacy MAP interface identifier format (draft-ietf-softwire-map-00) "
 "instead of RFC7597"
 msgstr ""
+"Utilizarea formatului tradițional de identificare a interfeței MAP (draft-"
+"ietf-softwire-map-00) în loc de RFC7597"
 
 #: protocols/luci-proto-relay/htdocs/luci-static/resources/protocol/relay.js:179
 msgid "Use routing table"
-msgstr ""
+msgstr "Utilizați tabelul de rutare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1571
 msgid "Use system certificates"
@@ -8138,7 +8461,7 @@ msgstr "Utilizați certificatele de sistem"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1629
 msgid "Use system certificates for inner-tunnel"
-msgstr ""
+msgstr "Utilizați certificate de sistem pentru tunelul interior"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:598
 msgid ""
@@ -8148,15 +8471,23 @@ msgid ""
 "the requesting host. The optional <em>Lease time</em> can be used to set non-"
 "standard host-specific lease time, e.g. 12h, 3d or infinite."
 msgstr ""
+"Utilizați butonul <em>Add</em> pentru a adăuga o nouă intrare de închiriere. "
+"<em>Adresa MAC</em> identifică gazda, <em>Adresa IPv4</em> specifică adresa "
+"fixă care urmează să fie utilizată, iar <em>Numele gazdei</em> este atribuit "
+"ca nume simbolic gazdei solicitante. Opțional, <em>Lease time</em> poate fi "
+"utilizat pentru a seta un timp de închiriere nestandardizat specific gazdei, "
+"de exemplu, 12h, 3d sau infinit."
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:324
 msgid "Use upper layer protocol information (layer3+4)"
-msgstr ""
+msgstr "Utilizați informațiile de protocol din stratul superior (layer3+4)"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:326
 msgid ""
 "Use upper layer protocol information, rely on skb_flow_dissect (encap3+4)"
 msgstr ""
+"Utilizează informații de protocol din stratul superior, se bazează pe "
+"skb_flow_dissect (encap3+4)"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/20_memory.js:36
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js:194
@@ -8172,6 +8503,8 @@ msgid ""
 "Used for two different purposes: RADIUS NAS ID and 802.11r R0KH-ID. Not "
 "needed with normal WPA(2)-PSK."
 msgstr ""
+"Se utilizează în două scopuri diferite: RADIUS NAS ID și 802.11r R0KH-ID. Nu "
+"este necesar cu WPA(2)-PSK normal."
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:111
 msgid "User Group"
@@ -8179,7 +8512,7 @@ msgstr "Grup de utilizatori"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:120
 msgid "User certificate (PEM encoded)"
-msgstr ""
+msgstr "Certificat de utilizator (codificat PEM)"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:132
 msgid "User key (PEM encoded)"
@@ -8204,7 +8537,7 @@ msgstr "VDSL"
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:435
 msgctxt "MACVLAN mode"
 msgid "VEPA (Virtual Ethernet Port Aggregator)"
-msgstr ""
+msgstr "VEPA (Agregator virtual de porturi Ethernet)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:346
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1394
@@ -8239,48 +8572,50 @@ msgstr "Port local VPN"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:96
 msgid "VPN Protocol"
-msgstr ""
+msgstr "Protocol VPN"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:102
 #: protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js:42
 #: protocols/luci-proto-ppp/htdocs/luci-static/resources/protocol/pptp.js:58
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:39
 msgid "VPN Server"
-msgstr ""
+msgstr "Server VPN"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:105
 #: protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js:45
 msgid "VPN Server port"
-msgstr ""
+msgstr "Portul serverului VPN"
 
 #: protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js:109
 #: protocols/luci-proto-openfortivpn/htdocs/luci-static/resources/protocol/openfortivpn.js:60
 msgid "VPN Server's certificate SHA1 hash"
-msgstr ""
+msgstr "Certificatul serverului VPN hash SHA1"
 
 #: modules/luci-compat/luasrc/model/network/proto_vpnc.lua:9
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:9
 msgid "VPNC (CISCO 3000 (and others) VPN)"
-msgstr ""
+msgstr "VPNC (CISCO 3000 (și altele) VPN)"
 
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan.js:10
 msgid "VXLAN (RFC7348)"
-msgstr ""
+msgstr "VXLAN (RFC7348)"
 
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan.js:53
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:48
 msgid "VXLAN network identifier"
-msgstr ""
+msgstr "Identificatorul rețelei VXLAN"
 
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:10
 msgid "VXLANv6 (RFC7348)"
-msgstr ""
+msgstr "VXLANv6 (RFC7348)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:397
 msgid ""
 "Validate DNS replies and cache DNSSEC data, requires upstream to support "
 "DNSSEC."
 msgstr ""
+"Validează răspunsurile DNS și stochează datele DNSSEC în memoria cache; este "
+"necesar ca în amonte să fie acceptat DNSSEC."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1571
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1629
@@ -8288,18 +8623,20 @@ msgid ""
 "Validate server certificate using built-in system CA bundle,<br />requires "
 "the \"ca-bundle\" package"
 msgstr ""
+"Validați certificatul serverului utilizând pachetul CA de sistem "
+"încorporat,<br />necesită pachetul \"ca-bundle\""
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:388
 msgid "Validation for all slaves"
-msgstr ""
+msgstr "Validare pentru toți sclavii"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:386
 msgid "Validation only for active slave"
-msgstr ""
+msgstr "Validare numai pentru sclavul activ"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:387
 msgid "Validation only for backup slaves"
-msgstr ""
+msgstr "Validare numai pentru sclavii de rezervă"
 
 #: protocols/luci-proto-vpnc/htdocs/luci-static/resources/protocol/vpnc.js:73
 msgid "Vendor"
@@ -8307,11 +8644,13 @@ msgstr "Furnizor"
 
 #: modules/luci-base/htdocs/luci-static/resources/protocol/dhcp.js:40
 msgid "Vendor Class to send when requesting DHCP"
-msgstr ""
+msgstr "Clasa furnizorului care trebuie trimisă la solicitarea DHCP"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:402
 msgid "Verify unsigned domain responses really come from unsigned domains."
 msgstr ""
+"Verificați dacă răspunsurile din domenii nesemnate provin într-adevăr din "
+"domenii nesemnate."
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:196
 msgid "Verifying the uploaded image file."
@@ -8392,6 +8731,9 @@ msgid ""
 "When delegating prefixes to multiple downstreams, interfaces with a higher "
 "preference value are considered first when allocating subnets."
 msgstr ""
+"Atunci când se deleagă prefixe la mai multe fluxuri descendente, interfețele "
+"cu o valoare de preferință mai mare sunt luate în considerare mai întâi la "
+"alocarea subrețelelor."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1533
 msgid ""
@@ -8399,6 +8741,9 @@ msgid ""
 "R0/R1 key options below are not applied. Disable this to use the R0 and R1 "
 "key options."
 msgstr ""
+"Atunci când se utilizează un PSK, PMK poate fi generat automat. Atunci când "
+"este activată, opțiunile de cheie R0/R1 de mai jos nu se aplică. Dezactivați "
+"acest lucru pentru a utiliza opțiunile de cheie R0 și R1."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1143
 msgid ""
@@ -8413,6 +8758,8 @@ msgid ""
 "Where the ESSID is hidden, clients may fail to roam and airtime efficiency "
 "may be significantly reduced."
 msgstr ""
+"În cazul în care ESSID este ascuns, este posibil ca clienții să nu reușească "
+"să se deplaseze, iar eficiența timpului de antenă să fie redusă semnificativ."
 
 #: modules/luci-compat/luasrc/view/cbi/wireless_modefreq.htm:166
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:520
@@ -8484,7 +8831,7 @@ msgstr "Scrieți jurnalul de sistem într-un fișier"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:206
 msgid "XOR policy (balance-xor, 2)"
-msgstr ""
+msgstr "Politica XOR (balance-xor, 2)"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:3886
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:297
@@ -8501,6 +8848,8 @@ msgid ""
 "You appear to be currently connected to the device via the \"%h\" interface. "
 "Do you really want to shut down the interface?"
 msgstr ""
+"Se pare că sunteți conectat în prezent la dispozitiv prin intermediul "
+"interfeței \"%h\". Chiar doriți să închideți interfața?"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js:112
 msgid ""
@@ -8508,6 +8857,10 @@ msgid ""
 "after a device reboot.<br /><strong>Warning: If you disable essential init "
 "scripts like \"network\", your device might become inaccessible!</strong>"
 msgstr ""
+"Aici puteți activa sau dezactiva scripturile de init instalate. Modificările "
+"se vor aplica după o repornire a dispozitivului.<br /><strong>Atenție: Dacă "
+"dezactivați scripturi init esențiale, cum ar fi \"network\", dispozitivul "
+"dvs. ar putea deveni inaccesibil!</strong>"
 
 #: themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm:80
 #: themes/luci-theme-material/luasrc/view/themes/material/header.htm:97
@@ -8523,11 +8876,15 @@ msgid ""
 "You must select a primary interface which is included in selected slave "
 "interfaces!"
 msgstr ""
+"Trebuie să selectați o interfață primară care să fie inclusă în interfețele "
+"secundare selectate!"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:98
 msgid ""
 "You must select at least one ARP IP target if ARP monitoring is selected!"
 msgstr ""
+"Trebuie să selectați cel puțin o țintă IP ARP dacă este selectată "
+"monitorizarea ARP!"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js:212
 msgid "ZRam Compression Algorithm"
@@ -8566,7 +8923,7 @@ msgstr "automat"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:82
 msgid "baseT"
-msgstr ""
+msgstr "bazăT"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1565
 msgid "bridged"
@@ -8641,11 +8998,11 @@ msgstr "driver implicit"
 
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:66
 msgid "e.g: --proxy 10.10.10.10"
-msgstr ""
+msgstr "de exemplu: --proxy 10.10.10.10"
 
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:68
 msgid "e.g: dump"
-msgstr ""
+msgstr "de exemplu: dump"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:725
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:746
@@ -8662,7 +9019,7 @@ msgstr "forțat"
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:195
 #: modules/luci-compat/luasrc/view/cbi/firewall_zonelist.htm:61
 msgid "forward"
-msgstr ""
+msgstr "redirecționare"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:97
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:84
@@ -8709,7 +9066,7 @@ msgstr "cheie cu 5 sau 13 caractere"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:793
 msgid "managed config (M)"
-msgstr ""
+msgstr "configurație gestionată (M)"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1389
 msgid "medium security"
@@ -8721,11 +9078,11 @@ msgstr "minute"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:797
 msgid "mobile home agent (H)"
-msgstr ""
+msgstr "agent pentru case mobile (H)"
 
 #: protocols/luci-proto-bonding/htdocs/luci-static/resources/protocol/bonding.js:423
 msgid "netif_carrier_ok()"
-msgstr ""
+msgstr "netif_carrier_ok()"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:47
 msgid "no"
@@ -8739,7 +9096,7 @@ msgstr "fără legătură"
 #: modules/luci-base/htdocs/luci-static/resources/form.js:2244
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:59
 msgid "non-empty value"
-msgstr ""
+msgstr "valoare nevidă"
 
 #: modules/luci-base/htdocs/luci-static/resources/form.js:3216
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:800
@@ -8760,7 +9117,7 @@ msgstr "oprit"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:778
 msgid "on available prefix"
-msgstr ""
+msgstr "cu privire la prefixul disponibil"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1390
 msgid "open network"
@@ -8768,30 +9125,30 @@ msgstr "rețea deschisă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:795
 msgid "other config (O)"
-msgstr ""
+msgstr "altă configurație (O)"
 
 #: modules/luci-base/htdocs/luci-static/resources/tools/widgets.js:69
 #: modules/luci-compat/luasrc/view/cbi/firewall_zonelist.htm:46
 msgid "output"
-msgstr ""
+msgstr "ieșire"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:252
 msgid "positive decimal value"
-msgstr ""
+msgstr "valoare zecimală pozitivă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:244
 msgid "positive integer value"
-msgstr ""
+msgstr "valoare întreagă pozitivă"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:132
 msgid "random"
-msgstr ""
+msgstr "aleatoriu"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:769
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:877
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:911
 msgid "relay mode"
-msgstr ""
+msgstr "mod releu"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1566
 msgid "routed"
@@ -8800,16 +9157,16 @@ msgstr "rutat"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1166
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1175
 msgid "sec"
-msgstr ""
+msgstr "secundă"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:767
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:875
 msgid "server mode"
-msgstr ""
+msgstr "mod server"
 
 #: protocols/luci-proto-sstp/htdocs/luci-static/resources/protocol/sstp.js:54
 msgid "sstpc Log-level"
-msgstr ""
+msgstr "sstpc Nivel de jurnal"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1388
 msgid "strong security"
@@ -8821,7 +9178,7 @@ msgstr "etichetat"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1521
 msgid "time units (TUs / 1.024 ms) [1000-65535]"
-msgstr ""
+msgstr "unități de timp (TUs / 1.024 ms) [1000-65535]"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/uhttpd.js:9
 msgid ""
@@ -8829,10 +9186,13 @@ msgid ""
 "<abbr title=\"Hypertext Transfer Protocol Secure\">HTTPS</abbr> network "
 "access."
 msgstr ""
+"uHTTPd oferă <abbr title=\"Hypertext Transfer Protocol\">HTTP</abbr> sau "
+"<abbr title=\"Hypertext Transfer Protocol Secure\">HTTPS</abbr> acces la "
+"rețea."
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:574
 msgid "unique value"
-msgstr ""
+msgstr "valoare unică"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1443
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1455
@@ -8863,7 +9223,7 @@ msgstr "nespecificat"
 
 #: modules/luci-compat/luasrc/view/cbi/network_netlist.htm:71
 msgid "unspecified -or- create:"
-msgstr ""
+msgstr "nespecificat - sau- creați:"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:352
 msgid "untagged"
@@ -8873,65 +9233,65 @@ msgstr "neetichetat"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:175
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:186
 msgid "valid IP address"
-msgstr ""
+msgstr "adresă IP validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:257
 msgid "valid IP address or prefix"
-msgstr ""
+msgstr "adresă IP validă sau prefix"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:294
 msgid "valid IPv4 CIDR"
-msgstr ""
+msgstr "IPv4 CIDR valid"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:265
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:179
 msgid "valid IPv4 address"
-msgstr ""
+msgstr "adresă IPv4 validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:265
 msgid "valid IPv4 address or network"
-msgstr ""
+msgstr "adresă sau rețea IPv4 validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:389
 msgid "valid IPv4 address:port"
-msgstr ""
+msgstr "adresă IPv4 validă:port"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:328
 msgid "valid IPv4 network"
-msgstr ""
+msgstr "rețea IPv4 validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:288
 msgid "valid IPv4 or IPv6 CIDR"
-msgstr ""
+msgstr "CIDR IPv4 sau IPv6 valabil"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:278
 msgid "valid IPv4 prefix value (0-32)"
-msgstr ""
+msgstr "valoarea prefixului IPv4 valabil (0-32)"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:300
 msgid "valid IPv6 CIDR"
-msgstr ""
+msgstr "IPv6 CIDR valid"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:273
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:183
 msgid "valid IPv6 address"
-msgstr ""
+msgstr "adresă IPv6 validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:273
 msgid "valid IPv6 address or prefix"
-msgstr ""
+msgstr "adresă sau prefix IPv6 validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:318
 msgid "valid IPv6 host id"
-msgstr ""
+msgstr "ID gazdă IPv6 validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:333
 msgid "valid IPv6 network"
-msgstr ""
+msgstr "rețea IPv6 validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:283
 msgid "valid IPv6 prefix value (0-128)"
-msgstr ""
+msgstr "valoarea prefixului IPv6 valabil (0-128)"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:355
 msgid "valid MAC address"
@@ -8939,11 +9299,11 @@ msgstr "adresă MAC validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:426
 msgid "valid UCI identifier"
-msgstr ""
+msgstr "identificator UCI valabil"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:377
 msgid "valid UCI identifier, hostname or IP address range"
-msgstr ""
+msgstr "identificator UCI valabil, nume de gazdă sau interval de adrese IP"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:398
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:401
@@ -8969,7 +9329,7 @@ msgstr "cheie WPA hexazecimală validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:383
 msgid "valid host:port"
-msgstr ""
+msgstr "gazdă validă:port"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:370
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:372
@@ -8985,7 +9345,7 @@ msgstr "nume de gazdă sau adresă IP validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:240
 msgid "valid integer value"
-msgstr ""
+msgstr "valoare întreagă validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:355
 msgid "valid multicast MAC address"
@@ -8993,16 +9353,16 @@ msgstr "Adresă MAC multicast validă"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:323
 msgid "valid network in address/netmask notation"
-msgstr ""
+msgstr "rețea validă în notație adresă/mască de rețea"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:523
 msgid "valid phone digit (0-9, \"*\", \"#\", \"!\" or \".\")"
-msgstr ""
+msgstr "cifră de telefon validă (0-9, \"*\", \"#\", \"!\" sau \".\")"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:346
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:349
 msgid "valid port or port range (port1-port2)"
-msgstr ""
+msgstr "port sau interval de porturi valide (port1-port2)"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:338
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:190
@@ -9031,15 +9391,15 @@ msgstr "valoare mai mică sau egală cu %f"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:444
 msgid "value with %d characters"
-msgstr ""
+msgstr "valoare cu %d caractere"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:455
 msgid "value with at least %d characters"
-msgstr ""
+msgstr "valoare cu cel puțin %d caractere"
 
 #: modules/luci-base/htdocs/luci-static/resources/validation.js:460
 msgid "value with at most %d characters"
-msgstr ""
+msgstr "valoare cu cel mult %d caractere"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1390
 msgid "weak security"

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2021-12-16 12:03+0000\n"
+"PO-Revision-Date: 2021-12-19 22:52+0000\n"
 "Last-Translator: Kristoffer Grundström <swedishsailfishosuser@tutanota.com>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/openwrt/luci/sv/>"
 "\n"
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.10-dev\n"
+"X-Generator: Weblate 4.10\n"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1513
 msgid "%.1f dB"
@@ -6372,7 +6372,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:210
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:37
 msgid "Short GI"
-msgstr ""
+msgstr "Kort GI"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1158
 msgid "Short Preamble"


### PR DESCRIPTION
MaxMissed was implemented with positive integers only, whereas I think it should also allow (and default to) the option of "-1" (disabled state) as per collectd documentation