### PR TITLE
luci-material-theme: fix localizated left menu

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -583,8 +583,7 @@ header > .fill > .container > .status > * {
 }
 
 .main > .main-left > .nav > .slide > .menu,
-.main > .main-left > .nav > li > [data-title="Logout"],
-.main > .main-left > .nav > li > [data-title="Dashboard"] {
+.main > .main-left > .nav > li > [data-title] {
 	font-size: 1.15rem;
 	font-weight: 500;
 	display: flex;
@@ -2656,7 +2655,7 @@ input[name="nslookup"] {
 	.main > .main-left > .nav > li,
 	.main > .main-left > .nav > li a,
 	.main > .main-left > .nav > .slide > .menu,
-	.main > .main-left > .nav > li:last-child > [data-title] {
+	.main > .main-left > .nav > li > [data-title] {
 		font-size: .9rem;
 	}
 
@@ -2935,7 +2934,7 @@ input[name="nslookup"] {
 	}
 
 	.main > .main-left > .nav > .slide > .menu,
-	.main > .main-left > .nav > li > [data-title="Logout"] {
+	.main > .main-left > .nav > li > [data-title] {
 		font-size: 1.2rem;
 	}
 


### PR DESCRIPTION
The latest fix to fix the logout worked, but it was not applied to all
the resolutions, and I have observed the same problem exists for the
dasboard optional component.
Looking at the code, it seems only the components without submenu, have the
data-title element, so this fix modifies the style for all of them, not
relying on the position or text content.

Signed-off-by: Miguel Angel Mulero Martinez <migmul@gmail.com>

Before:
![image](https://user-images.githubusercontent.com/2673520/166201753-59f8e10c-f463-4349-ba3a-2c696834f1a4.png)

After:
![image](https://user-images.githubusercontent.com/2673520/166201847-5dc854dd-e720-48f1-b88e-6f26581199ba.png)
