### PR TITLE
Luci mod status handle obsoleted /proc/net/nf conntrack

### DIFF
--- a/modules/luci-base/luasrc/sys.lua
+++ b/modules/luci-base/luasrc/sys.lua
@@ -279,10 +279,14 @@ function net.host_hints(callback)
 end
 
 function net.conntrack(callback)
-	local ok, nfct = pcall(io.lines, "/proc/net/nf_conntrack")
-	if not ok or not nfct then
-		return nil
-	end
+	local ok, fd = pcall(io.open, "/proc/net/nf_conntrack")
+        if not ok or not fd then
+                ok, fd = pcall(io.popen, "/usr/sbin/conntrack -L -o extended", "r")
+        end
+        if not ok or not fd then
+                return nil
+        end
+        nfct = fd:lines()
 
 	local line, connt = nil, (not callback) and { }
 	for line in nfct do

--- a/modules/luci-mod-status/src/luci-bwc.c
+++ b/modules/luci-mod-status/src/luci-bwc.c
@@ -442,8 +442,14 @@ static int run_daemon(void)
 	struct dirent *e;
 
 	struct stat s;
-	const char *ipc = stat("/proc/net/nf_conntrack", &s)
-		? "/proc/net/ip_conntrack" : "/proc/net/nf_conntrack";
+	char *ipc;
+        char *ipc_command;
+        if(! stat("/proc/net/nf_conntrack", &s))
+                ipc = "/proc/net/nf_conntrack";
+         else if(! stat("/proc/net/ip_conntrack", &s))
+                ipc = "/proc/net/ip_conntrack";
+        else if(! stat("/usr/sbin/conntrack" , &s))
+                ipc_command = "/usr/sbin/conntrack -L -o extended";
 
 	const struct {
 		const char *file;
@@ -535,7 +541,8 @@ static int run_daemon(void)
 			closedir(dir);
 		}
 
-		if ((info = fopen(ipc, "r")) != NULL)
+		if (((ipc != '\0') && ((info = fopen(ipc, "r")) != NULL)) ||
+                        ((ipc_command != '\0') && ((info=popen(ipc_command, "r")) != NULL)))
 		{
 			udp   = 0;
 			tcp   = 0;
@@ -575,7 +582,10 @@ static int run_daemon(void)
 							  (uint16_t)(lf15 * 100));
 			}
 
-			fclose(info);
+			if (ipc != '\0')
+                                fclose(info);
+                        if (ipc_command != '\0')
+                                pclose(info);
 		}
 
 		sleep(STEP_TIME);


### PR DESCRIPTION
enables use of the conntrack tool (/usr/sbin/conntrack) in cases the kernel hasn't been compiled with [CONFIG_NF_CONNTRACK_PROCFS](https://cateee.net/lkddb/web-lkddb/NF_CONNTRACK_PROCFS.html). 

Obsoleting of /proc/net/nf_conntrack affects luci-bwc (luci-mod-status) and sys.net.conntrack within sys.lua (luci-base). 

/proc/net/nf_conntrack remains preferred over /usr/sbin/conntrack 