### PR TITLE
luci-mod-dashboard: show IPv6 connection uptime

### DIFF
--- a/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js
+++ b/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js
@@ -146,6 +146,8 @@ return baseclass.extend({
 			 var ifc = data[i];
 
 			 if (v6) {
+				var uptime = ifc.getUptime();
+				this.params.internet.v6.uptime.value = (uptime > 0) ? '%t'.format(uptime) : '-';
 				this.params.internet.v6.ipprefixv6.value =  ifc.getIP6Prefix() || '-';
 				this.params.internet.v6.gatewayv6.value =  ifc.getGateway6Addr() || '-';
 				this.params.internet.v6.protocol.value=  ifc.getI18n() || E('em', _('Not connected'));
@@ -178,7 +180,7 @@ return baseclass.extend({
 				},
 
 				uptime: {
-					title: _('Connected since'),
+					title: _('Uptime'),
 					visible: true,
 					value: '-'
 				},
@@ -218,7 +220,7 @@ return baseclass.extend({
 				},
 
 				uptime: {
-					title: _('Connected since'),
+					title: _('Uptime'),
 					visible: true,
 					value: '-'
 				},

--- a/modules/luci-mod-dashboard/po/templates/dashboard.pot
+++ b/modules/luci-mod-dashboard/po/templates/dashboard.pot
@@ -30,7 +30,7 @@ msgstr ""
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:181
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:221
-msgid "Connected since"
+msgid "Uptime"
 msgstr ""
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/20_lan.js:13


### PR DESCRIPTION
Show connection uptime for both IPv4 & IPv6 interfaces.
Rename display field from 'Connected since' to 'Uptime' as this makes
more sense to me.  You could say 'Connected for' or 'Connection
duration'.  After a lot of thought decided that 'Uptime' is what I'm
most comfortable saying.

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>