### PR TITLE
luci-mod-system: mount sections are always mounted unless they are explicitly not mounted

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/mounts.js
@@ -242,6 +242,7 @@ return view.extend({
 
 		o = s.taboption('general', form.Flag, 'enabled', _('Enabled'));
 		o.rmempty  = false;
+		o.default = true;
 		o.editable = true;
 
 		o = s.taboption('general', form.DummyValue, '_device', _('Device'));


### PR DESCRIPTION
fixes #4862