### PR TITLE
luci-app-openvpn: fix openvpn config corruption on upload

### DIFF
--- a/applications/luci-app-openvpn/luasrc/controller/openvpn.lua
+++ b/applications/luci-app-openvpn/luasrc/controller/openvpn.lua
@@ -31,8 +31,7 @@ function ovpn_upload()
 
 		http.setfilehandler(
 			function(meta, chunk, eof)
-				local data = util.trim(chunk:gsub("\r\n", "\n")) .. "\n"
-				data = util.trim(data:gsub("[\128-\255]", ""))
+				local data = chunk:gsub("\r\n", "\n")
 
 				if not fp and meta and meta.name == "ovpn_file" then
 					fp = io.open(file, "w")

--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-file.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-file.lua
@@ -51,7 +51,7 @@ function file.cfgvalue()
 end
 
 function file.write(self, section, data1)
-	return fs.writefile(cfg_file, "\n" .. util.trim(data1:gsub("\r\n", "\n")) .. "\n")
+	return fs.writefile(cfg_file, util.trim(data1:gsub("\r\n", "\n")) .. "\n")
 end
 
 function file.remove(self, section, value)


### PR DESCRIPTION
Fix openvpn config corruption on upload.
This fixed issue #5731
Corruption was caused by applying trim to the chunks of the file.

Signed-off-by: Anna Tikhomirova <vamp@vampik.ru>