### PR TITLE
luci-theme-material: CSS Fix for previous update

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -1735,6 +1735,7 @@ body:not(.Interfaces) .cbi-rowstyle-2:first-child {
 .modal p {
 	padding-left: .25rem;
 	word-break: break-word;
+	color: #fff;
 }
 
 .modal label.btn {


### PR DESCRIPTION
Commit b0f13ef Changed the color of a CSS element from a bright blue to
a dark blue. This resulted in a modal with difficult-to-read text (black
text on dark blue).

This commit sets the modal text-color to #000, in line with style
guidelines.

---

Before: 
![whoops](https://user-images.githubusercontent.com/14336407/174222507-18ab8d27-e334-4bc8-b5a1-cf59f4d3b876.png)

After:
![fixed](https://user-images.githubusercontent.com/14336407/174222518-1e0133b1-9f2f-4d52-b738-c03bb00ca1c9.png)


Signed-off-by: Quentin Baker <opensource@quentb.com>