### PR TITLE
[22.03] luci-app-simple-adblock: update to 1.9.0-1

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -1,11 +1,11 @@
-# Copyright 2017-2018 Stan Grishin (stangri@melmac.net)
+# Copyright 2017-2018 Stan Grishin (stangri@melmac.ca)
 # This is free software, licensed under the GNU General Public License v3.
 
 include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
-PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.8.7-3
+PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
+PKG_VERSION:=1.9.0-1
 
 LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.

--- a/applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm
+++ b/applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm
@@ -1,4 +1,4 @@
-<%# Copyright 2020 Stan Grishin <stangri@melmac.net> -%>
+<%# Copyright 2020 Stan Grishin <stangri@melmac.ca> -%>
 
 <%+simple-adblock/css%>
 <%+simple-adblock/js%>
@@ -7,8 +7,9 @@
 	local packageName = "simple-adblock"
 	local serviceRunning, serviceEnabled = false, false;
 	local tmpfs, tmpfsStatus;
-	if nixio.fs.access("/var/run/" .. packageName .. ".json") then
-		tmpfs = luci.jsonc.parse(luci.util.trim(luci.sys.exec("cat /var/run/" .. packageName .. ".json")))
+	local jsonStatusFile = "/var/run/" .. packageName .. "/" .. packageName .. ".json"
+	if nixio.fs.access(jsonStatusFile) then
+		tmpfs = luci.jsonc.parse(luci.util.trim(luci.sys.exec("cat " .. jsonStatusFile)))
 		if tmpfs and tmpfs['data'] and tmpfs['data']['status'] then
 			tmpfsStatus = tmpfs['data']['status']
 		end
@@ -48,27 +49,25 @@
 -%>
 
 <%+cbi/valueheader%>
-	<div class="cbi-value-field">
-		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
-			onclick="button_action(this)" />
-		<span id="btn_start_spinner" class="btn_spinner"></span>
-		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_action" name="action" value="<%:Force Re-Download%>"
-			onclick="button_action(this)" />
-		<span id="btn_action_spinner" class="btn_spinner"></span>
-		<input type="button" class="btn cbi-button cbi-button-reset" id="btn_stop" name="stop" value="<%:Stop%>"
-			onclick="button_action(this)" />
-		<span id="btn_stop_spinner" class="btn_spinner"></span>
-		&#160;
-		&#160;
-		&#160;
-		&#160;
-		<input type="button" class="btn cbi-button cbi-button-apply" id="btn_enable" name="enable" value="<%:Enable%>"
-			onclick="button_action(this)" />
-		<span id="btn_enable_spinner" class="btn_spinner"></span>
-		<input type="button" class="btn cbi-button cbi-button-reset" id="btn_disable" name="disable" value="<%:Disable%>"
-			onclick="button_action(this)" />
-		<span id="btn_disable_spinner" class="btn_spinner"></span>
-	</div>
+	<input type="button" class="btn cbi-button cbi-button-apply" id="btn_start" name="start" value="<%:Start%>"
+		onclick="button_action(this)" />
+	<span id="btn_start_spinner" class="btn_spinner"></span>
+	<input type="button" class="btn cbi-button cbi-button-apply" id="btn_action" name="action" value="<%:Force Re-Download%>"
+		onclick="button_action(this)" />
+	<span id="btn_action_spinner" class="btn_spinner"></span>
+	<input type="button" class="btn cbi-button cbi-button-reset" id="btn_stop" name="stop" value="<%:Stop%>"
+		onclick="button_action(this)" />
+	<span id="btn_stop_spinner" class="btn_spinner"></span>
+	&#160;
+	&#160;
+	&#160;
+	&#160;
+	<input type="button" class="btn cbi-button cbi-button-apply" id="btn_enable" name="enable" value="<%:Enable%>"
+		onclick="button_action(this)" />
+	<span id="btn_enable_spinner" class="btn_spinner"></span>
+	<input type="button" class="btn cbi-button cbi-button-reset" id="btn_disable" name="disable" value="<%:Disable%>"
+		onclick="button_action(this)" />
+	<span id="btn_disable_spinner" class="btn_spinner"></span>
 <%+cbi/valuefooter%>
 
 <%-if not btn_start_status then%>

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -1,167 +1,171 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:221
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:250
 msgid "%s Error: %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:219
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:248
 msgid "%s Error: %s %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:133
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:161
 msgid "%s is not installed or not found"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:299
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:336
 msgid "Add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:297
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:334
 msgid "Add IPv6 entries to block-list."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:267
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:296
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:339
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:375
 msgid "Allowed Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:334
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:371
 msgid "Allowed Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:332
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:369
 msgid "Allowed and Blocked Lists Management"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:321
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:358
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:265
 msgid "Automatic Config Update"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:234
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:263
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:349
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:383
 msgid "Blocked Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:344
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:379
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:354
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:387
 msgid "Blocked Hosts URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:202
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:231
 msgid "Blocking %s domains (with %s)."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:192
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:221
 msgid "Cache file containing %s domains found."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:212
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:241
 msgid "Collected Errors"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:196
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:225
 msgid "Compressed cache file found."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:232
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:261
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:241
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:270
 msgid "Controls system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:349
 msgid "Curl download retry"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:283
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
 msgid "DNS Service"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:285
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:319
 msgid "DNSMASQ Additional Hosts"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:286
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:320
 msgid "DNSMASQ Config"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:322
 msgid "DNSMASQ IP Set"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:290
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:325
+msgid "DNSMASQ NFT Set"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:327
 msgid "DNSMASQ Servers File"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:304
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:341
 msgid "Delay (in seconds) for on-boot start"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:237
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:266
 #: applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm:68
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:327
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:364
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:298
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:335
 msgid "Do not add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:322
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:359
 msgid "Do not store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:317
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:354
 msgid "Do not use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:308
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
 msgid "Download time-out (in seconds)"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:138
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:166
 msgid "Downloading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:238
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:267
 #: applications/luci-app-simple-adblock/luasrc/view/simple-adblock/buttons.htm:65
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:326
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:328
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:363
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:365
 msgid "Enable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:326
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:363
 msgid "Enables debug output to /tmp/simple-adblock.log."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:139
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:167
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:141
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:169
 msgid "Fail"
 msgstr ""
 
