### PR TITLE
rpcd-mod-luci: filter bonding_masters

### DIFF
--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -849,7 +849,7 @@ rpc_luci_get_network_devices(struct ubus_context *ctx,
 			if (e == NULL)
 				break;
 
-			if (strcmp(e->d_name, ".") && strcmp(e->d_name, ".."))
+			if (e->d_type != DT_DIR && e->d_type != DT_REG)
 				rpc_luci_parse_network_device_sys(e->d_name, ifaddr);
 		}
 


### PR DESCRIPTION
When kernel bonding module is loaded it will create a special
file /sys/class/net/bonding_masters. This is no network device.
Filter it out for getNetworkDevices() call.