### PR TITLE
luci-proto-ipip: add nohostroute configurable

### DIFF
--- a/protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js
+++ b/protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js
@@ -64,6 +64,7 @@ return network.registerProtocol('ipip', {
 		o.optional = true;
 		o.datatype = 'range(0, 255)';
 
-		s.taboption('advanced', form.Flag, 'df', _("Don't Fragment"), _("Enable the DF (Don't Fragment) flag of the encapsulating packets."));
+		o = s.taboption('advanced', form.Flag, 'df', _("Don't Fragment"), _("Enable the DF (Don't Fragment) flag of the encapsulating packets."));
+		o.optional = true;
 	}
 });

--- a/protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js
+++ b/protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js
@@ -66,5 +66,8 @@ return network.registerProtocol('ipip', {
 
 		o = s.taboption('advanced', form.Flag, 'df', _("Don't Fragment"), _("Enable the DF (Don't Fragment) flag of the encapsulating packets."));
 		o.optional = true;
+
+		o = s.taboption('advanced', form.Flag, 'nohostroute', _("No host route"), _("Do not create host route to peer (optional)."));
+		o.optional = true;
 	}
 });


### PR DESCRIPTION
Add nohostroute configurable to luci-proto-ipip.

Also explicitly set this option, and the previous df configurable, to optional.

linked pr (merged) [openwrt #4970](https://github.com/openwrt/openwrt/pull/4970)