### PR TITLE
luci-material-theme: reduce size of logout icon

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -623,8 +623,8 @@ body[class*="node-"] > .main > .main-left > .nav > .slide > .menu.active::before
 .main > .main-left > .nav > li:last-child::before {
 	position: absolute;
 	left: 14px;
-	width: 24px;
-	height: 24px;
+	width: 20px;
+	height: 20px;
 	content: url(./icons/logout.svg);
 }
 


### PR DESCRIPTION
The icon of the logout option overflows the text. This reduces the size of the icon to not overflow.

Signed-off-by: Miguel Angel Mulero <mcgivergim@gmail.com>


This is before:
![image](https://user-images.githubusercontent.com/2673520/165969956-dc0e2c20-4249-45ad-881b-28fed5e14184.png)

And this is after:
![image](https://user-images.githubusercontent.com/2673520/165970056-96e6aeae-36b7-49fd-9535-d1a097de7239.png)

I've tested it under Chrome in Windows and Android.