### PR TITLE
luci-app-https-dns-proxy: massive providers update

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2021-09-27-2
+PKG_VERSION:=2021-09-27-3
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/app.tiar.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/app.tiar.doh.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh.tiar.app",
+	label = _("Tiarap Public DNS - SG"),
+	resolver_url = "https://doh.tiar.app/dns-query",
+	bootstrap_dns = "174.138.21.128,2400:6180:0:d0::5f6e:4001",
+	help_link = "https://tiarap.org/",
+	help_link_text = "Tiarap.org"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/app.tiar.jp.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/app.tiar.jp.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh.tiar.jp",
+	label = _("Tiarap Public DNS - JP"),
+	resolver_url = "https://doh.tiar.jp/dns-query",
+	bootstrap_dns = "172.104.93.80,2400:8902::f03c:91ff:feda:c514",
+	help_link = "https://tiarap.org/",
+	help_link_text = "Tiarap.org"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua
@@ -1,5 +1,5 @@
 return {
-	name = "cira-canadian-shield-family",
+	name = "family.canadianshield.cira.ca",
 	label = _("CIRA Canadian Shield (Family)"),
 	resolver_url = "https://family.canadianshield.cira.ca/dns-query",
 	bootstrap_dns = "149.112.121.30,149.112.122.30,2620:10A:80BB::30,2620:10A:80BC::30",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.private.lua
@@ -1,5 +1,5 @@
 return {
-	name = "cira-canadian-shield-private",
+	name = "private.canadianshield.cira.ca",
 	label = _("CIRA Canadian Shield (Private)"),
 	resolver_url = "https://private.canadianshield.cira.ca/dns-query",
 	bootstrap_dns = "149.112.121.10,149.112.122.10,2620:10A:80BB::10,2620:10A:80BC::10",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua
@@ -1,5 +1,5 @@
 return {
-	name = "cira-canadian-shield-protected",
+	name = "protected.canadianshield.cira.ca",
 	label = _("CIRA Canadian Shield (Protected)"),
 	resolver_url = "https://protected.canadianshield.cira.ca/dns-query",
 	bootstrap_dns = "149.112.121.20,149.112.122.20,2620:10A:80BB::20,2620:10A:80BC::20",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.digitale-gesellschaft.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.digitale-gesellschaft.dns.lua
@@ -1,7 +1,9 @@
 return {
-	name = "Digitale-Gesellschaft",
-	label = _("Digitale Gesellschaft"),
+	name = "dns.digitale-gesellschaft.ch",
+	label = _("Digitale Gesellschaft - CH"),
 	resolver_url = "https://dns.digitale-gesellschaft.ch/dns-query",
 	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
-	http2_only = true
+	http2_only = true,
+	help_link = "https://www.digitale-gesellschaft.ch/dns/",
+	help_link_text = "Digitale Gesellschaft"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.switch.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.switch.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "dns.switch.ch",
+	label = _("Switch DNS - CH"),
+	resolver_url = "https://dns.switch.ch/dns-query",
+	bootstrap_dns = "130.59.31.248,2001:620:0:ff::2",
+	help_link = "https://www.switch.ch/security/info/public-dns/",
+	help_link_text = "Switch.ch"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.360.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.360.doh.lua
@@ -1,0 +1,6 @@
+return {
+	name = "doh.360.cn",
+	label = _("360 Secure DNS - CN"),
+	resolver_url = "https://doh.360.cn/dns-query",
+	bootstrap_dns = "101.226.4.6,218.30.118.6,123.125.81.6,140.207.198.6"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.rubyfish.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.rubyfish.dns.lua
@@ -1,5 +1,5 @@
 return {
-	name = "rubyfish.cn",
+	name = "dns.rubyfish.cn",
 	label = _("rubyfish.cn"),
 	resolver_url = "https://dns.rubyfish.cn/dns-query",
 	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/co.osxz.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/co.osxz.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "dns.oszx.co",
+	label = _("OSZX DNS - UK"),
+	resolver_url = "https://dns.oszx.co/dns-query",
+	bootstrap_dns = "51.38.83.141,2001:41d0:801:2000::d64",
+	help_link = "https://dns.oszx.co/#mdoh",
+	help_link_text = "OSZX.co"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua
@@ -1,5 +1,5 @@
 return {
-	name = "AdGuard-Family",
+	name = "dns-family.adguard.com",
 	label = _("AdGuard (Family Protection)"),
 	resolver_url = "https://dns-family.adguard.com/dns-query",
 	bootstrap_dns = "176.103.130.132,176.103.130.134",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua
@@ -1,5 +1,5 @@
 return {
-	name = "AdGuard-Standard",
+	name = "dns.adguard.com",
 	label = _("AdGuard (Standard)"),
 	resolver_url = "https://dns.adguard.com/dns-query",
 	bootstrap_dns = "176.103.130.130,176.103.130.131",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.ahadns.blitz.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.ahadns.blitz.lua
@@ -1,0 +1,8 @@
+return {
+	name = "blitz.ahadns.com",
+	label = _("AhaDNS Blitz (Configurable)"),
+	resolver_url = "https://blitz.ahadns.com/",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://blitz-setup.ahadns.com/",
+	help_link_text = "AhaDNS Blitz"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.alidns.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.alidns.dns.lua
@@ -1,6 +1,8 @@
 return { 
-	name="AliDNS",
-	label=_("AliDNS"),
+	name="dns.alidns.com",
+	label=_("AliDNS - CN"),
 	resolver_url="https://dns.alidns.com/dns-query",
-	bootstrap_dns="223.5.5.5,223.6.6.6,2400:3200::1,2400:3200:baba::1"
+	bootstrap_dns="223.5.5.5,223.6.6.6,2400:3200::1,2400:3200:baba::1",
+	help_link = "https://alidns.com/",
+	help_link_text = "AliDNS.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-ch.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-ch.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh-ch.blahdns.com",
+	label = _("BlahDNS - CH"),
+	resolver_url = "https://doh-ch.blahdns.com/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://blahdns.com/",
+	help_link_text = "BlahDNS.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-de.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-de.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh-de.blahdns.com",
+	label = _("BlahDNS - DE"),
+	resolver_url = "https://doh-de.blahdns.com/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://blahdns.com/",
+	help_link_text = "BlahDNS.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-fi.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-fi.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh-fi.blahdns.com",
+	label = _("BlahDNS - FI"),
+	resolver_url = "https://doh-fi.blahdns.com/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://blahdns.com/",
+	help_link_text = "BlahDNS.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-jp.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-jp.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh-jp.blahdns.com",
+	label = _("BlahDNS - JP"),
+	resolver_url = "https://doh-jp.blahdns.com/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://blahdns.com/",
+	help_link_text = "BlahDNS.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-sg.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-sg.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh-sg.blahdns.com",
+	label = _("BlahDNS - SG"),
+	resolver_url = "https://doh-sg.blahdns.com/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://blahdns.com/",
+	help_link_text = "BlahDNS.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.family.lua
@@ -1,8 +1,8 @@
 return {
-	name = "Cloudflare-Family",
+	name = "family.cloudflare-dns.com",
 	label = _("Cloudflare (Family Protection)"),
 	resolver_url = "https://family.cloudflare-dns.com/dns-query",
 	bootstrap_dns = "1.1.1.3,1.0.0.3,2606:4700:4700::1113,2606:4700:4700::1003",
 	help_link = "https://one.one.one.one/family/",
-	help_link_text = "Cloudflare"
+	help_link_text = "Cloudflare.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.lua
@@ -1,9 +1,9 @@
 return {
-	name = "Cloudflare",
+	name = "cloudflare-dns.com",
 	label = _("Cloudflare"),
 	resolver_url = "https://cloudflare-dns.com/dns-query",
 	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001",
 	help_link = "https://one.one.one.one/family/",
-	help_link_text = "Cloudflare",
+	help_link_text = "Cloudflare.com",
 	default = true
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.security.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.cloudflare-dns.security.lua
@@ -1,8 +1,8 @@
 return {
-	name = "Cloudflare-Security",
+	name = "security.cloudflare-dns.com",
 	label = _("Cloudflare (Security Protection)"),
 	resolver_url = "https://security.cloudflare-dns.com/dns-query",
 	bootstrap_dns = "1.1.1.2,1.0.0.2,2606:4700:4700::1112,2606:4700:4700::1002",
 	help_link = "https://one.one.one.one/family/",
-	help_link_text = "Cloudflare"
+	help_link_text = "Cloudflare.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.family.lua
@@ -1,8 +1,8 @@
 return {
-	name = "ControlD-Family",
+	name = "freedns.controld.com-family",
 	label = _("ControlD (Family)"),
 	resolver_url = "https://freedns.controld.com/family",
 	bootstrap_dns = "76.76.2.4,2606:1a40::4",
 	help_link = "https://kb.controld.com/tutorials",
-	help_link_text = "ControlD"
+	help_link_text = "ControlD.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p0.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p0.lua
@@ -1,0 +1,8 @@
+return {
+	name = "freedns.controld.com-p0",
+	label = _("ControlD (Unfiltered)"),
+	resolver_url = "https://freedns.controld.com/p0",
+	bootstrap_dns = "76.76.2.0,2606:1a40::0",
+	help_link = "https://kb.controld.com/tutorials",
+	help_link_text = "ControlD.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p1.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p1.lua
@@ -1,0 +1,8 @@
+return {
+	name = "freedns.controld.com-p1",
+	label = _("ControlD (Block Malware)"),
+	resolver_url = "https://freedns.controld.com/p1",
+	bootstrap_dns = "76.76.2.1,2606:1a40::1",
+	help_link = "https://kb.controld.com/tutorials",
+	help_link_text = "ControlD.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p2.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p2.lua
@@ -1,0 +1,8 @@
+return {
+	name = "freedns.controld.com-p2",
+	label = _("ControlD (Block Malware + Ads)"),
+	resolver_url = "https://freedns.controld.com/p2",
+	bootstrap_dns = "76.76.2.2,2606:1a40::2",
+	help_link = "https://kb.controld.com/tutorials",
+	help_link_text = "ControlD.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p3.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p3.lua
@@ -1,0 +1,8 @@
+return {
+	name = "freedns.controld.com-p3",
+	label = _("ControlD (Block Malware + Ads + Social)"),
+	resolver_url = "https://freedns.controld.com/p3",
+	bootstrap_dns = "76.76.2.3,2606:1a40::3",
+	help_link = "https://kb.controld.com/tutorials",
+	help_link_text = "ControlD.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.decloudus.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.decloudus.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "dns.decloudus.com",
+	label = _("DeCloudUs DNS"),
+	resolver_url = "https://dns.decloudus.com/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://decloudus.com/",
+	help_link_text = "DeCloudUs.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.dnsforfamily.dns-doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.dnsforfamily.dns-doh.lua
@@ -1,0 +1,8 @@
+return {
+	name = "dnsforfamily",
+	label = _("DNS For Family"),
+	resolver_url = "https://dns-doh.dnsforfamily.com/dns-query",
+	bootstrap_dns = "94.130.180.225,78.47.64.161",
+	help_link = "https://dnsforfamily.com/#DNS_Servers_DNS_Over_HTTPS",
+	help_link_text = "DNSForFamily.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.dnslify.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.dnslify.doh.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh.dnslify.com",
+	label = _("DNSlify DNS"),
+	resolver_url = "https://doh.dnslify.com/dns-query",
+	bootstrap_dns = "185.235.81.1,185.235.81.2,2a0d:4d00:81::1,2a0d:4d00:81::2",
+	help_link = "https://www.dnslify.com/services/doh/",
+	help_link_text = "DNSlify.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.opendns.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.opendns.doh.lua
@@ -1,8 +1,8 @@
 return {
-	name = "OpenDNS",
+	name = "doh.opendns.com",
 	label = _("OpenDNS"),
 	resolver_url = "https://doh.opendns.com/dns-query",
 	bootstrap_dns = "208.67.222.222,208.67.220.220",
 	help_link = "https://support.opendns.com/hc/en-us/articles/360038086532-Using-DNS-over-HTTPS-DoH-with-OpenDNS",
-	help_link_text = "OpenDNS"
+	help_link_text = "OpenDNS.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.opendns.familyshield.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.opendns.familyshield.doh.lua
@@ -1,8 +1,8 @@
 return {
-	name = "OpenDNS-FamilyShield",
+	name = "doh.familyshield.opendns.com",
 	label = _("OpenDNS (Family Shield)"),
 	resolver_url = "https://doh.familyshield.opendns.com/dns-query",
 	bootstrap_dns = "208.67.222.123,208.67.220.123",
 	help_link = "https://support.opendns.com/hc/en-us/articles/360038086532-Using-DNS-over-HTTPS-DoH-with-OpenDNS",
-	help_link_text = "OpenDNS"
+	help_link_text = "OpenDNS.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.pumplex.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.pumplex.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "dns.pumplex.com",
+	label = _("OSZX DNS (Pumplex)"),
+	resolver_url = "https://dns.pumplex.com/dns-query",
+	bootstrap_dns = "51.38.82.198,2001:41d0:801:2000::1b28",
+	help_link = "https://dns.oszx.co/#mdoh",
+	help_link_text = "OSZX.co"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.rethinkdns.basic.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.rethinkdns.basic.lua
@@ -1,0 +1,8 @@
+return {
+	name = "basic.rethinkdns.com",
+	label = _("Rethink DNS (Configurable)"),
+	resolver_url = "https://basic.rethinkdns.com/",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://www.rethinkdns.com/configure",
+	help_link_text = "RethinkDNS.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua
@@ -1,6 +1,8 @@
 return {
-	name = "odvr-nic-cz",
+	name = "odvr.nic.cz",
 	label = _("ODVR (nic.cz)"),
 	resolver_url = "https://odvr.nic.cz/doh",
-	bootstrap_dns = "193.17.47.1,185.43.135.1,2001:148f:ffff::1,2001:148f:fffe::1"
+	bootstrap_dns = "193.17.47.1,185.43.135.1,2001:148f:ffff::1,2001:148f:fffe::1",
+	help_link = "https://www.nic.cz/odvr/",
+	help_link_text = "nic.cz"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/de.dnsforge.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/de.dnsforge.lua
@@ -1,0 +1,8 @@
+return {
+	name = "dnsforge.de",
+	label = _("DNS Forge - DE"),
+	resolver_url = "https://dnsforge.de/dns-query",
+	bootstrap_dns = "176.9.93.198,176.9.1.117,2a01:4f8:151:34aa::198,2a01:4f8:141:316d::117",
+	help_link = "https://dnsforge.de/",
+	help_link_text = "DNSForge.de"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/fi.lelux.resolver-eu.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/fi.lelux.resolver-eu.lua
@@ -1,0 +1,8 @@
+return {
+	name = "resolver-eu.lelux.fi",
+	label = _("Lelux DNS - FI"),
+	resolver_url = "https://resolver-eu.lelux.fi/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://lelux.fi/resolver/",
+	help_link_text = "Lelux.fi"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/google.dns.lua
@@ -1,5 +1,5 @@
 return {
-	name = "Google",
+	name = "dns.google",
 	label = _("Google"),
 	resolver_url = "https://dns.google/dns-query",
 	bootstrap_dns = "8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844"

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua
@@ -1,6 +1,6 @@
 return {
-	name = "LibreDNS (No Ads)",
-	label = _("LibreDNS (No Ads)"),
+	name = "doh.libredns.gr-ads",
+	label = _("LibreDNS - GR (No Ads)"),
 	resolver_url = "https://doh.libredns.gr/ads",
 	bootstrap_dns = "116.202.176.26,1.1.1.1",
 	help_link = "https://libredns.gr/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "LibreDNS",
-	label = _("LibreDNS"),
+	name = "doh.libredns.gr",
+	label = _("LibreDNS - GR"),
 	resolver_url = "https://doh.libredns.gr/dns-query",
 	bootstrap_dns = "116.202.176.26,1.1.1.1",
 	help_link = "https://libredns.gr/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua
@@ -1,6 +1,6 @@
 return {
-	name = "NextDNS.io",
-	label = _("NextDNS.io"),
+	name = "dns.nextdns.io",
+	label = _("NextDNS.io (Configurable)"),
 	resolver_url = "https://dns.nextdns.io/",
 	bootstrap_dns = "45.90.28.49,45.90.30.49",
 	help_link = " https://my.nextdns.io",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.seby.doh-2.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.seby.doh-2.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh-2.seby.io",
+	label = _("Seby DNS - AU"),
+	resolver_url = "https://doh-2.seby.io/dns-query",
+	bootstrap_dns = "45.76.113.31,139.99.222.72",
+	help_link = "https://dns.seby.io/",
+	help_link_text = "Seby.io"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/jp.iij.dns.public.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/jp.iij.dns.public.lua
@@ -1,0 +1,8 @@
+return {
+	name = "public.dns.iij.jp",
+	label = _("IIJ Public DNS - JP"),
+	resolver_url = "https://public.dns.iij.jp/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://www.iij.ad.jp/",
+	help_link_text = "IIJ.ad.jp"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/lu.restena.kaitain.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/lu.restena.kaitain.lua
@@ -1,0 +1,8 @@
+return {
+	name = "kaitain.restena.lu",
+	label = _("Restena DNS - LU"),
+	resolver_url = "https://kaitain.restena.lu/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://www.restena.lu/en/service/public-dns-resolver",
+	help_link_text = "Restena.lu"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.au.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.au.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-au",
-	label = _("AhaDNS.com - Australia (Block Malware + Ads)"),
+	name = "doh.au.ahadns.net",
+	label = _("AhaDNS - AU (Block Malware + Ads)"),
 	resolver_url = "https://doh.au.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.chi.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.chi.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-chi",
-	label = _("AhaDNS.com - US/Chicago (Block Malware + Ads)"),
+	name = "doh.chi.ahadns.net",
+	label = _("AhaDNS - US/Chicago (Block Malware + Ads)"),
 	resolver_url = "https://doh.chi.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.es.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.es.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-es",
-	label = _("AhaDNS.com - Spain (Block Malware + Ads)"),
+	name = "doh.es.ahadns.net",
+	label = _("AhaDNS - ES (Block Malware + Ads)"),
 	resolver_url = "https://doh.es.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.in.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.in.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-in",
-	label = _("AhaDNS.com - India (Block Malware + Ads)"),
+	name = "doh.in.ahadns.net",
+	label = _("AhaDNS - IN (Block Malware + Ads)"),
 	resolver_url = "https://doh.in.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.it.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.it.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-it",
-	label = _("AhaDNS.com - Italy (Block Malware + Ads)"),
+	name = "doh.it.ahadns.net",
+	label = _("AhaDNS - IT (Block Malware + Ads)"),
 	resolver_url = "https://doh.it.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.la.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.la.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-la",
-	label = _("AhaDNS.com - US/Los Angeles (Block Malware + Ads)"),
+	name = "doh.la.ahadns.net",
+	label = _("AhaDNS - US/Los Angeles (Block Malware + Ads)"),
 	resolver_url = "https://doh.la.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.nl.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.nl.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-nl",
-	label = _("AhaDNS.com - Netherlands (Block Malware + Ads)"),
+	name = "doh.nl.ahadns.net",
+	label = _("AhaDNS - NL (Block Malware + Ads)"),
 	resolver_url = "https://doh.nl.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.no.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.no.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-no",
-	label = _("AhaDNS.com - Norway (Block Malware + Ads)"),
+	name = "doh.no.ahadns.net",
+	label = _("AhaDNS - NO (Block Malware + Ads)"),
 	resolver_url = "https://doh.no.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.ny.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.ny.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-ny",
-	label = _("AhaDNS.com - US/New York (Block Malware + Ads)"),
+	name = "doh.ny.ahadns.net",
+	label = _("AhaDNS - US/New York (Block Malware + Ads)"),
 	resolver_url = "https://doh.ny.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.pl.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.pl.doh.lua
@@ -1,6 +1,6 @@
 return {
-	name = "ahadns-doh-pl",
-	label = _("AhaDNS.com - Poland (Block Malware + Ads)"),
+	name = "doh.pl.ahadns.net",
+	label = _("AhaDNS - PL (Block Malware + Ads)"),
 	resolver_url = "https://doh.pl.ahadns.net/dns-query",
 	bootstrap_dns = "185.213.26.187,45.67.219.208,5.2.75.75,45.79.120.233,2a0d:5600:33:3::3,2a04:bdc7:100:70::70,2a04:52c0:101:75::75,2400:8904:e001:43::43",
 	help_link = "https://ahadns.com/dns-over-https/",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.applied-privacy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.applied-privacy.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh.applied-privacy.net",
+	label = _("Applied Privacy DNS - AT/DE"),
+	resolver_url = "https://doh.applied-privacy.net/query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://applied-privacy.net/services/dns/",
+	help_link_text = "Applied-Privacy.net"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.cfiec.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.cfiec.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "dns.cfiec.net",
+	label = _("CFIEC Public DNS (IPv6 Only)"),
+	resolver_url = "https://dns.cfiec.net/dns-query",
+	bootstrap_dns = "240C::6666,240C::6644"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ffmuc.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ffmuc.doh.lua
@@ -1,0 +1,8 @@
+return {
+	name = "doh.ffmuc.net",
+	label = _("FFMUC DNS - DE"),
+	resolver_url = "https://doh.ffmuc.net/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://ffmuc.net/wiki/doku.php?id=knb:dohdot",
+	help_link_text = "FFMUC.net"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.he.ordns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.he.ordns.lua
@@ -1,8 +1,8 @@
 return {
-        name = "HurricaneElectric",
-        label = _("Hurricane Electric"),
-        resolver_url = "https://ordns.he.net/dns-query",
-        bootstrap_dns = "74.82.42.42,2001:470:20::2",
-        help_link = "https://forums.he.net/index.php?topic=3996.0",
-        help_link_text = "he.net"
+	name = "ordns.he.net",
+	label = _("Hurricane Electric"),
+	resolver_url = "https://ordns.he.net/dns-query",
+	bootstrap_dns = "74.82.42.42,2001:470:20::2",
+	help_link = "https://forums.he.net/index.php?topic=3996.0",
+	help_link_text = "he.net"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.idnet.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.idnet.doh.lua
@@ -1,6 +1,6 @@
 return{
-	name = "IDNet (UK)",
-	label = _("IDNet.net (UK)"),
+	name = "doh.idnet.net",
+	label = _("IDNet.net - UK"),
 	resolver_url = "https://doh.idnet.net/dns-query",
 	bootstrap_dns = "212.69.36.23,212.69.40.23"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.adblocker.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.adblocker.lua
@@ -1,5 +1,5 @@
 return {
-	name="mullvad-adblock",
+	name="adblock.doh.mullvad.net",
 	label=_("Mullvad (AdBlock)"),
 	resolver_url="https://adblock.doh.mullvad.net/dns-query",
 	bootstrap_dns="1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.mullvad.doh.lua
@@ -1,5 +1,5 @@
 return {
-	name="mullvad",
+	name="doh.mullvad.net",
 	label=_("Mullvad"),
 	resolver_url="https://doh.mullvad.net/dns-query",
 	bootstrap_dns="1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua
@@ -1,5 +1,5 @@
 return {
-	name = "Quad9-Recommended",
+	name = "dns.quad9.net",
 	label = _("Quad 9 (Recommended)"),
 	resolver_url = "https://dns.quad9.net/dns-query",
 	bootstrap_dns = "9.9.9.9,149.112.112.112,2620:fe::fe,2620:fe::9",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns10.lua
@@ -1,5 +1,5 @@
 return {
-	name = "Quad9-Unsecured",
+	name = "dns10.quad9.net",
 	label = _("Quad 9 (Unsecured)"),
 	resolver_url = "https://dns10.quad9.net/dns-query",
 	bootstrap_dns = "9.9.9.10,149.112.112.10,2620:fe::10,2620:fe::fe:10",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns11.lua
@@ -1,5 +1,5 @@
 return {
-	name = "Quad9-ECS",
+	name = "dns11.quad9.net",
 	label = _("Quad 9 (Secured with ECS Support)"),
 	resolver_url = "https://dns11.quad9.net/dns-query",
 	bootstrap_dns = "9.9.9.11,149.112.112.11,2620:fe::11,2620:fe::fe:11",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns9.lua
@@ -1,5 +1,5 @@
 return {
-	name = "Quad9-Secured",
+	name = "dns9.quad9.net",
 	label = _("Quad 9 (Secured)"),
 	resolver_url = "https://dns9.quad9.net/dns-query",
 	bootstrap_dns = "9.9.9.9,149.112.112.9,2620:fe::fe,2620:fe::9",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/one.comss.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/one.comss.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "dns.comss.one",
+	label = _("Comss.ru DNS (West)"),
+	resolver_url = "https://dns.comss.one/dns-query",
+	bootstrap_dns = "92.38.152.163,93.115.24.204,2a03:90c0:56::1a5,2a02:7b40:5eb0:e95d::1"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/one.comss.east.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/one.comss.east.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "dns.east.comss.one",
+	label = _("Comss.ru DNS (East)"),
+	resolver_url = "https://dns.east.comss.one/dns-query",
+	bootstrap_dns = "92.223.109.31,91.230.211.67,2a03:90c0:b5::1a,2a04:2fc0:39::47"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua
@@ -1,5 +1,5 @@
 return {
-	name = "CleanBrowsing-Adult",
+	name = "doh.cleanbrowsing.org-doh-adult-filter",
 	label = _("CleanBrowsing (Adult Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/adult-filter/",
 	bootstrap_dns = "185.228.168.168,1.1.1.1",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-family.lua
@@ -1,5 +1,5 @@
 return {
-	name = "CleanBrowsing-Family",
+	name = "doh.cleanbrowsing.org-doh-family-filter",
 	label = _("CleanBrowsing (Family Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/family-filter/",
 	bootstrap_dns = "185.228.168.168,1.1.1.1",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-security.lua
@@ -1,5 +1,5 @@
 return {
-	name = "CleanBrowsing-Security",
+	name = "doh.cleanbrowsing.org-doh-security-filter",
 	label = _("CleanBrowsing (Security Filter)"),
 	resolver_url = "https://doh.cleanbrowsing.org/doh/security-filter/",
 	bootstrap_dns = "185.228.168.168,1.1.1.1",

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.snopyta.dns.doh.fi.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.snopyta.dns.doh.fi.lua
@@ -1,0 +1,8 @@
+return {
+	name = "fi.doh.dns.snopyta.org",
+	label = _("Snopyta DNS - FI"),
+	resolver_url = "https://fi.doh.dns.snopyta.org/dns-query",
+	bootstrap_dns = "1.1.1.1,1.0.0.1,2606:4700:4700::1111,2606:4700:4700::1001,8.8.8.8,8.8.4.4,2001:4860:4860::8888,2001:4860:4860::8844",
+	help_link = "https://snopyta.org/service/dns/",
+	help_link_text = "Snopyta.org"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/pub.doh.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/pub.doh.lua
@@ -1,6 +1,8 @@
 return{
-	name = "DNSPod-cn-Public-DNS",
-	label = _("DNSPod.cn Public DNS"),
+	name = "doh.pub",
+	label = _("DNSPod Public DNS - CN"),
 	resolver_url = "https://doh.pub/dns-query",
-	bootstrap_dns = "119.29.29.29,119.28.28.28"
+	bootstrap_dns = "119.29.29.29,119.28.28.28",
+	help_link = "https://www.dnspod.com/Products/Public.DNS",
+	help_link_text = "DNSPod.com"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/sb.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/sb.dns.lua
@@ -1,7 +1,9 @@
 return {
-	name = "DNS.SB",
+	name = "doh.dns.sb",
 	label = _("DNS.SB"),
 	resolver_url = "https://doh.dns.sb/dns-query",
 	bootstrap_dns = "185.222.222.222,185.184.222.222",
-	http2_only = true
+	http2_only = true,
+	help_link = "https://dns.sb/doh/",
+	help_link_text = "DNS.sb"
 }

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/tw.twnic.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/tw.twnic.dns.lua
@@ -1,8 +1,8 @@
 return {
-	name = "Quad 101 (Taiwan)",
-	label = _("Quad 101 (Taiwan)"),
+	name = "dns.twnic.tw",
+	label = _("Quad 101 - TW"),
 	resolver_url = "https://dns.twnic.tw/dns-query",
 	bootstrap_dns = "101.101.101.101,101.102.103.104,2001:de4::101,2001:de4::102",
 	help_link = "https://blog.twnic.tw/2018/12/28/1803/",
-	help_link_text = "Quad 101 (Taiwan)"
+	help_link_text = "TWNIC.tw"
 }

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -9,6 +9,10 @@ msgstr ""
 msgid "%s is not installed or not found"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.360.doh.lua:3
+msgid "360 Secure DNS - CN"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua:3
 msgid "AdGuard (Family Protection)"
 msgstr ""
@@ -18,47 +22,79 @@ msgid "AdGuard (Standard)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.au.doh.lua:3
-msgid "AhaDNS.com - Australia (Block Malware + Ads)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.in.doh.lua:3
-msgid "AhaDNS.com - India (Block Malware + Ads)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.it.doh.lua:3
-msgid "AhaDNS.com - Italy (Block Malware + Ads)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.nl.doh.lua:3
-msgid "AhaDNS.com - Netherlands (Block Malware + Ads)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.no.doh.lua:3
-msgid "AhaDNS.com - Norway (Block Malware + Ads)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.pl.doh.lua:3
-msgid "AhaDNS.com - Poland (Block Malware + Ads)"
+msgid "AhaDNS - AU (Block Malware + Ads)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.es.doh.lua:3
-msgid "AhaDNS.com - Spain (Block Malware + Ads)"
+msgid "AhaDNS - ES (Block Malware + Ads)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.in.doh.lua:3
+msgid "AhaDNS - IN (Block Malware + Ads)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.it.doh.lua:3
+msgid "AhaDNS - IT (Block Malware + Ads)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.nl.doh.lua:3
+msgid "AhaDNS - NL (Block Malware + Ads)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.no.doh.lua:3
+msgid "AhaDNS - NO (Block Malware + Ads)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.pl.doh.lua:3
+msgid "AhaDNS - PL (Block Malware + Ads)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.chi.doh.lua:3
-msgid "AhaDNS.com - US/Chicago (Block Malware + Ads)"
+msgid "AhaDNS - US/Chicago (Block Malware + Ads)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.la.doh.lua:3
-msgid "AhaDNS.com - US/Los Angeles (Block Malware + Ads)"
+msgid "AhaDNS - US/Los Angeles (Block Malware + Ads)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ahadns.ny.doh.lua:3
-msgid "AhaDNS.com - US/New York (Block Malware + Ads)"
+msgid "AhaDNS - US/New York (Block Malware + Ads)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.ahadns.blitz.lua:3
+msgid "AhaDNS Blitz (Configurable)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.alidns.dns.lua:3
-msgid "AliDNS"
+msgid "AliDNS - CN"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.applied-privacy.lua:3
+msgid "Applied Privacy DNS - AT/DE"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-ch.lua:3
+msgid "BlahDNS - CH"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-de.lua:3
+msgid "BlahDNS - DE"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-fi.lua:3
+msgid "BlahDNS - FI"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-jp.lua:3
+msgid "BlahDNS - JP"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.blahdns.doh-sg.lua:3
+msgid "BlahDNS - SG"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.cfiec.dns.lua:3
+msgid "CFIEC Public DNS (IPv6 Only)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.family.lua:3
@@ -97,19 +133,27 @@ msgstr ""
 msgid "Cloudflare (Security Protection)"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/one.comss.east.dns.lua:3
+msgid "Comss.ru DNS (East)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/one.comss.dns.lua:3
+msgid "Comss.ru DNS (West)"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:122
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware-ads-social.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p3.lua:3
 msgid "ControlD (Block Malware + Ads + Social)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware-ads.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p2.lua:3
 msgid "ControlD (Block Malware + Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p1.lua:3
 msgid "ControlD (Block Malware)"
 msgstr ""
 
@@ -117,8 +161,16 @@ msgstr ""
 msgid "ControlD (Family)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.unfiltered.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p0.lua:3
 msgid "ControlD (Unfiltered)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.dnsforfamily.dns-doh.lua:3
+msgid "DNS For Family"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/de.dnsforge.lua:3
+msgid "DNS Forge - DE"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/controller/https-dns-proxy.lua:4
@@ -142,15 +194,23 @@ msgid "DNSCrypt.ca (DNS2)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/pub.doh.lua:3
-msgid "DNSPod.cn Public DNS"
+msgid "DNSPod Public DNS - CN"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.dnslify.doh.lua:3
+msgid "DNSlify DNS"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:195
 msgid "DSCP Codepoint"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.decloudus.dns.lua:3
+msgid "DeCloudUs DNS"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.digitale-gesellschaft.dns.lua:3
-msgid "Digitale Gesellschaft"
+msgid "Digitale Gesellschaft - CH"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:57
@@ -163,6 +223,10 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:54
 msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.ffmuc.doh.lua:3
+msgid "FFMUC DNS - DE"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:29
@@ -194,7 +258,11 @@ msgid "Hurricane Electric"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.idnet.doh.lua:3
-msgid "IDNet.net (UK)"
+msgid "IDNet.net - UK"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/jp.iij.dns.public.lua:3
+msgid "IIJ Public DNS - JP"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:123
@@ -208,16 +276,20 @@ msgstr ""
 msgid "Instances"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/fi.lelux.resolver-eu.lua:3
+msgid "Lelux DNS - FI"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:133
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh.lua:3
-msgid "LibreDNS"
+msgid "LibreDNS - GR"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/gr.libredns.doh-ads.lua:3
-msgid "LibreDNS (No Ads)"
+msgid "LibreDNS - GR (No Ads)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:178
@@ -241,11 +313,19 @@ msgid "Mullvad (AdBlock)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.nextdns.dns.lua:3
-msgid "NextDNS.io"
+msgid "NextDNS.io (Configurable)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cz.nic.odvr.lua:3
 msgid "ODVR (nic.cz)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.pumplex.dns.lua:3
+msgid "OSZX DNS (Pumplex)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/co.osxz.dns.lua:3
+msgid "OSZX DNS - UK"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.opendns.doh.lua:3
@@ -261,7 +341,7 @@ msgid "Proxy Server"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/tw.twnic.dns.lua:3
-msgid "Quad 101 (Taiwan)"
+msgid "Quad 101 - TW"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.quad9.dns.lua:3
@@ -288,6 +368,18 @@ msgstr ""
 msgid "Resolver"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/lu.restena.kaitain.lua:3
+msgid "Restena DNS - LU"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.rethinkdns.basic.lua:3
+msgid "Rethink DNS (Configurable)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.seby.doh-2.lua:3
+msgid "Seby DNS - AU"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:118
 msgid "Service Control"
 msgstr ""
@@ -300,6 +392,10 @@ msgstr ""
 msgid "Service Status [%s %s]"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.snopyta.dns.doh.fi.lua:3
+msgid "Snopyta DNS - FI"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/view/https-dns-proxy/buttons.htm:41
 msgid "Start"
 msgstr ""
@@ -310,6 +406,18 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:99
 msgid "Stopped"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ch.switch.dns.lua:3
+msgid "Switch DNS - CH"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/app.tiar.jp.lua:3
+msgid "Tiarap Public DNS - JP"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/app.tiar.doh.lua:3
+msgid "Tiarap Public DNS - SG"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:65


### PR DESCRIPTION
* introduce 31 new providers
* uniform names (FQDNs) in provider files
* other minor fixes

Signed-off-by: Stan Grishin <stangri@melmac.ca>