### PR TITLE
luci-lib-nixio: always build without TLS support

### DIFF
--- a/libs/luci-lib-nixio/Makefile
+++ b/libs/luci-lib-nixio/Makefile
@@ -7,47 +7,9 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=NIXIO POSIX library
-LUCI_DEPENDS:=+PACKAGE_luci-lib-nixio_openssl:libopenssl +PACKAGE_luci-lib-nixio_cyassl:libcyassl +liblua
+LUCI_DEPENDS:=+liblua
 
 PKG_LICENSE:=Apache-2.0
-
-define Package/luci-lib-nixio/config
-	choice
-		prompt "TLS Provider"
-		default PACKAGE_luci-lib-nixio_notls
-
-		config PACKAGE_luci-lib-nixio_notls
-			bool "Disabled"
-
-		config PACKAGE_luci-lib-nixio_axtls
-			bool "Builtin (axTLS)"
-
-		config PACKAGE_luci-lib-nixio_cyassl
-			bool "CyaSSL"
-			select PACKAGE_libcyassl
-
-		config PACKAGE_luci-lib-nixio_openssl
-			bool "OpenSSL"
-			select PACKAGE_libopenssl
-	endchoice
-endef
-
-NIXIO_TLS:=
-
-ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_axtls),)
-  NIXIO_TLS:=axtls
-endif
-
-ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_openssl),)
-  NIXIO_TLS:=openssl
-endif
-
-ifneq ($(CONFIG_PACKAGE_luci-lib-nixio_cyassl),)
-  NIXIO_TLS:=cyassl
-  LUCI_CFLAGS+=-I$(STAGING_DIR)/usr/include/cyassl
-endif
-
-MAKE_VARS += NIXIO_TLS="$(NIXIO_TLS)"
 
 include ../../luci.mk
 


### PR DESCRIPTION
The build system fails to set up the chosen TLS provider and always
builds the package without TLS.

While this could be easily fixed, the package would fail to build with
axTLS and cyaSSL without further intervention.

The version of axTLS included with the source is outdated, as is the API
used with cyaSSL, now wolfSSL.

OpenSSL support could be enabled, but the TLS code limits connections to
TLS 1.0, deprecated by RFC 8996: "TLS 1.0 MUST NOT be used".

Remove the provider configuration from build options, and always build
the library without TLS.

Signed-off-by: Eneas U de Queiroz <cotequeiroz@gmail.com>

---

I was looking at this package, just to eliminate the last use of the old `libcyassl` package dependency.

@jow- mentioned in https://github.com/openwrt/luci/pull/4432#issuecomment-1209965610:

> The regression potential is too high, also there's no TLS users for nixio left in LuCI, so I likely won't touch it anymore in the future.

I believe the fix proposed in #4432 is in the right path, but I can't assure there will be no regression.  Meanwhile, this can be merged for now, and #4432 can remain open if there is anything else that can be done there.
