### PR TITLE
luci-material-theme: align text buttons center

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -200,6 +200,7 @@ input,
 	background-color: transparent;
 	background-image: none;
 	box-shadow: none;
+	align-items: center;
 }
 
 select,


### PR DESCRIPTION
The text inside the buttons is aligned to the top. This change mades
it aligned to the center.

Signed-off-by: Miguel Angel Mulero Martinez <migmul@gmail.com>

This is before this change:
![image](https://user-images.githubusercontent.com/2673520/166136439-b986e904-70b0-45da-b06c-c917627413e9.png)

And this is after:
![image](https://user-images.githubusercontent.com/2673520/166136451-592bc4af-2d45-42f8-a8f5-a02e65b122f7.png)
