### PR TITLE
luci-app-email: configure emailrelay

### DIFF
--- a/applications/luci-app-email/Makefile
+++ b/applications/luci-app-email/Makefile
@@ -1,0 +1,12 @@
+# See /LICENSE for more information.
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI app for email server configuration (EmailRelay)
+LUCI_DEPENDS:=+luci-base +emailrelay
+PKG_MAINTAINER:=Sergey Ponomarev <stokito@gmail.com>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js
+++ b/applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js
@@ -1,0 +1,297 @@
+'use strict';
+'require view';
+'require form';
+
+return view.extend({
+	render: function () {
+		var docsRefAttrs = 'target="_blank" rel="noreferrer" href="https://emailrelay.sourceforge.net/';
+		var m, s, o;
+
+		m = new form.Map('emailrelay', _('Email Server Configuration'),
+			_('E-MailRelay Server Configuration.') + '<br />' +
+			_('For further information <a %s>check the documentation</a>')
+				.format('href="https://openwrt.org/docs/guide-user/services/email/emailrelay" target="_blank" rel="noreferrer"')
+		);
+
+		s = m.section(form.GridSection, 'emailrelay', _('Instance config'));
+		s.anonymous = false;
+		s.addremove = true;
+		s.nodescriptions = true;
+
+
+		o = s.tab('smtp_server', _('SMTP Server'));
+		o = s.tab('smtp_client', _('SMTP Client'));
+		o = s.tab('pop_server', _('POP3'));
+		o = s.tab('advanced', _('Advanced Settings'));
+
+		o = s.taboption('smtp_server', form.Flag, 'enabled', _('Enabled'));
+		o.rmempty = false;
+
+		o = s.taboption('smtp_server', form.ListValue, 'mode', _('Mode'),
+			_('See <a %s>Running E-MailRelay</a>')
+				.format(docsRefAttrs + '#userguide_md_Running_E_MailRelay"')
+		);
+		o.value('server', _('Server: receive incoming mail'));
+		o.value('proxy', _('Proxy: submission outgoing mail, store and forward to smarthost SMTP server'));
+		o.value('cmdline', _('Manual command line options (deprecated)'));
+		o.default = 'server';
+		o.rmempty = false;
+
+		o = s.taboption('smtp_server', form.Value, 'port', _('SMTP Port'),
+			_('SMTP Port to listen for incoming emails.') + '<br />' +
+			_('Incoming mail by default received on <em>25</em> port.') + '<br />' +
+			_('Outcoming mail by usually received on <em>587</em> or <em>465</em> (TLS only) ' +
+				'but the <em>25</em> is also used often.')
+		);
+		o.datatype = 'port';
+		o.default = '25';
+
+		o = s.taboption('smtp_server', form.Flag, 'remote_clients', _('Allow remote clients'),
+			_('Allow connections from the public internet.') + '<br />' +
+			_('<b>You may receive spam so be careful</b>.') + '<br />' +
+			_('Enable ports in firewall.') + '<br />' +
+			_('See <a %s>--remote-clients</a>')
+				.format(docsRefAttrs + '#__remote_clients"')
+		);
+		o.modalonly = true;
+		o.default = '0';
+
+		o = s.taboption('smtp_server', form.Flag, 'anonymous', _('Anonymous'),
+			_('Reduce the amount of information leaked to remote clients.') + '<br />' +
+			_('See <a %s>--anonymous</a>')
+				.format(docsRefAttrs + '#__anonymous"')
+		);
+		o.modalonly = true;
+		o.default = '0';
+
+		o = s.taboption('smtp_server', form.Value, 'domain', _('Domain'),
+			_(
+				'Specifies the server\'s domain name that is used in SMTP EHLO.<br />' +
+				'By default, the local hostname is used.<br />' +
+				'See <a %s>--domain</a>'
+			).format(docsRefAttrs + '#__domain"')
+		);
+		o.datatype = 'hostname';
+		o.optional = true;
+		o.rmempty = false;
+		o.depends('anonymous', '0');
+
+		o = s.taboption('smtp_server', form.FileUpload, 'server_auth', _('Auth file'),
+			_(
+				'Server/proxy authorization file.<br />' +
+				'See <a %s>Authentication</a>'
+			).format(docsRefAttrs + '#reference_md_Authentication"')
+		);
+		o.datatype = 'file';
+		o.root_directory = '/';
+		o.default = '/etc/emailrelay.auth';
+		o.optional = true;
+		o.rmempty = true;
+		o.modalonly = true;
+
+		o = s.taboption('smtp_server', form.Flag, 'server_tls', _('Enable TLS for server'),
+			_('Use TLS encryption for SMTP and POP connections.') + '<br />' +
+			_('Configure <a %s>acme.sh to issue a TLS cert</a>.')
+				.format('href="https://openwrt.org/docs/guide-user/services/tls/acmesh" target="_blank" rel="noreferrer"') + '<br />' +
+			_('See <a %s>TLS encryption</a>')
+				.format(docsRefAttrs + '#reference_md_TLS_encryption"')
+		);
+		o.default = '0';
+		o.optional = true;
+		o.rmempty = true;
+		o.modalonly = true;
+
+		o = s.taboption('smtp_server', form.FileUpload, 'server_tls_key', _('TLS private key'),
+			_('Path to TLS private key.') + '<br />' +
+			_('E.g. ') + '<code>/etc/ssl/acme/example.com.key</code>'
+		);
+		o.datatype = 'file';
+		o.root_directory = '/';
+		o.optional = true;
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('server_tls', '1');
+
+		o = s.taboption('smtp_server', form.FileUpload, 'server_tls_certificate', _('TLS certificate'),
+			_('Path to TLS cert.') + + '<br />' +
+			_('E.g. ') + '<code>/etc/ssl/acme/example.com.fullchain.crt</code>'
+		);
+		o.datatype = 'file';
+		o.root_directory = '/';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('server_tls', '1');
+
+		o = s.taboption('smtp_server', form.Value, 'server_tls_verify', _('CA certificate'),
+			_('Verify an SMTP and POP client\'s certificates ') +
+			_('against trusted CA certificates in the specified file or directory.') + '<br />' +
+			_('In many use cases this should be your self-signed root certificate.') + '<br />' +
+			_('Use <code>&lt;default&gt;</code> to use the system trusted CAs')
+		);
+		o.datatype = 'or(file, directory, "<default>")';
+		o.default = '<default>';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('server_tls', '1');
+
+		o = s.taboption('smtp_server', form.Value, 'spool_dir', _('Mail storage directory'),
+			_('The directory used for holding received mail messages.') + '<br />' +
+			_('<b>Note:</b> The <code>/var/</code> is a small in-memory folder and you\'ll lose mail in reboot.') + '<br />' +
+			_('Instead, use a mounted disk with enough of space.')
+		);
+		o.datatype = 'directory';
+		o.default = '/var/spool/emailrelay';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+
+
+		o = s.taboption('smtp_client', form.Value, 'smarthost', _('Smarthost'),
+			_('The SMTP server to forward emails')
+		);
+		o.datatype = 'host';
+		o.optional = false;
+		o.rmempty = false;
+		o.depends('mode', 'proxy');
+
+		o = s.taboption('smtp_client', form.FileUpload, 'client_auth', _('Client authorization file'),
+			_('A file that contains credentials for SMTP smarthost client.') + '<br />' +
+			_('See <a %s>Authentication</a>')
+				.format(docsRefAttrs + '#reference_md_Authentication"')
+		);
+		o.datatype = 'file';
+		o.root_directory = '/';
+		o.default = '/etc/emailrelay.auth';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('mode', 'proxy');
+
+		o = s.taboption('smtp_client', form.Flag, 'client_tls', _('Enable SMTP client TLS'),
+			_('Use TLS encryption for SMTP proxy client.') + '<br />' +
+			_('See example for <a %s>Gmail</a>')
+				.format(docsRefAttrs + '#userguide_md_Google_mail"')
+		);
+		o.default = '0';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('mode', 'proxy');
+
+		o = s.taboption('smtp_client', form.FileUpload, 'client_tls_key', _('TLS private key'),
+			_('Path to TLS private key.')
+		);
+		o.datatype = 'file';
+		o.root_directory = '/';
+		o.optional = true;
+		o.rmempty = true;
+		o.modalonly = true;
+		o.depends('client_tls', '1');
+
+		o = s.taboption('smtp_client', form.FileUpload, 'client_tls_certificate', _('TLS certificate'),
+			_('Path to TLS cert.')
+		);
+		o.datatype = 'file';
+		o.root_directory = '/';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('client_tls', '1');
+
+		o = s.taboption('smtp_client', form.Value, 'client_tls_verify', _('CA certificate'),
+			_('Verify an SMTP server\'s certificate ') +
+			_('against trusted CA certificates in the specified file or directory.') + '<br />' +
+			_('Use <code>&lt;default&gt;</code> to use the system trusted CAs')
+		);
+		o.datatype = 'or(file, directory, "<default>")';
+		o.default = '<default>';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('client_tls', '1');
+
+
+		o = s.taboption('pop_server', form.Flag, 'pop', _('Enable POP3'),
+			_('The POP3 used to fetch a mail.') + '<br />' +
+			_('See <a %s>Running as a POP server</a>')
+				.format(docsRefAttrs + '#userguide_md_Running_as_a_POP_server"')
+		);
+		o.default = '0';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('mode', 'server');
+
+		o = s.taboption('pop_server', form.FileUpload, 'pop_auth', _('POP Auth file'),
+			_('A file containing POP accounts and their credentials.')
+		);
+		o.datatype = 'file';
+		o.root_directory = '/';
+		o.default = '/etc/emailrelay.auth';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('pop', '1');
+
+		o = s.taboption('pop_server', form.Flag, 'pop_by_name', _('POP by name'),
+			_(
+				'Modifies the spool directory used by the POP server to be a sub-directory ' +
+				'with the same name as the POP authentication user-id'
+			)
+		);
+		o.default = '1';
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.depends('pop', '1');
+
+
+		o = s.taboption('advanced', form.Value, 'dnsbl', _('DNSBL'),
+			_('<a %s>DNS Block List (DNSBL)</a> used to block connections from known spammers.')
+				.format('href="https://en.wikipedia.org/wiki/DNSBL" target="_blank" rel="noreferrer"') + '<br />' +
+			_('Starts with the transport DNS server\'s address:port, a timeout in milliseconds, a rejection threshold and list of DNSBL servers.') + '<br />' +
+			_('E.g. ') + '<code>127.0.0.1:53,5000,1,zen.spamhaus.org,bl.mailspike.net</code><br />' +
+			_('If the threshold number of servers deny the incoming connection\'s network address then it\'s dropped. ') +
+			_('A threshold of zero is useful for testing and means only to log a result code but allow a connection.') + '<br />' +
+			_('See <a %s>Connection blocking</a>')
+				.format(docsRefAttrs + '#reference_md_Connection_blocking"')
+		);
+		o.datatype = 'string';
+		o.optional = true;
+		o.rmempty = true;
+		o.modalonly = true;
+
+		o = s.taboption('advanced', form.Value, 'address_verifier', _('Address verifier'),
+			_('Runs the specified external program to verify a message recipient\'s email address.') + '<br />' +
+			_('See <a %s>Address verification</a>')
+				.format(docsRefAttrs + '#reference_md_Address_verification"')
+		);
+		// o.default = "allow:/etc/emailrelay.auth";
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('advanced', form.Value, 'filter', _('Filter'),
+			_('Runs the specified external filter program whenever a mail message is stored.') + '<br />' +
+			_('See <a %s>--filter</a>')
+				.format(docsRefAttrs + '#__filter"')
+		);
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('advanced', form.Value, 'extra_cmdline', _('Extra command line options'),
+			_('Specify additional arguments that should be passed to the EmailRelay.') + '<br />' +
+			_('See <a %s>Command line reference</a>')
+				.format(docsRefAttrs + '#reference_md_Reference"')
+		);
+		o.optional = true;
+		o.rmempty = false;
+		o.modalonly = true;
+		o.modalonly = true;
+
+		return m.render();
+	},
+});

