### PR TITLE
[21.02] luci-mod-system: add interface selection for NTPD

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
@@ -5,6 +5,7 @@
 'require uci';
 'require rpc';
 'require form';
+'require tools.widgets as widgets';
 
 var callInitList, callInitAction, callTimezone,
     callGetLocaltime, callSetLocaltime, CBILocalTime;
@@ -280,6 +281,15 @@ return view.extend({
 			o = s.taboption('timesync', form.Flag, 'enable_server', _('Provide NTP server'));
 			o.ucisection = 'ntp';
 			o.depends('enabled', '1');
+
+			o = s.taboption('timesync', widgets.NetworkSelect, 'interface',
+				_('Bind NTP server'),
+				_('Provide the NTP server to the selected interface or, if unspecified, to all interfaces'));
+			o.ucisection = 'ntp';
+			o.depends('enable_server', '1');
+			o.multiple = false;
+			o.nocreate = true;
+			o.optional = true;
 
 			o = s.taboption('timesync', form.Flag, 'use_dhcp', _('Use DHCP advertised servers'));
 			o.ucisection = 'ntp';


### PR DESCRIPTION
UCI option `interface` for sysntpd server was introduced in
OpenWrt commit 4da60500ebd2. NTP server binds to the specified interface,
or if unspecified, to all.

This patch adds selection widget to LuCI.

Signed-off-by: Alexey Dobrovolsky <dobrovolskiy.alexey@gmail.com>
(cherry picked from commit 24ac5a2bf6d713c6878cf7be7d4e4516965c2884)