### PR TITLE
luci-app-frpc/frps: fix service status bar style

### DIFF
--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -135,7 +135,7 @@ function getServiceStatus() {
 
 function renderStatus(isRunning) {
 	var renderHTML = "";
-	var spanTemp = "<span style=\"color:%s;font-weight:bold;margin-left:15px\">%s - %s</span>";
+	var spanTemp = '<em><span style="color:%s"><strong>%s %s</strong></span></em>';
 
 	if (isRunning) {
 		renderHTML += String.format(spanTemp, 'green', _("frp Client"), _("RUNNING"));
@@ -163,8 +163,8 @@ return view.extend({
 			});
 
 			return E('div', { class: 'cbi-map' },
-				E('div', { class: 'cbi-section'}, [
-					E('div', { id: 'service_status' },
+				E('fieldset', { class: 'cbi-section'}, [
+					E('p', { id: 'service_status' },
 						_('Collecting data ...'))
 				])
 			);

--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -110,7 +110,7 @@ function getServiceStatus() {
 
 function renderStatus(isRunning) {
 	var renderHTML = "";
-	var spanTemp = "<span style=\"color:%s;font-weight:bold;margin-left:15px\">%s - %s</span>";
+	var spanTemp = '<em><span style="color:%s"><strong>%s %s</strong></span></em>';
 
 	if (isRunning) {
 		renderHTML += String.format(spanTemp, 'green', _("frp Server"), _("RUNNING"));
@@ -138,8 +138,8 @@ return view.extend({
 			});
 
 			return E('div', { class: 'cbi-map' },
-				E('div', { class: 'cbi-section'}, [
-					E('div', { id: 'service_status' },
+				E('fieldset', { class: 'cbi-section'}, [
+					E('p', { id: 'service_status' },
 						_('Collecting data ...'))
 				])
 			);


### PR DESCRIPTION
mod the service status bar to use normaly 'cbi-section' class style.
Testing on openwrt master SNAPSHOT, also can be merge to openwrt-21.02/openwrt-22.03

before:
![style-before](https://user-images.githubusercontent.com/1388852/165915417-a7b6a9b5-772f-4832-8d34-b009004c7dbf.png)
after:
![style-fixed](https://user-images.githubusercontent.com/1388852/165915502-f760253f-10d3-4b20-9b82-b094b545f746.png)

