### PR TITLE
luci-proto-openconnect: add request parameter

### DIFF
--- a/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
+++ b/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
@@ -106,6 +106,9 @@ return network.registerProtocol('openconnect', {
 		o.placeholder = '443';
 		o.datatype    = 'port';
 
+		o = s.taboption('general', form.Value, 'request', _('VPN Server URL request additional parameter'));
+		o.placeholder = '/';
+
 		s.taboption('general', form.Value, 'serverhash', _("VPN Server's certificate SHA1 hash"));
 		s.taboption('general', form.Value, 'authgroup', _('Auth Group'));
 		s.taboption('general', form.Value, 'usergroup', _('User Group'));


### PR DESCRIPTION
When a VPN server require specified URL with parameters (for example: https://vpn.example.com/specialparameter) you can set it up in JSON 'require' option.

This is depends on https://github.com/openwrt/packages/pull/18120