### PR TITLE
luci-app-attendedsysupgrade: s/res/response/

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -83,9 +83,9 @@ return view.extend({
 	},
 
 	handle200: function (response) {
-		res = response.json();
+		response = response.json();
 		var image;
-		for (image of res.images) {
+		for (image of response.images) {
 			if (this.firmware.filesystem == image.filesystem) {
 				if (this.data.efi) {
 					if (image.type == 'combined-efi') {
@@ -100,21 +100,21 @@ return view.extend({
 		}
 
 		if (image.name != undefined) {
-			var sysupgrade_url = `${this.data.url}/store/${res.bin_dir}/${image.name}`;
+			var sysupgrade_url = `${this.data.url}/store/${response.bin_dir}/${image.name}`;
 
 			var keep = E('input', { type: 'checkbox' });
 			keep.checked = true;
 
 			var fields = [
-				_('Version'), `${res.version_number} ${res.version_code}`,
+				_('Version'), `${response.version_number} ${response.version_code}`,
 				_('SHA256'), image.sha256,
 			];
 
 			if (this.data.advanced_mode == 1) {
 				fields.push(
-					_('Profile'), res.id,
-					_('Target'), res.target,
-					_('Build Date'), res.build_at,
+					_('Profile'), response.id,
+					_('Target'), response.target,
+					_('Build Date'), response.build_at,
 					_('Filename'), image.name,
 					_('Filesystem'), image.filesystem,
 				)
@@ -155,7 +155,7 @@ return view.extend({
 
 	handle202: function (response) {
 		response = response.json();
-		this.data.request_hash = res.request_hash;
+		this.data.request_hash = response.request_hash;
 
 		if ('queue_position' in response) {
 			ui.showModal(_('Queued...'), [
@@ -417,18 +417,18 @@ return view.extend({
 		]);
 	},
 
-	render: function (res) {
-		this.firmware.client = 'luci/' + res[0].packages['luci-app-attendedsysupgrade'];
-		this.firmware.packages = res[0].packages;
+	render: function (response) {
+		this.firmware.client = 'luci/' + response[0].packages['luci-app-attendedsysupgrade'];
+		this.firmware.packages = response[0].packages;
 
-		this.firmware.profile = res[1].board_name;
-		this.firmware.target = res[1].release.target;
-		this.firmware.version = res[1].release.version;
-		this.data.branch = get_branch(res[1].release.version);
-		this.firmware.filesystem = res[1].rootfs_type;
-		this.data.revision = res[1].release.revision;
+		this.firmware.profile = response[1].board_name;
+		this.firmware.target = response[1].release.target;
+		this.firmware.version = response[1].release.version;
+		this.data.branch = get_branch(response[1].release.version);
+		this.firmware.filesystem = response[1].rootfs_type;
+		this.data.revision = response[1].release.revision;
 
-		this.data.efi = res[2];
+		this.data.efi = response[2];
 
 		this.data.url = uci.get_first('attendedsysupgrade', 'server', 'url');
 		this.data.advanced_mode = uci.get_first('attendedsysupgrade', 'client', 'advanced_mode') || 0


### PR DESCRIPTION
The variable was party called `res` or `response`, always call it
`response` from now on. This also solves a typo where
`data.request_hash` is never set to a correct value.

Signed-off-by: Paul Spooren <mail@aparcar.org>