### PR TITLE
luci-material-theme: adjust data-title for logout

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -2649,7 +2649,7 @@ input[name="nslookup"] {
 	.main > .main-left > .nav > li,
 	.main > .main-left > .nav > li a,
 	.main > .main-left > .nav > .slide > .menu,
-	.main > .main-left > .nav > li > [data-title="Logout"] {
+	.main > .main-left > .nav > li:last-child > [data-title] {
 		font-size: .9rem;
 	}
 

--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -623,8 +623,8 @@ body[class*="node-"] > .main > .main-left > .nav > .slide > .menu.active::before
 .main > .main-left > .nav > li:last-child::before {
 	position: absolute;
 	left: 14px;
-	width: 20px;
-	height: 20px;
+	width: 24px;
+	height: 24px;
 	content: url(./icons/logout.svg);
 }
 


### PR DESCRIPTION
The data-title attribute style depends on the content in the css rule.
When translated to other language, the css rule fails.
This change uses the position and not the content to apply the style.

Signed-off-by: Miguel Angel Mulero <mcgivergim@gmail.com>

This PR reverts my earlier fix https://github.com/openwrt/luci/pull/5788 and adds a new commit to fix the issue in all languages.

Thanks to @castillofrancodamian for noticing that the problem was only with translated UI.


Before any fix for the logout in English:
![image](https://user-images.githubusercontent.com/2673520/166077197-48242d48-df13-4e49-b2ee-d716b952d96a.png)
And Spanish:
![image](https://user-images.githubusercontent.com/2673520/166077264-3679a0f2-fd71-4fd8-bb72-279db38dad59.png)
With my earlier fix:
![image](https://user-images.githubusercontent.com/2673520/166077301-bafd758c-84a3-411b-a839-093792ad8162.png)
Now in Spanish: 
![image](https://user-images.githubusercontent.com/2673520/166077126-39c0a997-a86f-4f0b-92a2-b56e5c4769b3.png)


