### PR TITLE
luci-theme-material: fix size of progressbar text

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1650,7 +1650,6 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
 
 .cbi-progressbar::after {
 	font-family: monospace;
-	font-size: 1.3em;
 	font-weight: bold;
 	font-size-adjust: .38;
 	line-height: normal;


### PR DESCRIPTION
The text of the progressbar is bigger than the progressbar height. This removes the font-size element that produced that.

Signed-off-by: Miguel Angel Mulero <mcgivergim@gmail.com>

This is a screen capture of the before:
![image](https://user-images.githubusercontent.com/2673520/165966155-6c1a9134-6a17-4693-b155-f2b96401fc5d.png)

and after:
![image](https://user-images.githubusercontent.com/2673520/165966041-0f5ebfde-0771-4139-8a5a-937b112fbc57.png)

I've tested it under Chrome in Windows and Android.