### PR TITLE
luci-app-zerotier: add a new luci app to manage zerotier vpn

### DIFF
--- a/applications/luci-app-zerotier/Makefile
+++ b/applications/luci-app-zerotier/Makefile
@@ -1,0 +1,13 @@
+## This is free software, licensed under the Apache License, Version 2.0 .
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI support for Zerotier
+LUCI_DEPENDS:=+luci-compat +zerotier
+LUCI_PKGARCH:=all
+PKG_VERSION:=1.0
+PKG_RELEASE:=20
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-zerotier/luasrc/controller/zerotier.lua
+++ b/applications/luci-app-zerotier/luasrc/controller/zerotier.lua
@@ -1,0 +1,23 @@
+module("luci.controller.zerotier",package.seeall)
+
+function index()
+	if not nixio.fs.access("/etc/config/zerotier") then
+		return
+	end
+
+	entry({"admin","vpn"}, firstchild(), "VPN", 45).dependent = false
+
+	entry({"admin", "vpn", "zerotier"},firstchild(), _("ZeroTier")).dependent = false
+
+	entry({"admin", "vpn", "zerotier", "general"}, cbi("zerotier/settings"), _("Base Setting"), 1)
+	entry({"admin", "vpn", "zerotier", "log"}, form("zerotier/info"), _("Interface Info"), 2)
+
+	entry({"admin", "vpn", "zerotier", "status"}, call("act_status"))
+end
+
+function act_status()
+	local e = {}
+	e.running = luci.sys.call("pgrep /usr/bin/zerotier-one >/dev/null") == 0
+	luci.http.prepare_content("application/json")
+	luci.http.write_json(e)
+end

--- a/applications/luci-app-zerotier/luasrc/model/cbi/zerotier/info.lua
+++ b/applications/luci-app-zerotier/luasrc/model/cbi/zerotier/info.lua
@@ -1,0 +1,15 @@
+local fs = require "nixio.fs"
+local conffile = "/tmp/zero.info"
+
+f = SimpleForm("logview")
+
+t = f:field(TextValue, "conf")
+t.rmempty = true
+t.rows = 19
+function t.cfgvalue()
+  luci.sys.exec("for i in $(ifconfig | grep 'zt' | awk '{print $1}'); do ifconfig $i; done > /tmp/zero.info")
+	return fs.readfile(conffile) or ""
+end
+t.readonly="readonly"
+
+return f

--- a/applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua
+++ b/applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua
@@ -1,0 +1,23 @@
+a = Map("zerotier")
+a.title = translate("ZeroTier")
+a.description = translate("Zerotier is an open source, cross-platform and easy to use virtual LAN")
+
+a:section(SimpleSection).template = "zerotier/zerotier_status"
+
+t = a:section(NamedSection, "sample_config", "zerotier")
+t.anonymous = true
+t.addremove = false
+
+e = t:option(Flag, "enabled", translate("Enable"))
+e.default = 0
+e.rmempty=false
+
+e = t:option(DynamicList, "join", translate('ZeroTier Network ID'))
+e.password = true
+e.rmempty = false
+
+
+e = t:option(DummyValue, "opennewwindow", "<input type=\"button\" class=\"btn cbi-button cbi-button-apply\" value=\"" .. translate('Zerotier.com') .. "\" onclick=\"window.open('https://my.zerotier.com/network')\" />")
+e.description = translate("Create or manage your zerotier network, and auth clients who could access")
+
+return a

--- a/applications/luci-app-zerotier/luasrc/view/zerotier/zerotier_status.htm
+++ b/applications/luci-app-zerotier/luasrc/view/zerotier/zerotier_status.htm
@@ -1,0 +1,22 @@
+<script type="text/javascript">//<![CDATA[
+XHR.poll(3, '<%=url([[admin]], [[vpn]], [[zerotier]], [[status]])%>', null,
+	function(x, data) {
+		var tb = document.getElementById('zerotier_status');
+		if (data && tb) {
+			if (data.running) {
+				var links = '<em><b><font color=green>Zerotier <%:RUNNING%></font></b></em>';
+				tb.innerHTML = links;
+			} else {
+				tb.innerHTML = '<em><b><font color=red>Zerotier <%:NOT RUNNING%></font></b></em>';
+			}
+		}
+	}
+);
+//]]>
+</script>
+<style>.mar-10 {margin-left: 50px; margin-right: 10px;}</style>
+<fieldset class="cbi-section">
+	<p id="zerotier_status">
+		<em><%:Collecting data...%></em>
+	</p>
+</fieldset>