--- a/applications/luci-app-email/po/templates/email.pot
+++ b/applications/luci-app-email/po/templates/email.pot
@@ -1,0 +1,351 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:245
+msgid ""
+"<a %s>DNS Block List (DNSBL)</a> used to block connections from known "
+"spammers."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:138
+msgid ""
+"<b>Note:</b> The <code>/var/</code> is a small in-memory folder and you'll "
+"lose mail in reboot."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:51
+msgid "<b>You may receive spam so be careful</b>."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:222
+msgid "A file containing POP accounts and their credentials."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:157
+msgid "A file that contains credentials for SMTP smarthost client."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:250
+msgid ""
+"A threshold of zero is useful for testing and means only to log a result "
+"code but allow a connection."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:259
+msgid "Address verifier"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:25
+msgid "Advanced Settings"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:50
+msgid "Allow connections from the public internet."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:49
+msgid "Allow remote clients"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:59
+msgid "Anonymous"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:79
+msgid "Auth file"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:123
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:197
+msgid "CA certificate"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:156
+msgid "Client authorization file"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:93
+msgid "Configure <a %s>acme.sh to issue a TLS cert</a>."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:244
+msgid "DNSBL"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:67
+msgid "Domain"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:11
+msgid "E-MailRelay Server Configuration."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:105
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:115
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:248
+msgid "E.g."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:10
+msgid "Email Server Configuration"
+msgstr ""
+
+#: applications/luci-app-email/root/usr/share/luci/menu.d/luci-app-email.json:3
+msgid "Email server"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:210
+msgid "Enable POP3"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:168
+msgid "Enable SMTP client TLS"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:91
+msgid "Enable TLS for server"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:52
+msgid "Enable ports in firewall."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:27
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:278
+msgid "Extra command line options"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:269
+msgid "Filter"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:12
+msgid "For further information <a %s>check the documentation</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:249
+msgid ""
+"If the threshold number of servers deny the incoming connection's network "
+"address then it's dropped."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:126
+msgid "In many use cases this should be your self-signed root certificate."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:42
+msgid "Incoming mail by default received on <em>25</em> port."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:16
+msgid "Instance config"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:139
+msgid "Instead, use a mounted disk with enough of space."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:136
+msgid "Mail storage directory"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:36
+msgid "Manual command line options (deprecated)"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:30
+msgid "Mode"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:233
+msgid ""
+"Modifies the spool directory used by the POP server to be a sub-directory "
+"with the same name as the POP authentication user-id"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:43
+msgid ""
+"Outcoming mail by usually received on <em>587</em> or <em>465</em> (TLS "
+"only) but the <em>25</em> is also used often."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:221
+msgid "POP Auth file"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:231
+msgid "POP by name"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:24
+msgid "POP3"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:114
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:189
+msgid "Path to TLS cert."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:104
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:180
+msgid "Path to TLS private key."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:35
+msgid ""
+"Proxy: submission outgoing mail, store and forward to smarthost SMTP server"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:60
+msgid "Reduce the amount of information leaked to remote clients."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:270
+msgid ""
+"Runs the specified external filter program whenever a mail message is stored."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:260
+msgid ""
+"Runs the specified external program to verify a message recipient's email "
+"address."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:23
+msgid "SMTP Client"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:40
+msgid "SMTP Port"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:41
+msgid "SMTP Port to listen for incoming emails."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:22
+msgid "SMTP Server"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:61
+msgid "See <a %s>--anonymous</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:271
+msgid "See <a %s>--filter</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:53
+msgid "See <a %s>--remote-clients</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:261
+msgid "See <a %s>Address verification</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:158
+msgid "See <a %s>Authentication</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:280
+msgid "See <a %s>Command line reference</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:251
+msgid "See <a %s>Connection blocking</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:31
+msgid "See <a %s>Running E-MailRelay</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:212
+msgid "See <a %s>Running as a POP server</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:95
+msgid "See <a %s>TLS encryption</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:170
+msgid "See example for <a %s>Gmail</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:81
+msgid "Server/proxy authorization file.<br />See <a %s>Authentication</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:34
+msgid "Server: receive incoming mail"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:148
+msgid "Smarthost"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:69
+msgid ""
+"Specifies the server's domain name that is used in SMTP EHLO.<br />By "
+"default, the local hostname is used.<br />See <a %s>--domain</a>"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:279
+msgid "Specify additional arguments that should be passed to the EmailRelay."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:247
+msgid ""
+"Starts with the transport DNS server's address:port, a timeout in "
+"milliseconds, a rejection threshold and list of DNSBL servers."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:113
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:188
+msgid "TLS certificate"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:103
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:179
+msgid "TLS private key"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:211
+msgid "The POP3 used to fetch a mail."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:149
+msgid "The SMTP server to forward emails"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:137
+msgid "The directory used for holding received mail messages."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:127
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:200
+msgid "Use <code>&lt;default&gt;</code> to use the system trusted CAs"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:92
+msgid "Use TLS encryption for SMTP and POP connections."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:169
+msgid "Use TLS encryption for SMTP proxy client."
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:124
+msgid "Verify an SMTP and POP client's certificates"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:198
+msgid "Verify an SMTP server's certificate"
+msgstr ""
+
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:125
+#: applications/luci-app-email/htdocs/luci-static/resources/view/email/emailrelay.js:199
+msgid "against trusted CA certificates in the specified file or directory."
+msgstr ""

