### PR TITLE
Introduce sortable status tables

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -764,72 +764,14 @@ function cbi_update_table(table, data, placeholder) {
 	if (!isElem(target))
 		return;
 
-	target.querySelectorAll('tr.table-titles, .tr.table-titles, .cbi-section-table-titles').forEach(function(thead) {
-		var titles = [];
+	var t = L.dom.findClassInstance(target);
 
-		thead.querySelectorAll('th, .th').forEach(function(th) {
-			titles.push(th);
-		});
+	if (!(t instanceof L.ui.Table)) {
+		t = new L.ui.Table(target);
+		L.dom.bindClassInstance(target, t);
+	}
 
-		if (Array.isArray(data)) {
-			var n = 0, rows = target.querySelectorAll('tr, .tr'), trows = [];
-
-			data.forEach(function(row) {
-				var trow = E('tr', { 'class': 'tr' });
-
-				for (var i = 0; i < titles.length; i++) {
-					var text = (titles[i].innerText || '').trim();
-					var td = trow.appendChild(E('td', {
-						'class': titles[i].className,
-						'data-title': (text !== '') ? text : null
-					}, (row[i] != null) ? row[i] : ''));
-
-					td.classList.remove('th');
-					td.classList.add('td');
-				}
-
-				trow.classList.add('cbi-rowstyle-%d'.format((n++ % 2) ? 2 : 1));
-
-				trows[n] = trow;
-			});
-
-			for (var i = 1; i <= n; i++) {
-				if (rows[i])
-					target.replaceChild(trows[i], rows[i]);
-				else
-					target.appendChild(trows[i]);
-			}
-
-			while (rows[++n])
-				target.removeChild(rows[n]);
-
-			if (placeholder && target.firstElementChild === target.lastElementChild) {
-				var trow = target.appendChild(E('tr', { 'class': 'tr placeholder' }));
-				var td = trow.appendChild(E('td', { 'class': titles[0].className }, placeholder));
-
-				td.classList.remove('th');
-				td.classList.add('td');
-			}
-		}
-		else {
-			thead.parentNode.style.display = 'none';
-
-			thead.parentNode.querySelectorAll('tr, .tr, .cbi-section-table-row').forEach(function(trow) {
-				if (trow !== thead) {
-					var n = 0;
-					trow.querySelectorAll('th, td, .th, .td').forEach(function(td) {
-						if (n < titles.length) {
-							var text = (titles[n++].innerText || '').trim();
-							if (text !== '')
-								td.setAttribute('data-title', text);
-						}
-					});
-				}
-			});
-
-			thead.parentNode.style.display = '';
-		}
-	});
+	t.update(data, placeholder);
 }
 
 function showModal(title, children)

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2051,6 +2051,10 @@ table table td,
 	background: var(--background-color-medium);
 }
 
+th[data-sortable-row] { cursor: pointer; }
+th[data-sort-direction="asc"]::after { content: "\a0\25b2"; }
+th[data-sort-direction="desc"]::after { content: "\a0\25bc"; }
+
 .cbi-value-description {
 	margin: .25em 0 0 1.25em;
 	position: relative;


### PR DESCRIPTION
This PR introduces sortable status tables in LuCI and replaces the old `cbi_update_table()` functon with wrapper logic for backwards compatibility.

In a later step, form `TableSection` and `GridSection` implementations will be rebased on top of the new table facility to provide column sorting for them as well.

![image](https://user-images.githubusercontent.com/2528802/155331591-6f91121d-29bd-4c2c-9230-fded1785dc80.png)
