### PR TITLE
luci-material-theme: make control-group flex

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -2340,6 +2340,12 @@ input[name="nslookup"] {
 	margin-bottom: .2rem;
 }
 
+.control-group {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 2px;
+}
+
 [data-page="admin-system-opkg"] div.btn {
 	line-height: 3;
 	display: inline;


### PR DESCRIPTION
The control-group div does not flex. The buttons overflow the screen.

This change mades them flex.

Signed-off-by: Miguel Angel Mulero Martinez <migmul@gmail.com>

Before:
![image](https://user-images.githubusercontent.com/2673520/166098484-e8596865-b62f-43b0-8dfe-ce777fdd439a.png)

After:
![image](https://user-images.githubusercontent.com/2673520/166098501-b572558d-e50c-4d4c-a620-d27c499fd329.png)

