### PR TITLE
luci-app-ledtrig-switch: add trigger mode option

### DIFF
--- a/applications/luci-app-ledtrig-switch/htdocs/luci-static/resources/view/system/led-trigger/switch0.js
+++ b/applications/luci-app-ledtrig-switch/htdocs/luci-static/resources/view/system/led-trigger/switch0.js
@@ -8,12 +8,23 @@ return baseclass.extend({
 	addFormOptions(s){
 		var o;
 
-		o = s.option(form.Value, 'port_mask', _('Switch Port Mask'));
+		o = s.option(form.Value, 'switch0_port_mask', _('Switch Port Mask'));
+		o.ucioption = "port_mask";
 		o.modalonly = true;
 		o.depends('trigger', 'switch0');
 
-		o = s.option(form.Value, 'speed_mask', _('Switch Speed Mask'));
+		o = s.option(form.Value, 'switch0_speed_mask', _('Switch Speed Mask'));
+		o.ucioption = "speed_mask";
 		o.modalonly = true;
 		o.depends('trigger', 'switch0');
+
+		o = s.option(form.MultiValue, 'switch0_mode', _('Trigger Mode'));
+		o.ucioption = "mode";
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('trigger', 'switch0');
+		o.value('link', _('Link On'));
+		o.value('tx', _('Transmit'));
+		o.value('rx', _('Receive'));
 	}
 });

--- a/applications/luci-app-ledtrig-switch/htdocs/luci-static/resources/view/system/led-trigger/switch1.js
+++ b/applications/luci-app-ledtrig-switch/htdocs/luci-static/resources/view/system/led-trigger/switch1.js
@@ -8,12 +8,23 @@ return baseclass.extend({
 	addFormOptions(s){
 		var o;
 
-		o = s.option(form.Value, 'port_mask', _('Switch Port Mask'));
+		o = s.option(form.Value, 'switch1_port_mask', _('Switch Port Mask'));
+		o.ucioption = "port_mask";
 		o.modalonly = true;
 		o.depends('trigger', 'switch1');
 
-		o = s.option(form.Value, 'speed_mask', _('Switch Speed Mask'));
+		o = s.option(form.Value, 'switch1_speed_mask', _('Switch Speed Mask'));
+		o.ucioption = "speed_mask";
 		o.modalonly = true;
 		o.depends('trigger', 'switch1');
+
+		o = s.option(form.MultiValue, 'switch1_mode', _('Trigger Mode'));
+		o.ucioption = "mode";
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('trigger', 'switch1');
+		o.value('link', _('Link On'));
+		o.value('tx', _('Transmit'));
+		o.value('rx', _('Receive'));
 	}
 });


### PR DESCRIPTION
Also fix issue of options being overwritten:
switch0.js switch1.js use the same option name, and one would
overwrite the other