--- a/applications/luci-app-email/root/usr/share/luci/menu.d/luci-app-email.json
+++ b/applications/luci-app-email/root/usr/share/luci/menu.d/luci-app-email.json
@@ -1,0 +1,13 @@
+{
+	"admin/services/email": {
+		"title": "Email server",
+		"order": 50,
+		"action": {
+			"type": "view",
+			"path": "email/emailrelay"
+		},
+		"depends": {
+			"acl": [ "luci-app-email" ]
+		}
+	}
+}

--- a/applications/luci-app-email/root/usr/share/rpcd/acl.d/luci-app-email.json
+++ b/applications/luci-app-email/root/usr/share/rpcd/acl.d/luci-app-email.json
@@ -1,0 +1,14 @@
+{
+	"luci-app-email": {
+		"read": {
+			"uci": [
+				"emailrelay"
+			]
+		},
+		"write": {
+			"uci": [
+				"emailrelay"
+			]
+		}
+	}
+}


### PR DESCRIPTION
A new Luci App to configure [EmailRelay package](https://openwrt.org/docs/guide-user/services/email/emailrelay). With this inexperienced users may set up their own SMTP and POP server just on a router. Sending of emails is still a pain because you need to configure SPF but 90% of a typical usage is just receiving email.

I decided to call it just luci-app-email because anyway only the emailrelay has a UCI config. Also I think to add a basic view of a mailbox.

This is a first version and far from ideal but at least this will be a good start.
All options from the PR https://github.com/openwrt/packages/pull/18536 are supported.
It still lacks of configuration of authorization and a user still need to edit the /etc/emailrelay.auth file manually over scp. But I'll fix that too.