### PR TITLE
luci-mod-network: add support for wireless no outdoor restriction

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -312,9 +312,9 @@ var CBIWifiFrequencyValue = form.Value.extend({
 			this.callFrequencyList(section_id)
 		]).then(L.bind(function(data) {
 			this.channels = {
-				'2g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', true ] : [],
-				'5g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', true ] : [],
-				'6g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', true ] : [],
+				'2g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', { available: true } ] : [],
+				'5g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', { available: true } ] : [],
+				'6g': L.hasSystemFeature('hostapd', 'acs') ? [ 'auto', 'auto', { available: true } ] : [],
 				'60g': []
 			};
 
@@ -322,12 +322,21 @@ var CBIWifiFrequencyValue = form.Value.extend({
 				if (!data[1][i].band)
 					continue;
 
-				var band = '%dg'.format(data[1][i].band);
+				var band = '%dg'.format(data[1][i].band),
+				    available = true;
+
+
+				if (data[1][i].restricted && data[1][i].no_ir)
+					available = false;
 
 				this.channels[band].push(
 					data[1][i].channel,
 					'%d (%d Mhz)'.format(data[1][i].channel, data[1][i].mhz),
-					!data[1][i].restricted
+					{
+						available: available,
+						no_outdoor: data[1][i].no_outdoor
+					}
+					
 				);
 			}
 
@@ -335,52 +344,52 @@ var CBIWifiFrequencyValue = form.Value.extend({
 				.reduce(function(o, v) { o[v] = true; return o }, {});
 
 			this.modes = [
-				'', 'Legacy', hwmodelist.a || hwmodelist.b || hwmodelist.g,
-				'n', 'N', hwmodelist.n,
-				'ac', 'AC', L.hasSystemFeature('hostapd', '11ac') && hwmodelist.ac,
-				'ax', 'AX', L.hasSystemFeature('hostapd', '11ax') && hwmodelist.ax
+				'', 'Legacy', { available: hwmodelist.a || hwmodelist.b || hwmodelist.g },
+				'n', 'N', { available: hwmodelist.n },
+				'ac', 'AC', { available: L.hasSystemFeature('hostapd', '11ac') && hwmodelist.ac },
+				'ax', 'AX', { available: L.hasSystemFeature('hostapd', '11ax') && hwmodelist.ax }
 			];
 
 			var htmodelist = L.toArray(data[0] ? data[0].getHTModes() : null)
 				.reduce(function(o, v) { o[v] = true; return o }, {});
 
 			this.htmodes = {
-				'': [ '', '-', true ],
+				'': [ '', '-', { available: true } ],
 				'n': [
-					'HT20', '20 MHz', htmodelist.HT20,
-					'HT40', '40 MHz', htmodelist.HT40
+					'HT20', '20 MHz', { available: htmodelist.HT20 },
+					'HT40', '40 MHz', { available: htmodelist.HT40 }
 				],
 				'ac': [
-					'VHT20', '20 MHz', htmodelist.VHT20,
-					'VHT40', '40 MHz', htmodelist.VHT40,
-					'VHT80', '80 MHz', htmodelist.VHT80,
-					'VHT160', '160 MHz', htmodelist.VHT160
+					'VHT20', '20 MHz', { available: htmodelist.VHT20 },
+					'VHT40', '40 MHz', { available: htmodelist.VHT40 },
+					'VHT80', '80 MHz', { available: htmodelist.VHT80 },
+					'VHT160', '160 MHz', { available: htmodelist.VHT160 }
 				],
 				'ax': [
-					'HE20', '20 MHz', htmodelist.HE20,
-					'HE40', '40 MHz', htmodelist.HE40,
-					'HE80', '80 MHz', htmodelist.HE80,
-					'HE160', '160 MHz', htmodelist.HE160
+					'HE20', '20 MHz', { available: htmodelist.HE20 },
+					'HE40', '40 MHz', { available: htmodelist.HE40 },
+					'HE80', '80 MHz', { available: htmodelist.HE80 },
+					'HE160', '160 MHz', { available: htmodelist.HE160 }
 				]
 			};
 
 			this.bands = {
 				'': [
-					'2g', '2.4 GHz', this.channels['2g'].length > 3,
-					'5g', '5 GHz', this.channels['5g'].length > 3,
-					'60g', '60 GHz', this.channels['60g'].length > 0
+					'2g', '2.4 GHz', { available: this.channels['2g'].length > 3 },
+					'5g', '5 GHz', { available: this.channels['5g'].length > 3 },
+					'60g', '60 GHz', { available: this.channels['60g'].length > 0 }
 				],
 				'n': [
-					'2g', '2.4 GHz', this.channels['2g'].length > 3,
-					'5g', '5 GHz', this.channels['5g'].length > 3
+					'2g', '2.4 GHz', { available: this.channels['2g'].length > 3 },
+					'5g', '5 GHz', { available: this.channels['5g'].length > 3 }
 				],
 				'ac': [
-					'5g', '5 GHz', true
+					'5g', '5 GHz', { available: true }
 				],
 				'ax': [
-					'2g', '2.4 GHz', this.channels['2g'].length > 3,
-					'5g', '5 GHz', this.channels['5g'].length > 3,
-					'6g', '6 GHz', this.channels['6g'].length > 3
+					'2g', '2.4 GHz', { available: this.channels['2g'].length > 3 },
+					'5g', '5 GHz', { available: this.channels['5g'].length > 3 },
+					'6g', '6 GHz', { available: this.channels['6g'].length > 3 }
 				]
 			};
 		}, this));
