### PR TITLE
luci-app-attendedsysupgrade: request filesystem

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -79,13 +79,14 @@ return view.extend({
 		version: '',
 		packages: [],
 		diff_packages: true,
+		filesystem: '',
 	},
 
 	handle200: function (response) {
 		res = response.json();
 		var image;
 		for (image of res.images) {
-			if (this.data.rootfs_type == image.filesystem) {
+			if (this.firmware.filesystem == image.filesystem) {
 				if (this.data.efi) {
 					if (image.type == 'combined-efi') {
 						break;
@@ -402,7 +403,6 @@ return view.extend({
 			L.resolveDefault(callPackagelist(), {}),
 			L.resolveDefault(callSystemBoard(), {}),
 			L.resolveDefault(fs.stat("/sys/firmware/efi"), null),
-			fs.read("/proc/mounts"),
 			uci.load('attendedsysupgrade'),
 		]);
 	},
@@ -415,13 +415,10 @@ return view.extend({
 		this.firmware.target = res[1].release.target;
 		this.firmware.version = res[1].release.version;
 		this.data.branch = get_branch(res[1].release.version);
+		this.firmware.filesystem = res[1].rootfs_type;
 		this.data.revision = res[1].release.revision;
+
 		this.data.efi = res[2];
-		if (res[1].rootfs_type) {
-			this.data.rootfs_type = res[1].rootfs_type;
-		} else {
-			this.data.rootfs_type = res[3].split(/\r?\n/)[0].split(' ')[2]
-		}
 
 		this.data.url = uci.get_first('attendedsysupgrade', 'server', 'url');
 		this.data.advanced_mode = uci.get_first('attendedsysupgrade', 'client', 'advanced_mode') || 0

--- a/applications/luci-app-attendedsysupgrade/root/usr/share/rpcd/acl.d/luci-app-attendedsysupgrade.json
+++ b/applications/luci-app-attendedsysupgrade/root/usr/share/rpcd/acl.d/luci-app-attendedsysupgrade.json
@@ -16,8 +16,7 @@
 				]
 			},
 			"file": {
-				"/sys/firmware/efi": [ "list" ],
-				"/proc/mounts": [ "read" ]
+				"/sys/firmware/efi": [ "list" ]
 			},
 			"uci": [
 				"attendedsysupgrade"


### PR DESCRIPTION
It is possible to request a specific filesystem so no other filesystems
are used. This speeds up the build process and may prevent failures in
edge cases.

A recent edge case is installing more packages than ext4 can handle
while squashfs works fine due to compression.

Signed-off-by: Paul Spooren <mail@aparcar.org>