### PR TITLE
sysauth: add autocomplete and id attributes to login inputs

### DIFF
--- a/modules/luci-base/luasrc/view/sysauth.htm
+++ b/modules/luci-base/luasrc/view/sysauth.htm
@@ -20,15 +20,15 @@
 		</div>
 		<div class="cbi-section"><div class="cbi-section-node">
 			<div class="cbi-value">
-				<label class="cbi-value-title"><%:Username%></label>
+				<label class="cbi-value-title" for="luci_username"><%:Username%></label>
 				<div class="cbi-value-field">
-					<input class="cbi-input-text" type="text" name="luci_username" value="<%=duser%>" />
+                    <input class="cbi-input-text" type="text" name="luci_username" id="luci_username" autocomplete="username" value="<%=duser%>" />
 				</div>
 			</div>
 			<div class="cbi-value cbi-value-last">
-				<label class="cbi-value-title"><%:Password%></label>
+				<label class="cbi-value-title" for="luci_password"><%:Password%></label>
 				<div class="cbi-value-field">
-					<input class="cbi-input-text" type="password" name="luci_password" />
+					<input class="cbi-input-text" type="password" name="luci_password" id="luci_password" autocomplete="current-password"/>
 				</div>
 			</div>
 		</div></div>

--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/sysauth.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/sysauth.htm
@@ -17,13 +17,13 @@
 				<div class="cbi-value">
 					<label class="cbi-value-title" for="luci_username"><%:Username%></label>
 					<div class="cbi-value-field">
-						<input name="luci_username" type="text"<%=attr("value", duser)%>>
+						<input name="luci_username" id="luci_username" type="text" autocomplete="username" <%=attr("value", duser)%>>
 					</div>
 				</div>
 				<div class="cbi-value">
 					<label class="cbi-value-title" for="luci_password"><%:Password%></label>
 					<div class="cbi-value-field">
-						<input name="luci_password" type="password">
+						<input name="luci_password" id="luci_password" type="password" autocomplete="current-password">
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
this let browser automatically fill according to HTML spec for input elements.
luci-theme-bootstrap and luci-base are affected.

![image](https://user-images.githubusercontent.com/11594423/147349966-81d341f1-3176-42cb-81ec-aeb4e4626eca.png)
