### PR TITLE
luci-mod-network: wireless.js: add wifi-iface macaddr random support

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1157,10 +1157,11 @@ return view.extend({
 					if (/^radio\d+\.network/.test(o.placeholder))
 						o.placeholder = '';
 
+					var macaddr = uci.get('wireless', radioNet.getName(), 'macaddr');
 					o = ss.taboption('advanced', form.Value, 'macaddr', _('MAC address'), _('Override default MAC address - the range of usable addresses might be limited by the driver'));
-					o.optional = true;
-					o.placeholder = radioNet.getActiveBSSID();
-					o.datatype = 'macaddr';
+					o.value('', _('driver default (%s)').format(!macaddr ? radioNet.getActiveBSSID() : _('no override')));
+					o.value('random', _('randomly generated'));
+					o.datatype = "or('random',macaddr)";
 
 					o = ss.taboption('advanced', form.Flag, 'short_preamble', _('Short Preamble'));
 					o.default = o.enabled;


### PR DESCRIPTION
Add ability to choose `random` or custom `macaddr` for wifi-iface

![wifi-iface macaddr option - BSSID visible](https://github.com/openwrt/luci/assets/51392775/13ac073e-d78d-4bb2-aefa-0f4f6aab6132)
![wifi-iface macaddr option - BSSID invisible](https://github.com/openwrt/luci/assets/51392775/7b85e0a6-ae4f-4cc7-9036-979ba94ea1f5)
(**Updated** screenshot as per latest commit: https://github.com/openwrt/luci/pull/5896/commits/ab73d459ca6a57ba0e5b4898c8eb3dbdc46f252a)

Choosing the new *randomly generated* MAC address option will cause a new MAC address to be generated whenever the WiFi interface is (re-)configured or the system is rebooted.

This will work only if wifi-iface supports `option macaddr 'random'`.
Depends on https://github.com/openwrt/openwrt/pull/10307