### PR TITLE
luci-theme-openwrt-2020: disabled button text wrap

### DIFF
--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -908,6 +908,7 @@ button, .btn {
 	box-shadow: 0 0 2px var(--main-dark-color);
 	padding: 0 .5em;
 	display: inline-block;
+	white-space: nowrap;
 }
 
 button:hover, .btn:hover {


### PR DESCRIPTION
luci-theme-openwrt-2020: disabled button text wrap