### PR TITLE
luci-mod-dashboard: improve label's display

### DIFF
--- a/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/css/custom.css
+++ b/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/css/custom.css
@@ -120,13 +120,11 @@
 .Dashboard .settings-info p span:nth-child(2){
     display: inline-block;
     word-break: break-all;
-    overflow: hidden;
-    position: relative;
-    top:2px;
 }
 
 .Dashboard .settings-info p span:nth-child(2).label {
-    font-size: 8px;
+    padding: 1px 4px 1px 4px;
+    font-size: 9.75px;
 }
 
 .Dashboard .router-status-info .settings-info p span:nth-child(2){


### PR DESCRIPTION
Removing overflow and position, adding padding and increasing font size for the label.

Signed-off-by: Santiago Kozak <arbolitoloco1@protonmail.com>