### PR TITLE
luci-app-opkg: listen to filter `input` event

### DIFF
--- a/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
+++ b/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
@@ -994,13 +994,13 @@ function updateLists(data)
 	});
 }
 
-var keyTimeout = null;
+var inputTimeout = null;
 
-function handleKeyUp(ev) {
-	if (keyTimeout !== null)
-		window.clearTimeout(keyTimeout);
+function handleInput(ev) {
+	if (inputTimeout !== null)
+		window.clearTimeout(inputTimeout);
 
-	keyTimeout = window.setTimeout(function() {
+	inputTimeout = window.setTimeout(function() {
 		display(ev.target.value);
 	}, 250);
 }
@@ -1027,7 +1027,7 @@ return view.extend({
 				E('div', {}, [
 					E('label', {}, _('Filter') + ':'),
 					E('span', { 'class': 'control-group' }, [
-						E('input', { 'type': 'text', 'name': 'filter', 'placeholder': _('Type to filter…'), 'value': query, 'keyup': handleKeyUp }),
+						E('input', { 'type': 'text', 'name': 'filter', 'placeholder': _('Type to filter…'), 'value': query, 'input': handleInput }),
 						E('button', { 'class': 'btn cbi-button', 'click': handleReset }, [ _('Clear') ])
 					])
 				]),


### PR DESCRIPTION
This PR changes the filter to listen to `input` event instead of `keyup`. The former doesn't work with pasting and has issues with IMEs.