### PR TITLE
luci-lib-jsonc: stringify int use json_object_new_int64 instead

### DIFF
--- a/libs/luci-lib-jsonc/src/jsonc.c
+++ b/libs/luci-lib-jsonc/src/jsonc.c
@@ -368,7 +368,7 @@ static struct json_object * _lua_to_json_rec(lua_State *L, int index,
 		ni = lua_tointeger(L, index);
 
 		if (nd == ni)
-			return json_object_new_int(nd);
+			return json_object_new_int64(nd);
 
 		return json_object_new_double(nd);
 


### PR DESCRIPTION
Fixes: #3293
Signed-off-by: Justin Klaassen <jck112@users.noreply.github.com>