### PR TITLE
luci-app-advanced-reboot: Add support for Linksys EA7500 v2

### DIFF
--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea7500v2.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea7500v2.json
@@ -1,0 +1,15 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "EA7500v2",
+	"boardNames": [ "linksys,ea7500-v2" ],
+	"partition1MTD": "mtd5",
+	"partition2MTD": "mtd7",
+	"labelOffset": 32,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": "bootcmd",
+	"bootEnv2Partition1Value": "run nandboot",
+	"bootEnv2Partition2Value": "run altnandboot"
+}
+


### PR DESCRIPTION
Very similar to the EA7300 v2. Tested and working. Some details,
```
# (dmesg | grep machine)
[    0.000000] MIPS: machine is Linksys EA7500 v2
```
```
# cat /proc/mtd
dev:    size   erasesize  name
mtd0: 00080000 00020000 "boot"
mtd1: 00040000 00020000 "u_env"
mtd2: 00040000 00020000 "factory"
mtd3: 00040000 00020000 "s_env"
mtd4: 00040000 00020000 "devinfo"
mtd5: 00400000 00020000 "kernel1"
mtd6: 02400000 00020000 "rootfs1"
mtd7: 00400000 00020000 "kernel2"
mtd8: 02400000 00020000 "ubi"
mtd9: 00100000 00020000 "sysdiag"
mtd10: 02d00000 00020000 "syscfg"
```
```
# ubus call system board
{
        "kernel": "5.10.111",
        "hostname": "OpenWrt",
        "system": "MediaTek MT7621 ver:1 eco:3",
        "model": "Linksys EA7500 v2",
        "board_name": "linksys,ea7500-v2",
        "rootfs_type": "squashfs",
        "release": {
                "distribution": "OpenWrt",
                "version": "SNAPSHOT",
                "revision": "r19508-0d2d52df69",
                "target": "ramips/mt7621",
                "description": "OpenWrt SNAPSHOT r19508-0d2d52df69"
        }
}
```

Signed-off-by: Russell Morris <rmorris@rkmorris.us>