### PR TITLE
[RFC] Add luci-app-attendedsysupgrade as default package

### DIFF
--- a/collections/luci/Makefile
+++ b/collections/luci/Makefile
@@ -12,9 +12,16 @@ LUCI_BASENAME:=luci
 LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (default)
 LUCI_DESCRIPTION:=Standard OpenWrt set including full admin with ppp support and the default Bootstrap theme
 LUCI_DEPENDS:= \
-	+uhttpd +uhttpd-mod-ubus +luci-mod-admin-full +luci-theme-bootstrap \
-	+luci-app-firewall +luci-app-opkg +luci-proto-ppp +libiwinfo-lua +IPV6:luci-proto-ipv6 \
-	+rpcd-mod-rrdns
+	+IPV6:luci-proto-ipv6 \
+	+libiwinfo-lua \
+	+luci-app-firewall \
+	+luci-app-opkg \
+	+luci-mod-admin-full \
+	+luci-proto-ppp \
+	+luci-theme-bootstrap \
+	+rpcd-mod-rrdns \
+	+uhttpd \
+	+uhttpd-mod-ubus
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci/Makefile
+++ b/collections/luci/Makefile
@@ -14,6 +14,7 @@ LUCI_DESCRIPTION:=Standard OpenWrt set including full admin with ppp support and
 LUCI_DEPENDS:= \
 	+IPV6:luci-proto-ipv6 \
 	+libiwinfo-lua \
+	+luci-app-attendedsysupgrade \
 	+luci-app-firewall \
 	+luci-app-opkg \
 	+luci-mod-admin-full \


### PR DESCRIPTION
This is more of a RFC, I'd like to see the app installed by default so more people use it and eventually use the latest (and greatest/safest/fastest) OpenWrt release possible. Telling someone to *click this button and wait 15 seconds, then click again* is much easier than any other way to upgrade a running system.

This pulls in packages like `ucert` and `attendedsysupgrade-common`, I'll look into the total space in a bit.

Another approach could be to integrate the code into the **Flash operations** view of LuCI.