### PR TITLE
luci-mod-status: improve channel_analysis and firewall page

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
@@ -314,6 +314,15 @@ return view.extend({
 	},
 
 	render: function(has_ip6tables) {
+		var tabs = E('div', {}, [
+			E('div', { 'data-tab': 'iptables', 'data-tab-title': has_ip6tables ? _('IPv4 Firewall') : null, 'data-tab-active': has_ip6tables ? null : true }, [
+				E('p', {}, E('em', { 'class': 'spinning' }, [ _('Collecting data...') ]))
+			]),
+			has_ip6tables ? E('div', { 'data-tab': 'ip6tables', 'data-tab-title': _('IPv6 Firewall') }, [
+				E('p', {}, E('em', { 'class': 'spinning' }, [ _('Collecting data...') ]))
+			]) : E([])
+		]);
+
 		var view = E([], [
 			E('style', { 'type': 'text/css' }, [
 				'.cbi-tooltip-container, span.jump { border-bottom:1px dotted #00f;cursor:pointer }',
@@ -322,43 +331,37 @@ return view.extend({
 				'.references .cbi-tooltip { left:0!important;top:1.5em!important }',
 				'h4>span { font-size:90% }'
 			]),
-
-			E('h2', {}, [ _('Firewall Status') ]),
-			E('div', { 'class': 'right', 'style': 'margin-bottom:-1.5em' }, [
-				E('button', {
-					'class': 'cbi-button',
-					'data-hide-empty': false,
-					'click': ui.createHandlerFn(this, 'handleHideEmpty')
-				}, [ _('Hide empty chains') ]),
-				' ',
-				E('button', {
-					'class': 'cbi-button',
-					'data-raw-counters': false,
-					'click': ui.createHandlerFn(this, 'handleRawCounters')
-				}, [ _('Show raw counters') ]),
-				' ',
-				E('button', {
-					'class': 'cbi-button',
-					'click': ui.createHandlerFn(this, 'handleCounterReset', has_ip6tables)
-				}, [ _('Reset Counters') ]),
-				' ',
-				E('button', {
-					'class': 'cbi-button',
-					'click': ui.createHandlerFn(this, 'handleRestart')
-				}, [ _('Restart Firewall') ])
+			E('div', {'class' : 'cbi-title-section'}, [ 
+				E('h2', {'class': 'cbi-title-field'}, [ _('Firewall Status') ]),
+				E('div', {'class': 'cbi-title-buttons'} , [
+					E('button', {
+						'class': 'cbi-button cbi-button-neutral',
+						'data-hide-empty': false,
+						'click': ui.createHandlerFn(this, 'handleHideEmpty')
+					}, [ _('Hide empty chains') ]),
+					E('div', {}, '&#160;'),
+					E('button', {
+						'class': 'cbi-button cbi-button-neutral',
+						'data-raw-counters': false,
+						'click': ui.createHandlerFn(this, 'handleRawCounters')
+					}, [ _('Show raw counters') ]),
+					E('div', {}, '&#160;'),
+					E('button', {
+						'class': 'cbi-button cbi-button-neutral',
+						'click': ui.createHandlerFn(this, 'handleCounterReset', has_ip6tables)
+					}, [ _('Reset Counters') ]),
+					E('div', {}, '&#160;'),
+					E('button', {
+						'class': 'cbi-button cbi-button-neutral',
+						'click': ui.createHandlerFn(this, 'handleRestart')
+					}, [ _('Restart Firewall') ])
+				])
 			]),
-			E('div', {}, [
-				E('div', { 'data-tab': 'iptables', 'data-tab-title': has_ip6tables ? _('IPv4 Firewall') : null, 'data-tab-active': has_ip6tables ? null : true }, [
-					E('p', {}, E('em', { 'class': 'spinning' }, [ _('Collecting data...') ]))
-				]),
-				has_ip6tables ? E('div', { 'data-tab': 'ip6tables', 'data-tab-title': _('IPv6 Firewall') }, [
-					E('p', {}, E('em', { 'class': 'spinning' }, [ _('Collecting data...') ]))
-				]) : E([])
-			])
+			tabs
 		]);
 
 		if (has_ip6tables)
-			ui.tabs.initTabGroup(view.lastElementChild.childNodes);
+			ui.tabs.initTabGroup(tabs.childNodes);
 
 		this.pollFirewallLists(has_ip6tables);
 

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -526,6 +526,20 @@ textarea {
 	line-height: normal;
 }
 
+.cbi-title-section {
+	display: flex;
+	flex-wrap: wrap;
+}
+
+.cbi-title-field {
+	flex: 1;
+}
+
+.cbi-title-buttons {
+	margin: auto;
+	display: flex;
+}
+
 .cbi-value {
 	display: flex;
 	flex-wrap: wrap;

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/mobile.css
@@ -234,6 +234,8 @@ header h3 a, header .brand {
 	button, .btn, .cbi-button {
 		font-size: 14px !important;
 		padding: 0 8px;
+		word-break: normal;
+		white-space: normal;
 	}
 
 	.actions,

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1253,6 +1253,26 @@ td > table > tbody > tr > td,
 	word-wrap: break-word;
 }
 
+.cbi-title-section {
+	display: flex;
+	flex-wrap: wrap;
+	margin: 2rem 0 0 0;
+	padding-bottom: 10px;
+	border-bottom: thin solid #eee;
+}
+
+.cbi-title-field {
+	flex: 1;
+	margin: 0;
+	padding: 0;
+	border: 0;
+}
+
+.cbi-title-buttons {
+	margin: auto;
+	display: flex;
+}
+
 .cbi-value {
 	display: inline-block;
 	width: 100%;
@@ -2554,6 +2574,7 @@ input[name="nslookup"] {
 	.cbi-button {
 		font-size: .8rem;
 		padding: .3rem .6rem;
+		white-space: normal;
 	}
 
 	.label,

--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -1100,6 +1100,21 @@ textarea {
 	flex: 10;
 }
 
+.cbi-title-section {
+	display: flex;
+	flex-wrap: wrap;
+	margin: 0 0 1rem 0;
+}
+
+.cbi-title-field {
+	flex: 1;
+	margin: 0;
+}
+
+.cbi-title-buttons {
+	display: flex;
+}
+
 .cbi-value {
 	display: flex;
 	flex-wrap: wrap;

--- a/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
+++ b/themes/luci-theme-openwrt/htdocs/luci-static/openwrt.org/cascade.css
@@ -794,6 +794,25 @@ table td, table th {
 	color: #000000;
 }
 
+.cbi-title-section {
+	display: flex;
+	flex-wrap: wrap;
+	margin: 0.25em 0 0.5em 0;
+	border-bottom: 1px solid;
+	padding-bottom: 4px;
+}
+
+.cbi-title-field {
+	flex: 1;
+	padding: 0;
+	margin: 0;
+	border: 0;
+}
+
+.cbi-title-buttons {
+	display: flex;
+}
+
 .cbi-value {
 	clear: left;
 	vertical-align: middle;


### PR DESCRIPTION
Many user complained problem with using pool with wifi scan.
This comes from the limitation that some wifi driver have problems with scanning
nearby wifi and keeping traffic.
Fix this by doing the wifi scan only one time on page load and provide a button
to refresh the channels manually.
The original implementation is preserved as the user can simply reenable the poll
referesh from the ui.
While at it also sort the table by channel instead of by signal quality to better
track the most used channels in the table.

This also try to improve the firewall page that is currently bugged.
2 new css class are introduced called cbi-title-section and cbi-title-field.
With these new class it's possible to put buttons on the same line of the title
view and we can use flex instead of using right class + hardcoded margin.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

@jow- only concern I have it the use of style in the h2 div... Any idea how to
improve? An old pr [1] still open added the ability to add buttons at the end of
the h2... Would be handy here and also in the firewall status page that is
currently broken... 

Current implementation by this pr

![image](https://user-images.githubusercontent.com/20289090/155034340-ff78ff0c-d046-45c7-ae42-7534a518b379.png)

Broken implementation by using strange div and right class

![image](https://user-images.githubusercontent.com/20289090/155034362-7a8676d6-52d5-435a-90e8-fe8cbf2cb6d9.png)

[1] https://github.com/openwrt/luci/pull/5224