### PR TITLE
[22.03]luci-theme-bootstrap: restore initramfs warning

### DIFF
--- a/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
+++ b/themes/luci-theme-bootstrap/luasrc/view/themes/bootstrap/header.htm
@@ -74,6 +74,16 @@
 				</div>
 			<%- end -%>
 
+			<%- if boardinfo.rootfs_type == "initramfs" then -%>
+				<div class="alert-message warning">
+					<h4><%:System running in recovery (initramfs) mode.%></h4>
+					<p><%:No changes to settings will be stored and are lost after rebooting. This mode should only be used to install a firmware upgrade%></p>
+					<% if disp.lookup("admin/system/flash") then %>
+					  <div class="right"><a class="btn" href="<%=url("admin/system/flash")%>"><%:Go to firmware upgrade...%></a></div>
+					<% end %>
+				</div>
+			<%- end -%>
+
 			<noscript>
 				<div class="alert-message warning">
 					<h4><%:JavaScript required!%></h4>


### PR DESCRIPTION
Restore accidentally removed the initramfs boot warning banner.

Ref: https://github.com/openwrt/luci/commit/8055acc9be89f0bed31b6692ad08e6196611d478#commitcomment-73447330
Fixes: 8055acc9be ("luci-theme-bootstrap: overhaul styles")
Signed-off-by: Jo-Philipp Wich <jo@mein.io>
(cherry picked from commit 56fab648caa78422aac47ab8cec168e8a0999316)

CC: @jow- @dangowrt 