### PR TITLE
proper cache control in firefox

### DIFF
--- a/modules/luci-base/root/www/index.html
+++ b/modules/luci-base/root/www/index.html
@@ -3,6 +3,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>
 		<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+		<meta http-equiv="Pragma" content="no-cache" />
+                <meta http-equiv="Expires" content="0" />
 		<meta http-equiv="refresh" content="0; URL=cgi-bin/luci/" />
 		<style type="text/css">
 			body { background: white; font-family: arial, helvetica, sans-serif; }


### PR DESCRIPTION
Added more meta headers to ensure proper cache control in Firefox. Before this patch, the `/` url hasn't even been requested when opened in Firefox.

Signed-off-by: Daniel Kucera <daniel.kucera@gmail.com>