@@ -394,7 +403,7 @@ var CBIWifiFrequencyValue = form.Value.extend({
 			sel.remove(0);
 
 		for (var i = 0; vals && i < vals.length; i += 3)
-			if (vals[i+2])
+			if (vals[i+2] && vals[i+2].available)
 				sel.add(E('option', { value: vals[i+0] }, [ vals[i+1] ]));
 
 		if (vals && !isNaN(vals.selected))
@@ -426,11 +435,31 @@ var CBIWifiFrequencyValue = form.Value.extend({
 		this.map.checkDepends();
 	},
 
+	checkWifiChannelRestriction: function(elem) {
+		var band = elem.querySelector('.band'),
+		     chan = elem.querySelector('.channel'),
+		     restricted_chan = elem.querySelector('.restricted_channel'),
+		     channels = this.channels[band.value],
+		     no_outdoor;
+
+		if (chan.selectedIndex < 0)
+			return;
+
+		no_outdoor = channels[(chan.selectedIndex*3)+2].no_outdoor;
+		if (no_outdoor)
+			restricted_chan.style.display = '';
+		else
+			restricted_chan.style.display = 'none';
+	},
+
 	toggleWifiChannel: function(elem) {
 		var band = elem.querySelector('.band');
 		var chan = elem.querySelector('.channel');
 
 		this.setValues(chan, this.channels[band.value]);
+
+		this.map.checkDepends();
+		this.checkWifiChannelRestriction(elem);
 	},
 
 	setInitialValues: function(section_id, elem) {
@@ -475,6 +504,8 @@ var CBIWifiFrequencyValue = form.Value.extend({
 		bwdt.value = htval;
 		chan.value = chval || (chan.options[0] ? chan.options[0].value : 'auto');
 
+		this.checkWifiChannelRestriction(elem);
+
 		return elem;
 	},
 
@@ -482,6 +513,9 @@ var CBIWifiFrequencyValue = form.Value.extend({
 		var elem = E('div');
 
 		dom.content(elem, [
+			E('div', { 'class' : 'restricted_channel', 'style': 'display:none'}, [
+				E('div', {'class': 'cbi-button alert-message warning disabled'}, _('Indoor Only Channel Selected'))
+			]),
 			E('label', { 'style': 'float:left; margin-right:3px' }, [
 				_('Mode'), E('br'),
 				E('select', {
@@ -505,7 +539,7 @@ var CBIWifiFrequencyValue = form.Value.extend({
 				E('select', {
 					'class': 'channel',
 					'style': 'width:auto',
-					'change': L.bind(this.map.checkDepends, this.map),
+					'change': L.bind(this.toggleWifiChannel, this, elem),
 					'disabled': (this.disabled != null) ? this.disabled : this.map.readonly
 				})
 			]),
@@ -931,7 +965,7 @@ return view.extend({
 				o.inputtitle = isDisabled ? _('Enable') : _('Disable');
 				o.onclick = ui.createHandlerFn(s, network_updown, s.section, s.map);
 
-				o = ss.taboption('general', CBIWifiFrequencyValue, '_freq', '<br />' + _('Operating frequency'));
+				o = ss.taboption('general', CBIWifiFrequencyValue, '_freq', '<br />' + _('Operating frequency'), _('Some channels may be restricted to Indoor Only use by your Regulatory Domain. Make sure to follow this advice if a channel is reported as such.'));
 				o.ucisection = s.section;
 
 				if (hwtype == 'mac80211') {


### PR DESCRIPTION
@jow- (sorry for the quote spam... I pushed v2 some times ago but got ignored so I wonder if an implementation in luci would move things up)
This depends on the series [1].
The current implementation is a simple warning message on the wifi selection.
This feature is useful for some Regulatory Domain like the Germany one where some channel are flagged as indoor only.

![image](https://user-images.githubusercontent.com/20289090/155146854-8cb49e84-efb8-401c-adde-05235bd0fc56.png)

Some channels may restrict its use to indoor only. Add support for
this and alert the user if a channel with this limitation is used.

Signed-off-by: Ansuel Smith <ansuelsmth@gmail.com>

[1] https://patchwork.ozlabs.org/project/openwrt/patch/20220121000751.8905-1-ansuelsmth@gmail.com/