### PR TITLE
luci-proto-openconnect: Add options proxy server and reconnect timeout

### DIFF
--- a/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
+++ b/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
@@ -116,6 +116,9 @@ return network.registerProtocol('openconnect', {
 
 		o = s.taboption('general', form.Value, 'password2', _('Password2'));
 		o.password = true;
+	
+		o = s.taboption('general', form.Value, 'proxy', _('Proxy Server'));
+		o.optional = true;
 
 		o = s.taboption('general', form.TextValue, 'usercert', _('User certificate (PEM encoded)'));
 		o.rows = 10;
@@ -157,5 +160,10 @@ return network.registerProtocol('openconnect', {
 		o.optional = true;
 		o.placeholder = 1406;
 		o.datatype = 'range(68, 9200)';
+		
+		o = s.taboption('advanced', form.Value, 'reconnect_timeout', _('Reconnect Timeout'));
+		o.optional = true;
+		o.placeholder = 300;
+		o.datatype = 'min(10)';
 	}
 });


### PR DESCRIPTION
Add options proxy server and reconnect timeout

Since commits from openwrt/packages where added:

[99213e631179437c6209b651c97c05511bceda9a](https://github.com/openwrt/packages/commit/99213e631179437c6209b651c97c05511bceda9a)

[614f33a9d7fcd582d2d0d01fedcfbd0ace60c459](https://github.com/openwrt/packages/commit/5c84d8ceba83b7f017f631a2fed1900b5926869a)

Signed-off-by: David Bentham <db260179@gmail.com>