### PR TITLE
add rrd graphs

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
@@ -15,38 +15,38 @@ return baseclass.extend({
 		if (plugin_instance != '')
 			title = "Category: %pi";
 
-		var if_octets = {
+		var total_bytes = {
 			title: title,
 			y_min: "0",
 			alt_autoscale_max: true,
 			vlabel: "Bytes/s",
 			data: {
 				instances: {
-					if_octets: [ "3g_wwan", "eth1"]
+					total_bytes: [ "3g_wwan", "eth1"]
 				},
 				sources: {
-					if_octets: [ "tx", "rx" ],
-					if_octets: [ "tx", "rx" ]
+					total_bytes: [ "tx", "rx" ],
+					total_bytes: [ "tx", "rx" ]
 				},
 				options: {
-					if_octets_eth1_tx: {
+					total_bytes_eth1_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
-					if_octets_eth1_rx: {
+					total_bytes_eth1_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
-					if_octets_3g_wwan_tx: {
+					total_bytes_3g_wwan_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
-					if_octets_3g_wwan_rx: {
+					total_bytes_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
@@ -61,8 +61,8 @@ return baseclass.extend({
 		for (var i = 0; i < types.length; i++)
 			if (types[i] == 'cpu')
 				p.push(cpu);
-			else if (types[i] == 'if_octets')
-				p.push(if_octets);
+			else if (types[i] == 'total_bytes')
+				p.push(total_bytes);
 
 		return p;
 	}

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
@@ -1,0 +1,69 @@
+/* Licensed to the public under the Apache License 2.0. */
+
+'use strict';
+'require baseclass';
+'require uci';
+
+return baseclass.extend({
+	title: _('Application'),
+
+	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
+		var p = [];
+
+		var title = "%H: Traffic usage";
+
+		if (plugin_instance != '')
+			title = "Category: %pi";
+
+		var if_octets = {
+			title: title,
+			y_min: "0",
+			alt_autoscale_max: true,
+			vlabel: "Bytes/s",
+			data: {
+				instances: {
+					if_octets: [ "3g_wwan", "eth1"]
+				},
+				sources: {
+					if_octets: [ "tx", "rx" ],
+					if_octets: [ "tx", "rx" ]
+				},
+				options: {
+					if_octets_eth1_tx: {
+						total: true,		/* report total amount of bytes */
+						color: "0000ff",	/* eth1 is blue */
+						title: "Viasat Bytes (TX)"
+					},
+					if_octets_eth1_rx: {
+						flip : true,		/* flip rx line */
+						total: true,		/* report total amount of bytes */
+						color: "0000ff",	/* eth1 is blue */
+						title: "Viasat Bytes (RX)"
+					},
+
+					if_octets_3g_wwan_tx: {
+						total: true,		/* report total amount of bytes */
+						color: "00ff00",	/* 3g_wwan is green */
+						title: "TMobile LTEBytes (TX)"
+					},
+					if_octets_3g_wwan_rx: {
+						flip : true,		/* flip rx line */
+						total: true,		/* report total amount of bytes */
+						color: "00ff00",	/* 3g_wwan is green */
+						title: "TMobile LTEBytes (RX)"
+					}
+				}
+			}
+		};
+
+		var types = graph.dataTypes(host, plugin, plugin_instance);
+
+		for (var i = 0; i < types.length; i++)
+			if (types[i] == 'cpu')
+				p.push(cpu);
+			else if (types[i] == 'if_octets')
+				p.push(if_octets);
+
+		return p;
+	}
+});

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
@@ -15,6 +15,13 @@ return baseclass.extend({
 		if (plugin_instance != '')
 			title = "Category: %pi";
 
+		/* 
+			Todo: use uci to get the interface names and use them to replace 
+			eth1 and 3g_wwan in all of the below 
+			Example:
+			var interface_name = uci.get("network", "wan", "device");
+		*/
+
 		var if_octets = {
 			title: title,
 			y_min: "0",

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
@@ -13,11 +13,11 @@ return baseclass.extend({
 		var title = "%H: Traffic usage";
 
 		if (plugin_instance != '')
-			title = "Category: %pi";
+			title = "Application: %pi";
 
 		/* 
 			Todo: use uci to get the interface names and use them to replace 
-			eth1 and 3g_wwan in all of the below 
+			the hardcoded eth1 and 3g_wwan in all of the below 
 			Example:
 			var interface_name = uci.get("network", "wan", "device");
 		*/
@@ -37,25 +37,25 @@ return baseclass.extend({
 				},
 				options: {
 					if_octets_eth1_tx: {
-						total: true,		/* report total amount of bytes */
+						total: true,		
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
 					if_octets_eth1_rx: {
 						flip : true,		/* flip rx line */
-						total: true,		/* report total amount of bytes */
+						total: true,		
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
 					if_octets_3g_wwan_tx: {
-						total: true,		/* report total amount of bytes */
+						total: true,		
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
 					if_octets_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
-						total: true,		/* report total amount of bytes */
+						total: true,		
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (RX)"
 					}
@@ -66,10 +66,10 @@ return baseclass.extend({
 		var types = graph.dataTypes(host, plugin, plugin_instance);
 
 		for (var i = 0; i < types.length; i++)
-			if (types[i] == 'cpu')
-				p.push(cpu);
-			else if (types[i] == 'if_octets')
+			if (types[i] == 'if_octets')
 				p.push(if_octets);
+			// else if (types[i] == 'total_bytes') /* Todo: add support for total bytes */
+			// 	p.push(total_bytes);
 
 		return p;
 	}

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/application.js
@@ -15,38 +15,38 @@ return baseclass.extend({
 		if (plugin_instance != '')
 			title = "Category: %pi";
 
-		var total_bytes = {
+		var if_octets = {
 			title: title,
 			y_min: "0",
 			alt_autoscale_max: true,
 			vlabel: "Bytes/s",
 			data: {
 				instances: {
-					total_bytes: [ "3g_wwan", "eth1"]
+					if_octets: [ "3g_wwan", "eth1"]
 				},
 				sources: {
-					total_bytes: [ "tx", "rx" ],
-					total_bytes: [ "tx", "rx" ]
+					if_octets: [ "tx", "rx" ],
+					if_octets: [ "tx", "rx" ]
 				},
 				options: {
-					total_bytes_eth1_tx: {
+					if_octets_eth1_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
-					total_bytes_eth1_rx: {
+					if_octets_eth1_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
-					total_bytes_3g_wwan_tx: {
+					if_octets_3g_wwan_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
-					total_bytes_3g_wwan_rx: {
+					if_octets_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
@@ -61,8 +61,8 @@ return baseclass.extend({
 		for (var i = 0; i < types.length; i++)
 			if (types[i] == 'cpu')
 				p.push(cpu);
-			else if (types[i] == 'total_bytes')
-				p.push(total_bytes);
+			else if (types[i] == 'if_octets')
+				p.push(if_octets);
 
 		return p;
 	}

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -15,38 +15,38 @@ return baseclass.extend({
 		if (plugin_instance != '')
 			title = "Category: %pi";
 
-		var if_octets = {
+		var total_bytes = {
 			title: title,
 			y_min: "0",
 			alt_autoscale_max: true,
 			vlabel: "Bytes/s",
 			data: {
 				instances: {
-					if_octets: [ "3g_wwan", "eth1"]
+					total_bytes: [ "3g_wwan", "eth1"]
 				},
 				sources: {
-					if_octets: [ "tx", "rx" ],
-					if_octets: [ "tx", "rx" ]
+					total_bytes: [ "tx", "rx" ],
+					total_bytes: [ "tx", "rx" ]
 				},
 				options: {
-					if_octets_eth1_tx: {
+					total_bytes_eth1_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
-					if_octets_eth1_rx: {
+					total_bytes_eth1_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
-					if_octets_3g_wwan_tx: {
+					total_bytes_3g_wwan_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
-					if_octets_3g_wwan_rx: {
+					total_bytes_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
@@ -61,8 +61,8 @@ return baseclass.extend({
 		for (var i = 0; i < types.length; i++)
 			if (types[i] == 'cpu')
 				p.push(cpu);
-			else if (types[i] == 'if_octets')
-				p.push(if_octets);
+			else if (types[i] == 'total_bytes')
+				p.push(total_bytes);
 
 		return p;
 	}

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -5,7 +5,7 @@
 'require uci';
 
 return baseclass.extend({
-	title: _('Application Category'),
+	title: _('Category'),
 
 	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
 		var p = [];
@@ -17,7 +17,7 @@ return baseclass.extend({
 
 		/* 
 			Todo: use uci to get the interface names and use them to replace 
-			eth1 and 3g_wwan in all of the below 
+			the hardcoded eth1 and 3g_wwan in all of the below 
 			Example:
 			var interface_name = uci.get("network", "wan", "device");
 		*/
@@ -37,25 +37,25 @@ return baseclass.extend({
 				},
 				options: {
 					if_octets_eth1_tx: {
-						total: true,		/* report total amount of bytes */
+						total: true,		
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
 					if_octets_eth1_rx: {
 						flip : true,		/* flip rx line */
-						total: true,		/* report total amount of bytes */
+						total: true,	
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
 					if_octets_3g_wwan_tx: {
-						total: true,		/* report total amount of bytes */
+						total: true,	
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
 					if_octets_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
-						total: true,		/* report total amount of bytes */
+						total: true,		
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (RX)"
 					}
@@ -66,10 +66,10 @@ return baseclass.extend({
 		var types = graph.dataTypes(host, plugin, plugin_instance);
 
 		for (var i = 0; i < types.length; i++)
-			if (types[i] == 'cpu')
-				p.push(cpu);
-			else if (types[i] == 'if_octets')
+			if (types[i] == 'if_octets')
 				p.push(if_octets);
+			// else if (types[i] == 'total_bytes')
+			// 	p.push(total_bytes);
 
 		return p;
 	}

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -28,27 +28,28 @@ return baseclass.extend({
 					]
 				},
 				sources: {
-					if_octets: [ "tx", "rx" ]
+					category_3g_wwan: [ "tx", "rx" ],
+					category_eth1: [ "tx", "rx" ]
 				},
 				options: {
-					if_octets_eth1__tx: {
+					category_eth1_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
-					if_octets_eth1__rx: {
+					category_eth1_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
-					
-					if_octets_3g_wwan__tx: {
+
+					category_3g_wwan_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
-					if_octets_3g_wwan__rx: {
+					category_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -17,63 +17,39 @@ return baseclass.extend({
 
 		var show_idle = uci.get("luci_statistics", "collectd_category", "ShowIdle") == "1" ? true : false;
 
-		if (uci.get("luci_statistics", "collectd_category", "ReportByState") == "1") {
-			var total_bytes = {
-				title: title,
-				y_min: "0",
-				alt_autoscale_max: true,
-				vlabel: "Total Bytes",
-				number_format: "%5.1lf%%",
-				data: {
-					instances: {
-						total_bytes: [
-							"3g_wwan",
-							"eth1"
-						]
+		var total_bytes = {
+			title: title,
+			y_min: "0",
+			alt_autoscale_max: true,
+			vlabel: "Total Bytes",
+			number_format: "%5.1lf%%",
+			data: {
+				instances: {
+					total_bytes: [
+						"3g_wwan",
+						"eth1"
+					]
+				},
+				options: {
+					total_bytes_3g_wwan: {
+						color: "ffffff",
+						title: "TMobile LTE"
 					},
-					options: {
-						total_bytes_3g_wwan: {
-							color: "ffffff",
-							title: "TMobile LTE"
-						},
-						total_bytes_eth1: {
-							color: "a000a0",
-							title: "Viasat"
-						}
+					total_bytes_eth1: {
+						color: "a000a0",
+						title: "Viasat"
 					}
 				}
-			};
+			}
+		};
 
-			var types = graph.dataTypes(host, plugin, plugin_instance);
+		var types = graph.dataTypes(host, plugin, plugin_instance);
 
-			for (var i = 0; i < types.length; i++)
-				if (types[i] == 'cpu')
-					p.push(cpu);
-				else if (types[i] == 'total_bytes')
-					p.push(total_bytes);
-		}
-		else {
-			p = {
-				title: title,
-				y_min: "0",
-				alt_autoscale_max: true,
-				vlabel: "Percent",
-				number_format: "%5.1lf%%",
-				data: {
-					instances: {
-						percent: [
-							"active",
-						]
-					},
-					options: {
-						percent_active: {
-							color: "00e000",
-							title: "Active"
-						}
-					}
-				}
-			};
-		}
+		for (var i = 0; i < types.length; i++)
+			if (types[i] == 'cpu')
+				p.push(cpu);
+			else if (types[i] == 'total_bytes')
+				p.push(total_bytes);
 
 		return p;
 	}

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -13,31 +13,46 @@ return baseclass.extend({
 		var title = "%H: Traffic usage";
 
 		if (plugin_instance != '')
-			title = "Category=%pi traffic";
+			title = "Category: %pi";
 
-		var show_idle = uci.get("luci_statistics", "collectd_category", "ShowIdle") == "1" ? true : false;
-
-		var total_bytes = {
+		var if_octets = {
 			title: title,
 			y_min: "0",
 			alt_autoscale_max: true,
-			vlabel: "Total Bytes",
-			number_format: "%5.1lf%%",
+			vlabel: "Bytes/s",
 			data: {
 				instances: {
-					total_bytes: [
+					category: [
 						"3g_wwan",
 						"eth1"
 					]
 				},
+				sources: {
+					if_octets: [ "tx", "rx" ]
+				},
 				options: {
-					total_bytes_3g_wwan: {
-						color: "ffffff",
-						title: "TMobile LTE"
+					if_octets_eth1__tx: {
+						total: true,		/* report total amount of bytes */
+						color: "0000ff",	/* eth1 is blue */
+						title: "Viasat Bytes (TX)"
 					},
-					total_bytes_eth1: {
-						color: "a000a0",
-						title: "Viasat"
+					if_octets_eth1__rx: {
+						flip : true,		/* flip rx line */
+						total: true,		/* report total amount of bytes */
+						color: "0000ff",	/* eth1 is blue */
+						title: "Viasat Bytes (RX)"
+					}
+
+					if_octets_3g_wwan__tx: {
+						total: true,		/* report total amount of bytes */
+						color: "00ff00",	/* 3g_wwan is green */
+						title: "TMobile LTEBytes (TX)"
+					},
+					if_octets_3g_wwan__rx: {
+						flip : true,		/* flip rx line */
+						total: true,		/* report total amount of bytes */
+						color: "00ff00",	/* 3g_wwan is green */
+						title: "TMobile LTEBytes (RX)"
 					}
 				}
 			}
@@ -48,8 +63,8 @@ return baseclass.extend({
 		for (var i = 0; i < types.length; i++)
 			if (types[i] == 'cpu')
 				p.push(cpu);
-			else if (types[i] == 'total_bytes')
-				p.push(total_bytes);
+			else if (types[i] == 'if_octets')
+				p.push(if_octets);
 
 		return p;
 	}

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -15,6 +15,13 @@ return baseclass.extend({
 		if (plugin_instance != '')
 			title = "Category: %pi";
 
+		/* 
+			Todo: use uci to get the interface names and use them to replace 
+			eth1 and 3g_wwan in all of the below 
+			Example:
+			var interface_name = uci.get("network", "wan", "device");
+		*/
+
 		var if_octets = {
 			title: title,
 			y_min: "0",

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -28,8 +28,8 @@ return baseclass.extend({
 					]
 				},
 				sources: {
-					if_octets_3g_wwan: [ "tx", "rx" ],
-					if_octets_eth1: [ "tx", "rx" ]
+					category_3g_wwan: [ "tx", "rx" ],
+					category_eth1: [ "tx", "rx" ]
 				},
 				options: {
 					category_eth1_tx: {

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -1,0 +1,47 @@
+/* Licensed to the public under the Apache License 2.0. */
+
+'use strict';
+'require baseclass';
+
+return baseclass.extend({
+	title: _('Application Category'),
+
+	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
+		/*
+		 * traffic diagram
+		 */
+		var traffic = {
+
+			/* draw this diagram for each plugin instance */
+			per_instance: true,
+			title: "%H: Transfer on %pi",
+			vlabel: "Bytes/s",
+
+			/* diagram data description */
+			data: {
+				/* defined sources for data types, if omitted assume a single DS named "value" (optional) */
+				sources: {
+					if_octets: [ "tx", "rx" ]
+				},
+
+				/* special options for single data lines */
+				options: {
+					if_octets__tx: {
+						total: true,		/* report total amount of bytes */
+						color: "00ff00",	/* tx is green */
+						title: "Bytes (TX)"
+					},
+
+					if_octets__rx: {
+						flip : true,		/* flip rx line */
+						total: true,		/* report total amount of bytes */
+						color: "0000ff",	/* rx is blue */
+						title: "Bytes (RX)"
+					}
+				}
+			}
+		};
+
+		return [ traffic ];
+	}
+});

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -22,34 +22,31 @@ return baseclass.extend({
 			vlabel: "Bytes/s",
 			data: {
 				instances: {
-					category: [
-						"3g_wwan",
-						"eth1"
-					]
+					if_octets: [ "3g_wwan", "eth1"]
 				},
 				sources: {
-					category_3g_wwan: [ "tx", "rx" ],
-					category_eth1: [ "tx", "rx" ]
+					if_octets: [ "tx", "rx" ],
+					if_octets: [ "tx", "rx" ]
 				},
 				options: {
-					category_eth1_tx: {
+					if_octets_eth1_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
-					category_eth1_rx: {
+					if_octets_eth1_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
-					category_3g_wwan_tx: {
+					if_octets_3g_wwan_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
-					category_3g_wwan_rx: {
+					if_octets_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -32,24 +32,24 @@ return baseclass.extend({
 					if_octets_eth1: [ "tx", "rx" ]
 				},
 				options: {
-					if_octets_eth1_tx: {
+					category_eth1_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
-					if_octets_eth1_rx: {
+					category_eth1_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
-					if_octets_3g_wwan_tx: {
+					category_3g_wwan_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
-					if_octets_3g_wwan_rx: {
+					category_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -28,28 +28,28 @@ return baseclass.extend({
 					]
 				},
 				sources: {
-					category_3g_wwan: [ "tx", "rx" ],
-					category_eth1: [ "tx", "rx" ]
+					if_octets_3g_wwan: [ "tx", "rx" ],
+					if_octets_eth1: [ "tx", "rx" ]
 				},
 				options: {
-					category_eth1_tx: {
+					if_octets_eth1_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
-					category_eth1_rx: {
+					if_octets_eth1_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
-					category_3g_wwan_tx: {
+					if_octets_3g_wwan_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
-					category_3g_wwan_rx: {
+					if_octets_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -41,8 +41,8 @@ return baseclass.extend({
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
-					}
-
+					},
+					
 					if_octets_3g_wwan__tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/category.js
@@ -15,38 +15,38 @@ return baseclass.extend({
 		if (plugin_instance != '')
 			title = "Category: %pi";
 
-		var total_bytes = {
+		var if_octets = {
 			title: title,
 			y_min: "0",
 			alt_autoscale_max: true,
 			vlabel: "Bytes/s",
 			data: {
 				instances: {
-					total_bytes: [ "3g_wwan", "eth1"]
+					if_octets: [ "3g_wwan", "eth1"]
 				},
 				sources: {
-					total_bytes: [ "tx", "rx" ],
-					total_bytes: [ "tx", "rx" ]
+					if_octets: [ "tx", "rx" ],
+					if_octets: [ "tx", "rx" ]
 				},
 				options: {
-					total_bytes_eth1_tx: {
+					if_octets_eth1_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (TX)"
 					},
-					total_bytes_eth1_rx: {
+					if_octets_eth1_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "0000ff",	/* eth1 is blue */
 						title: "Viasat Bytes (RX)"
 					},
 
-					total_bytes_3g_wwan_tx: {
+					if_octets_3g_wwan_tx: {
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
 						title: "TMobile LTEBytes (TX)"
 					},
-					total_bytes_3g_wwan_rx: {
+					if_octets_3g_wwan_rx: {
 						flip : true,		/* flip rx line */
 						total: true,		/* report total amount of bytes */
 						color: "00ff00",	/* 3g_wwan is green */
@@ -61,8 +61,8 @@ return baseclass.extend({
 		for (var i = 0; i < types.length; i++)
 			if (types[i] == 'cpu')
 				p.push(cpu);
-			else if (types[i] == 'total_bytes')
-				p.push(total_bytes);
+			else if (types[i] == 'if_octets')
+				p.push(if_octets);
 
 		return p;
 	}


### PR DESCRIPTION
This adds two definition files -- one for applications and one for application categories. When this is merged, and deployed, you will see two new files in /www/luci-static/resources/statistics/rrdtool/definitions and you will see two new tabs under Statistics/Graphs in Luci.

![image](https://user-images.githubusercontent.com/4001792/157671903-51f51ada-0477-4568-917b-01b11c0382f7.png)
