### PR TITLE
luci-app-attendedsysupgrade: report used client version

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -418,7 +418,7 @@ return view.extend({
 	},
 
 	render: function (res) {
-		this.data.app_version = res[0].packages['luci-app-attendedsysupgrade'];
+		this.firmware.client = 'luci/' + res[0].packages['luci-app-attendedsysupgrade'];
 		this.firmware.packages = res[0].packages;
 
 		this.firmware.profile = res[1].board_name;


### PR DESCRIPTION
This allows the backend to track popular app versions and drop support for
unsed version in case of API changes.

Specifically the app sends a version string in the format "luci - GIT_HASH" to
the backend.

Signed-off-by: Paul Spooren <mail@aparcar.org>