### PR TITLE
luci-proto-wireguard: add generate psk button

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -25,6 +25,12 @@ var generateQrCode = rpc.declare({
 	expect: { qr_code: '' }
 });
 
+var generatePsk = rpc.declare({
+	object: 'luci.wireguard',
+	method: 'generatePsk',
+	expect: { psk: '' }
+});
+
 function validateBase64(section_id, value) {
 	if (value.length == 0)
 		return true;
@@ -272,6 +278,18 @@ return network.registerProtocol('wireguard', {
 		o.password = true;
 		o.validate = validateBase64;
 		o.optional = true;
+
+		o = ss.option(form.Button, 'generate_key', _('Generate Key'));
+		o.inputstyle = 'apply';
+		o.onclick = ui.createHandlerFn(this, function (section_id, ev, peer_id) {
+			return generatePsk().then(function (psk) {
+				var keyInput = document.getElementById('widget.cbid.network.%s.preshared_key'.format(peer_id)),
+					changeEvent = new Event('change');
+
+				keyInput.value = psk;
+				keyInput.dispatchEvent(changeEvent);
+			});
+		}, s.section);
 
 		o = ss.option(form.DynamicList, 'allowed_ips', _('Allowed IPs'), _("Optional. IP addresses and prefixes that this peer is allowed to use inside the tunnel. Usually the peer's tunnel IP addresses and the networks the peer routes through the tunnel."));
 		o.datatype = 'ipaddr';

--- a/protocols/luci-proto-wireguard/root/usr/libexec/rpcd/luci.wireguard
+++ b/protocols/luci-proto-wireguard/root/usr/libexec/rpcd/luci.wireguard
@@ -8,6 +8,13 @@ local uci = require "uci"
 local fs = require "nixio.fs"
 
 local methods = {
+	generatePsk = {
+		call = function()
+			local psk = sys.exec("wg genpsk"):sub(1, -2)
+
+			return {psk = psk}
+		end
+	},
 	generateKeyPair = {
 		call = function()
 			local prv = sys.exec("wg genkey 2>/dev/null"):sub(1, -2)

--- a/protocols/luci-proto-wireguard/root/usr/share/rpcd/acl.d/luci-wireguard.json
+++ b/protocols/luci-proto-wireguard/root/usr/share/rpcd/acl.d/luci-wireguard.json
@@ -6,7 +6,8 @@
 				"luci.wireguard": [
 					"generateKeyPair",
 					"getPublicAndPrivateKeyFromPrivate",
-					"generateQrCode"
+					"generateQrCode",
+					"generatePsk"
 				]
 			}
 		}


### PR DESCRIPTION
Adds a "Generate Key" button to be able to generate a preshared key within LuCI.

![generate key button](https://user-images.githubusercontent.com/60816858/159019018-1e3c2e55-762f-4749-84e1-24587153b0ee.png)
