### PR TITLE
luci-app-dockerman: Update to play nice with recent changes

### DIFF
--- a/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
+++ b/applications/luci-app-dockerman/luasrc/controller/dockerman.lua
@@ -9,7 +9,7 @@ module("luci.controller.dockerman",package.seeall)
 
 function index()
 	entry({"admin", "docker"},
-		alias("admin", "docker", "config"),
+		firstchild(),
 		_("Docker"),
 		40).acl_depends = { "luci-app-dockerman" }
 


### PR DESCRIPTION
https://github.com/openwrt/luci/commit/180d39dcd2427e3c32c0ec7ecc3c7bfb48c0d0ab broke dockerman's appearance in the menus

Make a small change to dockerman's index entry to make it play nice with the new architecture, firstchild() was obtained using DAWN's controller/dawn.lua as an example

signed-off