### PR TITLE
luci-app-rp-pppoe-server: use netlist template

### DIFF
--- a/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
+++ b/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
@@ -13,7 +13,7 @@ s.addremove = true
 s.anonymous = true
 
 o = s:option(Value, "interface", translate("Interface"), translate("Interface on which to listen."))
-o.template = "cbi/network_ifacelist"
+o.template = "cbi/network_netlist"
 o.nocreate = true
 
 o = s:option(Value, "ac_name", translate("Access Concentrator Name"))


### PR DESCRIPTION
pppoe-server init script is expecting an OpenWRT interface name. The physical device name is looked up by the init script. 

So config 'interface' should be equal to an interface name e.g LAN not a physical device e.g eth0

This PR fixes the luci application to select Interfaces, not physical devices.