### PR TITLE
luci-app-nut: nut-monitor fixes

### DIFF
--- a/applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua
+++ b/applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua
@@ -78,9 +78,9 @@ o.optional = true
 validatenotify = function(self, value)
 	val = StaticList.validate(self, value)
 	if val then
-		for k, v in pairs(val) do
-			if (v == 'IGNORE') then
-				return nil, "Ignore must the only option selected, when selected"
+		for i, v in ipairs(val) do
+			if (i > 1) and (v == 'IGNORE') then
+				return nil, "If selected, Ignore must be the only option."
 			end
 		end
 	end
@@ -112,15 +112,7 @@ o:value("SYSLOG", translate("Write to syslog"))
 o:value("IGNORE", translate("Ignore"))
 o.validate = validatenotify
 
-o = s:option(StaticList, "nowbattnotify", translate("Notify when low battery"))
-o.optional = true
-o.widget = "select"
-o:value("EXEC", translate("Execute notify command"))
-o:value("SYSLOG", translate("Write to syslog"))
-o:value("IGNORE", translate("Ignore"))
-o.validate = validatenotify
-
-o = s:option(StaticList, "nowbattnotify", translate("Notify when low battery"))
+o = s:option(StaticList, "lowbattnotify", translate("Notify when low battery"))
 o.optional = true
 o.widget = "select"
 o:value("EXEC", translate("Execute notify command"))
@@ -161,6 +153,22 @@ o:value("IGNORE", translate("Ignore"))
 o.validate = validatenotify
 
 o = s:option(StaticList, "replbattnotify", translate("Notify when battery needs replacing"))
+o.optional = true
+o.widget = "select"
+o:value("EXEC", translate("Execute notify command"))
+o:value("SYSLOG", translate("Write to syslog"))
+o:value("IGNORE", translate("Ignore"))
+o.validate = validatenotify
+
+o = s:option(StaticList, "nocommnotify", translate("Notify when no communications"))
+o.optional = true
+o.widget = "select"
+o:value("EXEC", translate("Execute notify command"))
+o:value("SYSLOG", translate("Write to syslog"))
+o:value("IGNORE", translate("Ignore"))
+o.validate = validatenotify
+
+o = s:option(StaticList, "noparentnotify", translate("Notify when no parent process"))
 o.optional = true
 o.widget = "select"
 o:value("EXEC", translate("Execute notify command"))

--- a/applications/luci-app-nut/po/templates/nut.pot
+++ b/applications/luci-app-nut/po/templates/nut.pot
@@ -14,8 +14,8 @@ msgid "Allowed actions"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:20
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:188
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:217
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:196
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:225
 msgid "As configured by NUT"
 msgstr ""
 
@@ -23,7 +23,7 @@ msgstr ""
 msgid "Bytes to read from interrupt pipe"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:174
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:182
 msgid "CA Certificate path"
 msgstr ""
 
@@ -120,6 +120,7 @@ msgstr ""
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:150
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:158
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:166
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:174
 msgid "Execute notify command"
 msgstr ""
 
@@ -151,8 +152,8 @@ msgstr ""
 msgid "Hostname or IP address"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:191
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:220
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:199
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:228
 msgid "Hostname or address of UPS"
 msgstr ""
 
@@ -174,6 +175,7 @@ msgstr ""
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:152
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:160
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:168
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:176
 msgid "Ignore"
 msgstr ""
 
@@ -250,8 +252,8 @@ msgstr ""
 msgid "NUT Users"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:188
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:217
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:196
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:225
 msgid "Name of UPS"
 msgstr ""
 
@@ -314,32 +316,39 @@ msgstr ""
 msgid "Notify when back online"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:163
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:155
 msgid "Notify when battery needs replacing"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:147
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:139
 msgid "Notify when communications lost"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:139
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:131
 msgid "Notify when communications restored"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:131
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:123
 msgid "Notify when force shutdown"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:115
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:123
 msgid "Notify when low battery"
+msgstr ""
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:163
+msgid "Notify when no communications"
+msgstr ""
+
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:171
+msgid "Notify when no parent process"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:107
 msgid "Notify when on battery"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:155
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:147
 msgid "Notify when shutting down"
 msgstr ""
 
@@ -359,13 +368,13 @@ msgstr ""
 msgid "Online message"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:208
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:237
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:216
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:245
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:19
 msgid "Password"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:174
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:182
 msgid "Path containing ca certificates to match against host certificate"
 msgstr ""
 
@@ -398,15 +407,15 @@ msgid "Polling Frequency(s)"
 msgstr ""
 
 #: applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua:27
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:195
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:224
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:203
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:232
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:46
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:202
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:200
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:229
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:208
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:237
 msgid "Power value"
 msgstr ""
 
@@ -418,7 +427,7 @@ msgstr ""
 msgid "Replace battery message"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:178
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:186
 msgid "Require SSL and make sure server CN matches hostname"
 msgstr ""
 
@@ -509,7 +518,7 @@ msgstr ""
 msgid "Time in seconds that upsdrvctl will wait for driver to finish starting"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:183
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:191
 msgid "UPS Master"
 msgstr ""
 
@@ -517,7 +526,7 @@ msgstr ""
 msgid "UPS Server Global Settings"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:212
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:220
 msgid "UPS Slave"
 msgstr ""
 
@@ -549,8 +558,8 @@ msgid ""
 "be read-write for that user."
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:205
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:234
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:213
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:242
 #: applications/luci-app-nut/luasrc/model/cbi/nut_server.lua:16
 msgid "Username"
 msgstr ""
@@ -559,7 +568,7 @@ msgstr ""
 msgid "Vendor (regex)"
 msgstr ""
 
-#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:178
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:186
 msgid "Verify all connection with SSL"
 msgstr ""
 
@@ -577,6 +586,7 @@ msgstr ""
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:151
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:159
 #: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:167
+#: applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua:175
 msgid "Write to syslog"
 msgstr ""
 


### PR DESCRIPTION
Fix typo in lowbattnotify option
Remove duplicate lowbattnotify option
Fix notify validation preventing IGNORE to be set even alone
Add missing nocommnotify and noparentnotify options

Signed-off-by: Pascal Coudurier <coudu@wanadoo.fr>