### PR TITLE
luci-app-watchcat: add support for run_script mode

### DIFF
--- a/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
+++ b/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
@@ -40,11 +40,20 @@ return view.extend({
 				1 hour would be: <b>1h</b></li><li>1 week would be: <b>7d</b></li><ul>"));
 		o.default = '6h';
 
-		o = s.taboption('general', form.Value, 'pinghosts', _('Host To Check'), _(`IPv4 address or hostname to ping.`));
-		o.datatype = 'host(1)';
+		o = s.taboption('general', form.Value, 'pinghosts', _('Host To Check'), _(`IP address or hostname to ping.`));
+		o.datatype = 'host';
 		o.default = '8.8.8.8';
 		o.depends({ mode: "ping_reboot" });
 		o.depends({ mode: "restart_iface" });
+
+		o = s.taboption('general', form.ListValue, 'addressfamily',
+				_('Address family for pinging the host'));
+		o.default = 'any';
+		o.depends({ mode: 'ping_reboot' });
+		o.depends({ mode: 'restart_iface' });
+		o.value('any');
+		o.value('ipv4');
+		o.value('ipv6');
 
 		o = s.taboption('general', form.Value, 'pingperiod', 
 			_('Check Interval'), 

--- a/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
+++ b/applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js
@@ -22,18 +22,27 @@ return view.extend({
 			_('Mode'),
 			_("Ping Reboot: Reboot this device if a ping to a specified host fails for a specified duration of time. <br /> \
 				Periodic Reboot: Reboot this device after a specified interval of time. <br /> \
-				Restart Interface: Restart a network interface if a ping to a specified host fails for a specified duration of time."));
+				Restart Interface: Restart a network interface if a ping to a specified host fails for a specified duration of time. <br />\
+				Run Script: Run a script if a ping to a specified host fails for a specified duration of time. <br />"));
 		o.value('ping_reboot', _('Ping Reboot'));
 		o.value('periodic_reboot', _('Periodic Reboot'));
 		o.value('restart_iface', _('Restart Interface'));
+		o.value('run_script', _('Run Script'));
+
+		o = s.taboption('general', form.Value, 'script',
+				_('Script to run'),
+				_(`Script to run when the host has not responded for the specified duration of time. The script is passed the interface name as $1`));
+		o.datatype = 'file';
+		o.default = "/etc/watchcat.user.sh";
+		o.depends({ mode: "run_script" });
 
 		o = s.taboption('general', form.Value, 'period', 
 			_('Period'), 
 			_("In Periodic Reboot mode, it defines how often to reboot. <br /> \
 				In Ping Reboot mode, it defines the longest period of \
 				time without a reply from the Host To Check before a reboot is engaged. <br /> \
-				In Network Restart mode, it defines the longest period of \
-				time without a reply from the Host to Check before the interface is restarted. \
+				In Network Restart or Run Script mode, it defines the longest period of \
+				time without a reply from the Host to Check before the interface is restarted or the script is run. \
 				<br /><br />The default unit is seconds, without a suffix, but you can use the \
 				suffix <b>m</b> for minutes, <b>h</b> for hours or <b>d</b> \
 				for days. <br /><br />Examples:<ul><li>10 seconds would be: <b>10</b> or <b>10s</b></li><li>5 minutes would be: <b>5m</b></li><li> \
@@ -45,12 +54,14 @@ return view.extend({
 		o.default = '8.8.8.8';
 		o.depends({ mode: "ping_reboot" });
 		o.depends({ mode: "restart_iface" });
+		o.depends({ mode: "run_script" });
 
 		o = s.taboption('general', form.ListValue, 'addressfamily',
 				_('Address family for pinging the host'));
 		o.default = 'any';
 		o.depends({ mode: 'ping_reboot' });
 		o.depends({ mode: 'restart_iface' });
+		o.depends({ mode: "run_script" });
 		o.value('any');
 		o.value('ipv4');
 		o.value('ipv6');
@@ -63,6 +74,7 @@ return view.extend({
 		o.default = '30s';
 		o.depends({ mode: "ping_reboot" });
 		o.depends({ mode: "restart_iface" });
+		o.depends({ mode: "run_script" });
 
 		o = s.taboption('general', form.ListValue, 'pingsize', 
 			_('Ping Packet Size'));
@@ -75,6 +87,7 @@ return view.extend({
 		o.default = 'standard';
 		o.depends({ mode: 'ping_reboot' });
 		o.depends({ mode: 'restart_iface' });
+		o.depends({ mode: "run_script" });
 
 		o = s.taboption('general', form.Value, 'forcedelay',
 			_('Force Reboot Delay'),
@@ -88,9 +101,10 @@ return view.extend({
 		o = s.taboption('general', widgets.DeviceSelect, 'interface',
 			_('Interface'),
 			_('Interface to monitor and/or restart'),
-			_('<i>Applies to Ping Reboot and Restart Interface modes</i> <br /> Specify the interface to monitor and restart if a ping over it fails.'));
+			_('<i>Applies to Ping Reboot, Restart Interface, and Run Script modes</i> <br /> Specify the interface to monitor and react if a ping over it fails.'));
 		o.depends({ mode: 'ping_reboot' });
 		o.depends({ mode: 'restart_iface' });
+		o.depends({ mode: 'run_script' });
 
 		o = s.taboption('general', widgets.NetworkSelect, 'mmifacename',
 			_('Name of ModemManager Interface'), 

--- a/applications/luci-app-watchcat/po/templates/watchcat.pot
+++ b/applications/luci-app-watchcat/po/templates/watchcat.pot
@@ -1,17 +1,17 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:91
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:104
 msgid ""
-"<i>Applies to Ping Reboot and Restart Interface modes</i> <br /> Specify the "
-"interface to monitor and restart if a ping over it fails."
+"<i>Applies to Ping Reboot, Restart Interface, and Run Script modes</i> <br /"
+"> Specify the interface to monitor and react if a ping over it fails."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:50
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:60
 msgid "Address family for pinging the host"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:81
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:94
 msgid ""
 "Applies to Ping Reboot and Periodic Reboot modes</i> <br /> When rebooting "
 "the router, the service will trigger a soft reboot. Entering a non-zero "
@@ -20,22 +20,22 @@ msgid ""
 "0 to disable the forced reboot delay."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:97
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:111
 msgid ""
 "Applies to Ping Reboot and Restart Interface modes</i> <br /> If using "
 "ModemManager, you can have Watchcat restart your ModemManger interface by "
 "specifying its name."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:72
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:84
 msgid "Big: 248 bytes"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:59
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:70
 msgid "Check Interval"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:80
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:93
 msgid "Force Reboot Delay"
 msgstr ""
 
@@ -54,11 +54,11 @@ msgid ""
 "up more than one action."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:43
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:52
 msgid "Host To Check"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:60
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:71
 msgid ""
 "How often to ping the host specified above. <br /><br />The default unit is "
 "seconds, without a suffix, but you can use the suffix <b>m</b> for minutes, "
@@ -68,39 +68,39 @@ msgid ""
 "li><ul>"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:73
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:85
 msgid "Huge: 1492 bytes"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:104
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:118
 msgid ""
 "If using ModemManager, then before restarting the interface, set the modem "
 "to be allowed to use any band."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:32
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:41
 msgid ""
 "In Periodic Reboot mode, it defines how often to reboot. <br /> In Ping "
 "Reboot mode, it defines the longest period of time without a reply from the "
-"Host To Check before a reboot is engaged. <br /> In Network Restart mode, it "
-"defines the longest period of time without a reply from the Host to Check "
-"before the interface is restarted. <br /><br />The default unit is seconds, "
-"without a suffix, but you can use the suffix <b>m</b> for minutes, <b>h</b> "
-"for hours or <b>d</b> for days. <br /><br />Examples:<ul><li>10 seconds "
-"would be: <b>10</b> or <b>10s</b></li><li>5 minutes would be: <b>5m</b></"
-"li><li> 1 hour would be: <b>1h</b></li><li>1 week would be: <b>7d</b></"
-"li><ul>"
+"Host To Check before a reboot is engaged. <br /> In Network Restart or Run "
+"Script mode, it defines the longest period of time without a reply from the "
+"Host to Check before the interface is restarted or the script is run. <br /"
+"><br />The default unit is seconds, without a suffix, but you can use the "
+"suffix <b>m</b> for minutes, <b>h</b> for hours or <b>d</b> for days. <br /"
+"><br />Examples:<ul><li>10 seconds would be: <b>10</b> or <b>10s</b></"
+"li><li>5 minutes would be: <b>5m</b></li><li> 1 hour would be: <b>1h</b></"
+"li><li>1 week would be: <b>7d</b></li><ul>"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:89
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:102
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:90
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:103
 msgid "Interface to monitor and/or restart"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:74
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:86
 msgid "Jumbo: 9000 bytes"
 msgstr ""
 
@@ -108,23 +108,23 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:96
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:110
 msgid "Name of ModemManager Interface"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:31
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:40
 msgid "Period"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:27
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:28
 msgid "Periodic Reboot"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:68
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:80
 msgid "Ping Packet Size"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:26
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:27
 msgid "Ping Reboot"
 msgstr ""
 
@@ -134,18 +134,27 @@ msgid ""
 "specified duration of time. <br /> Periodic Reboot: Reboot this device after "
 "a specified interval of time. <br /> Restart Interface: Restart a network "
 "interface if a ping to a specified host fails for a specified duration of "
-"time."
+"time. <br /> Run Script: Run a script if a ping to a specified host fails "
+"for a specified duration of time. <br />"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:28
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:29
 msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:69
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:30
+msgid "Run Script"
+msgstr ""
+
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:33
+msgid "Script to run"
+msgstr ""
+
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:81
 msgid "Small: 1 byte"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:71
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:83
 msgid "Standard: 56 bytes"
 msgstr ""
 
@@ -153,7 +162,7 @@ msgstr ""
 msgid "These rules will govern how this device reacts to network events."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:103
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:117
 msgid "Unlock Modem Bands"
 msgstr ""
 
@@ -163,6 +172,6 @@ msgstr ""
 msgid "Watchcat"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:70
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:82
 msgid "Windows: 32 bytes"
 msgstr ""

--- a/applications/luci-app-watchcat/po/templates/watchcat.pot
+++ b/applications/luci-app-watchcat/po/templates/watchcat.pot
@@ -1,13 +1,17 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:82
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:91
 msgid ""
 "<i>Applies to Ping Reboot and Restart Interface modes</i> <br /> Specify the "
 "interface to monitor and restart if a ping over it fails."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:72
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:50
+msgid "Address family for pinging the host"
+msgstr ""
+
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:81
 msgid ""
 "Applies to Ping Reboot and Periodic Reboot modes</i> <br /> When rebooting "
 "the router, the service will trigger a soft reboot. Entering a non-zero "
@@ -16,22 +20,22 @@ msgid ""
 "0 to disable the forced reboot delay."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:88
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:97
 msgid ""
 "Applies to Ping Reboot and Restart Interface modes</i> <br /> If using "
 "ModemManager, you can have Watchcat restart your ModemManger interface by "
 "specifying its name."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:63
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:72
 msgid "Big: 248 bytes"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:50
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:59
 msgid "Check Interval"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:71
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:80
 msgid "Force Reboot Delay"
 msgstr ""
 
@@ -54,7 +58,7 @@ msgstr ""
 msgid "Host To Check"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:51
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:60
 msgid ""
 "How often to ping the host specified above. <br /><br />The default unit is "
 "seconds, without a suffix, but you can use the suffix <b>m</b> for minutes, "
@@ -64,15 +68,11 @@ msgid ""
 "li><ul>"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:64
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:73
 msgid "Huge: 1492 bytes"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:43
-msgid "IPv4 address or hostname to ping."
-msgstr ""
-
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:95
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:104
 msgid ""
 "If using ModemManager, then before restarting the interface, set the modem "
 "to be allowed to use any band."
@@ -92,15 +92,15 @@ msgid ""
 "li><ul>"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:80
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:89
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:81
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:90
 msgid "Interface to monitor and/or restart"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:65
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:74
 msgid "Jumbo: 9000 bytes"
 msgstr ""
 
@@ -108,7 +108,7 @@ msgstr ""
 msgid "Mode"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:87
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:96
 msgid "Name of ModemManager Interface"
 msgstr ""
 
@@ -120,7 +120,7 @@ msgstr ""
 msgid "Periodic Reboot"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:59
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:68
 msgid "Ping Packet Size"
 msgstr ""
 
@@ -141,11 +141,11 @@ msgstr ""
 msgid "Restart Interface"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:60
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:69
 msgid "Small: 1 byte"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:62
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:71
 msgid "Standard: 56 bytes"
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 msgid "These rules will govern how this device reacts to network events."
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:94
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:103
 msgid "Unlock Modem Bands"
 msgstr ""
 
@@ -163,6 +163,6 @@ msgstr ""
 msgid "Watchcat"
 msgstr ""
 
-#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:61
+#: applications/luci-app-watchcat/htdocs/luci-static/resources/view/watchcat.js:70
 msgid "Windows: 32 bytes"
 msgstr ""


### PR DESCRIPTION
This adds support for run_script mode, which I propose adding in https://github.com/openwrt/packages/pull/18593

I also added support for choosing the address family for the pings

@feckert @nickberry17 

I apologize, I don't know anything about the translated messages and how to deal with those in this package.  Can you point me at some documentation about that?