### PR TITLE
luci-material-theme: replace margin by gap in ifacebadge

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1836,6 +1836,7 @@ body.modal-overlay-active #modal_overlay {
 
 .ifacebadge {
 	display: inline-flex;
+	gap: .2rem;
 	padding: .5rem .8rem;
 	border-bottom: thin solid #ccc;
 	background: #eee;
@@ -1852,11 +1853,6 @@ td > .ifacebadge,
 .ifacebadge > img {
 	display: inline-block;
 	align-self: flex-start;
-	margin: 0 .2rem;
-}
-
-.ifacebadge > img + img {
-	margin: 0 .2rem 0 0;
 }
 
 .network-status-table {


### PR DESCRIPTION
Material is a "flex" theme. Better to use "gap" in place of "margin" to
add some space between elements inside "flex" elements.

This fixes the problem specially when there are text elements inside the
"flex" and don't hurt when there are images.

Signed-off-by: Miguel Angel Mulero Martinez <migmul@gmail.com>

This fixes, for example, some elements of the firewall tab:
![image](https://user-images.githubusercontent.com/2673520/166651377-af4015e4-ac3c-40e4-b9c5-783c60ac274d.png)

After the change:
![image](https://user-images.githubusercontent.com/2673520/166651198-d4275cb8-7744-460b-a70b-b1478fbb6d5a.png)
