### PR TITLE
luci-app-ledtrig-ath10k: initial checkin

### DIFF
--- a/applications/luci-app-ledtrig-ath10k/Makefile
+++ b/applications/luci-app-ledtrig-ath10k/Makefile
@@ -1,0 +1,16 @@
+#
+# Copyright (C) 2022 TDT AG <development@tdt.de>
+#
+# This is free software, licensed under the Apache License Version 2.0.
+# See https://www.apache.org/licenses/LICENSE-2.0 for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:= LuCI Support for ath10k led trigger
+LUCI_PKGARCH:=all
+LUCI_DEPENDS:=@(ATH10K_LEDS||ATH10K-CT_LEDS)
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-ath10k/htdocs/luci-static/resources/view/system/led-trigger/ath10k.js
+++ b/applications/luci-app-ledtrig-ath10k/htdocs/luci-static/resources/view/system/led-trigger/ath10k.js
@@ -1,0 +1,45 @@
+'use strict';
+'require baseclass';
+'require form';
+'require fs';
+'require uci';
+
+return baseclass.extend({
+	trigger: _('Wireless trigger (ath10k)'),
+	description: _('This LED trigger can be used for signalling the wireless state.'),
+	kernel: false,
+	addFormOptions(s){
+		var o;
+		var device;
+
+		device = s.option(form.ListValue, 'ath10k_device', _('Device'));
+		device.modalonly = true;
+		device.ucioption = "device";
+		device.depends('trigger', 'ath10k');
+		device.load = function(s) {
+			return Promise.all([
+				L.resolveDefault(fs.list('/sys/class/ieee80211/'), '')
+			]).then(L.bind(function(devices){
+				var phys = devices[0];
+				for (var i = 0; i < phys.length; i++)
+					device.value(phys[i].name);
+			}, this));
+		};
+		device.cfgvalue = function (section_id) {
+			return uci.get('system', section_id, 'device');
+		}
+
+		o = s.option(form.ListValue, 'ath10k_function', _('Trigger'));
+		o.modalonly = true;
+		o.ucioption = "function";
+		o.depends('trigger', 'ath10k');
+		o.value('assoc', _('Client connected (assoc)'));
+		o.value('radio', _('Interface enabled (radio)'));
+		o.value('rx', _('Activity (rx)'));
+		o.value('tx', _('Activity (tx)'));
+		o.value('tpt', _('Throughput activity (tpt)'));
+		o.cfgvalue = function (section_id) {
+			return uci.get('system', section_id, 'function');
+		}
+	}
+});


### PR DESCRIPTION
This depends one the following changes. https://patchwork.ozlabs.org/project/openwrt/list/?series=290888
This should fixed https://github.com/openwrt/openwrt/issues/9292

This change adds an application trigger ath10k under "/usr/libexec/led-trigger". The kernel LED API of the ath10k does not behave like the netdev trigger. For the netdev trigger, the interface to use can be set under /sys/class/leds/<led-device>device_name. For the LED ath10k, the interface is added to the supported trigger name.

So we have for one interface (phy0) the following triggers for each LED.
- phy0rx
- phy0tx
- phy0assoc
- phy0radio
- phy0tpt

To make it easier for us to configure this, there is now an application trigger. This has additional uci options.
- device: which interface we want to use (phyX)
- function: which trigger function we want to use (rx|tx|assoc|radio|tpt)

The trigger now behaves the same way again netdev trigger.

This change is backwards compatible. If the kernel trigger names are used (phy<X>rx | phy<X>tx | phy<X>assoc | phy<X>radio | phy<X>tpt) this will continue to work.

With this change it is now easier to create a LUCI configuration page without Javascript magic.


Signed-off-by: Florian Eckert <fe@dev.tdt.de>