@@ -169,19 +173,19 @@ msgstr ""
 msgid "Force Re-Download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:137
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:165
 msgid "Force Reloading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:276
 msgid "Force Router DNS"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:249
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:278
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:247
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:276
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
@@ -189,40 +193,40 @@ msgstr ""
 msgid "Grant UCI and file access for luci-app-simple-adblock"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:297
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:334
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:312
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:349
 msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:334
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:371
 msgid "Individual domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:344
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:379
 msgid "Individual domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:190
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:194
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:219
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:223
 msgid "Info"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:258
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:287
 msgid "LED to indicate status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:316
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:353
 msgid ""
 "Launch all lists downloads and processing simultaneously, reducing service "
 "start time."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:248
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:277
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
@@ -230,73 +234,73 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:207
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
 msgid "Message"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:241
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:270
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:236
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:265
 msgid "Perform config update before downloading the block/allow-lists."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:269
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:298
 msgid ""
 "Pick the DNS resolution option to create the adblock list for, see the "
 "%sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:259
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:288
 msgid "Pick the LED not already used in %sSystem LED Configuration%s."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:272
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:273
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:274
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:275
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:277
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:280
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:301
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:302
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:303
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:304
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:307
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:310
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:314
 msgid "Please note that %s is not supported on this system."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:136
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:164
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:304
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:341
 msgid "Run service after set delay on boot."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:227
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:256
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:199
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:205
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:215
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:228
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:170
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:199
 msgid "Service Status [%s %s]"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/luasrc/controller/simple-adblock.lua:4
-#: applications/luci-app-simple-adblock/root/usr/share/luci/menu.d/luci-app-simple-adblock.json:3
 msgid "Simple AdBlock"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:164
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:193
 msgid "Simple AdBlock Settings"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:316
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:353
 msgid "Simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:243
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:272
 msgid "Some output"
 msgstr ""
 
@@ -304,7 +308,7 @@ msgstr ""
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:135
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:163
 msgid "Starting"
 msgstr ""
 
@@ -312,142 +316,146 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:308
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:345
 msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:134
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:162
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:323
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:360
 msgid "Store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:321
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:358
 msgid "Store compressed cache file on router"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:142
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:170
 msgid "Success"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:242
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:271
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:180
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:209
 msgid "Task"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:339
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:375
 msgid "URLs to lists of domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:349
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:383
 msgid "URLs to lists of domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:354
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:387
 msgid "URLs to lists of hosts to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:293
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:330
 msgid "Unbound AdBlock List"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:318
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:355
 msgid "Use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:244
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:273
 msgid "Verbose output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:140
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:168
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:145
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:173
 msgid "failed to access shared memory"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:143
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:171
 msgid "failed to create '%s' file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:155
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:183
 msgid "failed to create block-list or restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:151
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:179
 msgid "failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:159
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:191
+msgid "failed to create output/cache/gzip file directory"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:187
 msgid "failed to download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:158
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:186
 msgid "failed to download Config Update file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:149
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:177
 msgid "failed to format data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:154
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:182
 msgid "failed to move '%s' to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:150
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:178
 msgid "failed to move temporary data file to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:147
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:175
 msgid "failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:161
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:189
 msgid "failed to parse"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:160
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:188
 msgid "failed to parse Config Update file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:148
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:176
 msgid "failed to process allow-list"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:157
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:185
 msgid "failed to reload/restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:152
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:180
 msgid "failed to remove temporary files"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:144
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:172
 msgid "failed to restart/reload DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:146
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:174
 msgid "failed to sort data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:156
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:184
 msgid "failed to stop %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:153
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:181
 msgid "failed to unpack compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:162
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:190
 msgid "no HTTPS/SSL support on device"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:261
+#: applications/luci-app-simple-adblock/luasrc/model/cbi/simple-adblock.lua:290
 msgid "none"
 msgstr ""

--- a/applications/luci-app-simple-adblock/root/etc/uci-defaults/40_luci-simple-adblock
+++ b/applications/luci-app-simple-adblock/root/etc/uci-defaults/40_luci-simple-adblock
@@ -1,3 +1,4 @@
 #!/bin/sh
 rm -rf /var/luci-modulecache/; rm -f /var/luci-indexcache;
+[ -x /etc/init.d/rpcd ] && /etc/init.d/rpcd reload
 exit 0


### PR DESCRIPTION
* Support for (upcoming) dnsmasq nftset

Depends on https://github.com/openwrt/packages/pull/19246

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 9b71a35428e0ddbf0347c8ba62da2f4168ddb21b)