### PR TITLE
luci-proto-unet: initial support

### DIFF
--- a/protocols/luci-proto-unet/Makefile
+++ b/protocols/luci-proto-unet/Makefile
@@ -1,0 +1,15 @@
+#
+# Copyright (C) 2022 Hannu Nyman <hannu.nyman@iki.fi>
+#
+# This is free software, licensed under the Apache License, Version 2.0 .
+#
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Support for unetd VPN
+LUCI_DEPENDS:=+unetd +unet-cli
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js
+++ b/protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js
@@ -1,0 +1,48 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+return network.registerProtocol('unet', {
+	getI18n: function() {
+		return _('Unet');
+	},
+
+	getIfname: function() {
+		return this._ubus('l3_device') || this.sid;
+	},
+
+	getOpkgPackage: function() {
+		return 'unetd';
+	},
+
+	isFloating: function() {
+		return true;
+	},
+
+	isVirtual: function() {
+		return true;
+	},
+
+	getDevices: function() {
+		return null;
+	},
+
+	containsDevice: function(ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function(s) {
+		var o;
+
+		o = s.taboption('general', form.DummyValue, 'device', _('Name of the tunnel device'));
+		o.optional = false;
+
+		o = s.taboption('general', form.DummyValue, 'key', _('Local wireguard key'));
+		o.optional = false;
+
+		o = s.taboption('general', form.DummyValue, 'auth_key', _('Key used to sign network config'));
+		o.optional = false;
+
+	}
+});


### PR DESCRIPTION
I made a small protocol handler to create initial support for the new unetd VPN daemon from @nbd168 

Currently this just enables seeing the VPN interface in the LuCI network overview, plus the keys used.
No relevant config change possibilities, yet, (as I am not sure how unetd would react if options like keys are later change via uci).

![image](https://user-images.githubusercontent.com/7926856/188735898-3cd9d4b2-7795-45ac-ac9c-bd2fed0a3a58.png)