### PR TITLE
[22.03]luci-mod-status,mod-network: Added fqdn-name to DHCPv4 lease table

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -726,8 +726,17 @@ return view.extend({
 							else
 								exp = '%t'.format(lease.expires);
 
+							var hint = lease.macaddr ? hosts[lease.macaddr] : null,
+							    name = hint ? hint.name : null,
+							    host = null;
+
+							if (name && lease.hostname && lease.hostname != name)
+								host = '%s (%s)'.format(lease.hostname, name);
+							else if (lease.hostname)
+								host = lease.hostname;
+
 							return [
-								lease.hostname || '?',
+								host || '-',
 								lease.ipaddr,
 								lease.macaddr,
 								exp

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -102,8 +102,16 @@ return baseclass.extend({
 			else
 				exp = '%t'.format(lease.expires);
 
+			var hint = lease.macaddr ? machints.filter(function(h) { return h[0] == lease.macaddr })[0] : null,
+			    host = null;
+
+			if (hint && lease.hostname && lease.hostname != hint[1])
+				host = '%s (%s)'.format(lease.hostname, hint[1]);
+			else if (lease.hostname)
+				host = lease.hostname;
+
 			rows = [
-				lease.hostname || '-',
+				host || '-',
 				lease.ipaddr,
 				lease.macaddr,
 				exp


### PR DESCRIPTION
Added code to display fcdn-name in DHCPv4 lease table.
(based on code in DHCPv6 lease table)

Signed-off-by: Max S Kash <asukms@ya.ru>
Indentation adjused and wrapped commit message
Signed-off-by: Florian Eckert <fe@dev.tdt.de>

cherry pick from master https://github.com/openwrt/luci/commit/8a46648e5bfb4b8f4d2452c51b5181631d260b6f