### PR TITLE
luci-material-theme: align td text width 33%

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -76,7 +76,8 @@
 	background: inherit;
 }
 
-.td[width="33%"] {
+.td[width="33%"], 
+.td[width="33%"]~.td {
 	padding: 1.1em;
 }
 


### PR DESCRIPTION
The CSS applies a different padding for td elements with 33% width. This
misaligns the text from this td to the others td.

This change modifies the CSS to apply the same padding to all of the
sibling td.

Signed-off-by: Miguel Angel Mulero Martinez <migmul@gmail.com>

This can be easily noted in phones, not in computers. This is before:
![image](https://user-images.githubusercontent.com/2673520/166097243-159a8e47-9c02-4de6-8218-0a5d7703e38d.png)

And this is after:
![image](https://user-images.githubusercontent.com/2673520/166097259-28f93713-e2d8-4027-b87b-cf00088cc19e.png)
