### PR TITLE
luci.mk: execute install recipe in subshell

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -202,7 +202,7 @@ define Package/$(PKG_NAME)/install
 	  cp -pR $(PKG_BUILD_DIR)/root/* $(1)/; \
 	else true; fi
 	if [ -d $(PKG_BUILD_DIR)/src ]; then \
-	  $(call Build/Install/Default) \
+	  ( $(call Build/Install/Default) ) && \
 	  $(CP) $(PKG_INSTALL_DIR)/* $(1)/; \
 	else true; fi
 endef


### PR DESCRIPTION
(CI failing because it assumes I'm working on a package)

The use of bash if statements has extra syntax requirements
compared to logical operators && and ||
for example, that each line must end with a semicolon.
Also, each line will execute regardless of the exit status of the last.

The default definition of Build/Install/Default
is not managed within the luci repo,
so a syntax requirement is not ideal.
A missing or extra semicolon for whatever reason
causes build failure.

By placing the Build/Install/Default recipe in a subshell
and connecting it to the next line with logical operator &&
the syntax of Build/Install/Default doesn't matter anymore,
and the copying from PKG_INSTALL_DIR is dependent
on Build/Install/Default being successful,
where the copy would still execute if Build/Install/Default fails
and the lines are separated.

Signed-off-by: Michael Pratt <mcpratt@pm.me>