--- a/applications/luci-app-zerotier/po/es/zerotier.po
+++ b/applications/luci-app-zerotier/po/es/zerotier.po
@@ -1,0 +1,90 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:10
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:2
+msgid "ZeroTier"
+msgstr "ZeroTier"
+
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:12
+msgid "Base Setting"
+msgstr "Configuración base"
+
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:13
+msgid "Interface Info"
+msgstr "Información de interfaz"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:3
+msgid "Zerotier is an open source, cross-platform and easy to use virtual LAN"
+msgstr ""
+"Zerotier es una LAN virtual de código abierto, multiplataforma y fácil de "
+"usar"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:11
+msgid "Enable"
+msgstr "Activar"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:15
+msgid "ZeroTier Network ID"
+msgstr "ID de red ZeroTier"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:20
+#| msgid "ZeroTier"
+msgid "Zerotier.com"
+msgstr "Zerotier.com"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:21
+msgid ""
+"Create or manage your zerotier network, and auth clients who could access"
+msgstr ""
+"Cree o administre su red zerotier y autentique clientes que puedan acceder"
+
+#~ msgid ""
+#~ "<input type=\"button\" class=\"cbi-button cbi-button-apply\" value="
+#~ "\"Zerotier.com\" onclick=\"window.open('https://my.zerotier.com/"
+#~ "network')\" />"
+#~ msgstr ""
+#~ "<input type=\"button\" class=\"cbi-button cbi-button-apply\" value="
+#~ "\"Zerotier.com\" onclick=\"window.open('https://my.zerotier.com/"
+#~ "network')\" />"
+
+#~ msgid "Auto NAT Clients"
+#~ msgstr "Clientes NAT automáticos"
+
+#~ msgid "Collecting data..."
+#~ msgstr "Recolectando datos..."
+
+#~ msgid "Manual Config"
+#~ msgstr "Configuración manual"
+
+#~ msgid "NOT RUNNING"
+#~ msgstr "NO CORRIENDO"
+
+#~ msgid "RUNNING"
+#~ msgstr "CORRIENDO"
+
+#~ msgid "Zerotier access control"
+#~ msgstr "Control de acceso zerotier"
+
+#~ msgid "lan access zerotier"
+#~ msgstr "acceso zerotier lan"
+
+#~ msgid "remote access lan"
+#~ msgstr "acceso remoto lan"
+
+#~ msgid "remote access wan"
+#~ msgstr "acceso remoto wan"
+
+#~ msgid "wan access zerotier"
+#~ msgstr "acceso zerotier zerotier"

--- a/applications/luci-app-zerotier/po/templates/zerotier.pot
+++ b/applications/luci-app-zerotier/po/templates/zerotier.pot
@@ -1,0 +1,32 @@
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:10
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:2
+msgid "ZeroTier"
+msgstr ""
+
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:12
+msgid "Base Setting"
+msgstr ""
+
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:13
+msgid "Interface Info"
+msgstr ""
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:3
+msgid "Zerotier is an open source, cross-platform and easy to use virtual LAN"
+msgstr ""
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:11
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:15
+msgid "ZeroTier Network ID"
+msgstr ""
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:20
+msgid "Zerotier.com"
+msgstr ""
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:21
+msgid "Create or manage your zerotier network, and auth clients who could access"
+msgstr ""

--- a/applications/luci-app-zerotier/po/zh-cn/zerotier.po
+++ b/applications/luci-app-zerotier/po/zh-cn/zerotier.po
@@ -1,0 +1,60 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Poedit 3.0.1\n"
+
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:10
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:2
+msgid "ZeroTier"
+msgstr "ZeroTier"
+
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:12
+msgid "Base Setting"
+msgstr "基本设置"
+
+#: applications/luci-app-zerotier/luasrc/controller/zerotier.lua:13
+msgid "Interface Info"
+msgstr "接口信息"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:3
+msgid "Zerotier is an open source, cross-platform and easy to use virtual LAN"
+msgstr ""
+"Zerotier 是一个开源，跨平台，而且适合内网穿透互联的傻瓜配置虚拟 VPN LAN"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:11
+#, fuzzy
+msgid "Enable"
+msgstr "Enable"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:15
+#, fuzzy
+msgid "ZeroTier Network ID"
+msgstr "ZeroTier Network ID"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:20
+msgid "Zerotier.com"
+msgstr "Zerotier.com"
+
+#: applications/luci-app-zerotier/luasrc/model/cbi/zerotier/settings.lua:21
+msgid ""
+"Create or manage your zerotier network, and auth clients who could access"
+msgstr ""
+"点击跳转到 Zerotier 官网管理平台，新建或者管理网络，并允许客户端接入访问你私"
+"人网路（新接入的节点默认不允许访问）"
+
+#~ msgid "Auto NAT Clients"
+#~ msgstr "自动允许客户端 NAT"
+
+#~ msgid "Allow zerotier clients access your LAN network"
+#~ msgstr ""
+#~ "允许 Zerotier 的拨入客户端访问路由器 LAN 资源（需要在 Zerotier 管理页面设"
+#~ "定到 LAN 网段的路由表）"

--- a/applications/luci-app-zerotier/root/usr/share/rpcd/acl.d/luci-app-zerotier.json
+++ b/applications/luci-app-zerotier/root/usr/share/rpcd/acl.d/luci-app-zerotier.json
@@ -1,0 +1,11 @@
+{
+ 	"luci-app-zerotier": {
+ 		"description": "Grant UCI access for luci-app-zerotier",
+ 		"read": {
+ 			"uci": [ "zerotier" ]
+ 		},
+ 		"write": {
+ 			"uci": [ "zerotier" ]
+ 		}
+ 	}
+}


### PR DESCRIPTION
Based off of https://github.com/coolsnowwolf/lede/tree/master/package/lean/luci-app-zerotier
- without the interface code and scripts for allowing NAT access to the local lan.
- added missing btn class to Zerotier.com button which fixes button style in the openwrt2020 theme.
- removed html from Zerotier.com button translation.
- add es translation and template from https://github.com/openwrtdiy/openwrt-ipk/tree/main/luci-app-zerotier
- regenerated translation template from source
- normalised translation files
- add luci-compat to package dependencies

Signed-off-by: Andrew Innes <andrew.c12@gmail.com>