### PR TITLE
luci-app-isc-dhcp: Add LuCI for ISC DHCP

### DIFF
--- a/applications/luci-app-isc-dhcp/Makefile
+++ b/applications/luci-app-isc-dhcp/Makefile
@@ -1,0 +1,19 @@
+#
+# Copyright (C) 2022 Jaymin Patel <jem.patel@gmail.com>
+#
+# This is free software, licensed under the GNU General Public License v2.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_LICENSE:=GPL-2.0-or-later
+PKG_MAINTAINER:=Jaymin Patel <jem.patel@gmail.com>
+
+LUCI_TITLE:=LuCI support for the ISC DHCP
+LUCI_DEPENDS:=+luci-base
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature
+

--- a/applications/luci-app-isc-dhcp/htdocs/luci-static/resources/view/isc-dhcp/dynamicdns.js
+++ b/applications/luci-app-isc-dhcp/htdocs/luci-static/resources/view/isc-dhcp/dynamicdns.js
@@ -1,0 +1,42 @@
+'use strict';
+'require view';
+'require form';
+
+return view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('dhcp', _('ISC DHCP Dynamic DNS'));
+
+		s = m.section(form.NamedSection, 'dynamicdns', 'dynamicdns');
+		s.addremove = false;
+		s.nodescription = true;
+
+		o = s.option(form.Value, 'server', _('Server'));
+		o.optional = false;
+		o.rmempty = false;
+		o.datatype = 'ipaddr';
+
+		o = s.option(form.Value, 'key_name', _('Key Name'));
+		o.optional = false;
+		o.rmempty = false;
+		o.datatype = 'string';
+
+		o = s.option(form.ListValue, 'key_algo', _('Key Algorithm'));
+		o.optional = false;
+		o.rmempty = false;
+		o.value('hmac-sha256', _('HMAC-SHA256'));
+
+		o = s.option(form.Value, 'key_secret', _('Key Secret'));
+		o.optional = false;
+		o.rmempty = false;
+		o.datatype = 'string';
+		o.modalonly = true;
+
+		o = s.option(form.DynamicList, 'zones', _('Zones'));
+		o.optional = false;
+		o.rmempty = false;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-isc-dhcp/htdocs/luci-static/resources/view/isc-dhcp/general.js
+++ b/applications/luci-app-isc-dhcp/htdocs/luci-static/resources/view/isc-dhcp/general.js
@@ -1,0 +1,48 @@
+'use strict';
+'require view';
+'require form';
+
+return view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.Map('dhcp', _('ISC DHCP General Settings'));
+
+		s = m.section(form.NamedSection, 'isc_dhcpd', 'isc_dhcpd');
+		s.anonymous = false;
+		s.addremove = false;
+
+		o = s.option(form.Flag, 'authoritative', _('Authoritative'));
+		o.rmempty = false;
+		o.default = true;
+
+		o = s.option(form.Value, 'default_lease_time', _('Default Lease Time'));
+		o.optional = true;
+		o.datatype = 'uinteger';
+		o.default = 3600;
+
+		o = s.option(form.Value, 'max_lease_time', _('Max Lease Time'));
+		o.optional = true;
+		o.datatype = 'uinteger';
+		o.default = 86400;
+
+		o = s.option(form.Flag, 'always_broadcast', _('Always Broadcast'));
+		o.default = false;
+
+		o = s.option(form.Flag, 'boot_unknown_clients', _('Boot Unknown Clients'));
+		o.default = false;
+
+		o = s.option(form.Value, 'log_facility', _('Log Facility'));
+		o.value('daemon', _('Daemon'));
+		o.default = 'daemon';
+		o.optional = true;
+
+		o = s.option(form.Value, 'domain', _('Domain'));
+		o.optional = true;
+
+		o = s.option(form.Flag, 'dynamicdns', _('Dynamic DNS'));
+		o.default = false;
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-isc-dhcp/root/usr/share/luci/menu.d/luci-app-isc-dhcp.json
+++ b/applications/luci-app-isc-dhcp/root/usr/share/luci/menu.d/luci-app-isc-dhcp.json
@@ -1,0 +1,27 @@
+{
+	"admin/network/isc-dhcp": {
+		"title": "ISC DHCP",
+		"order": 10,
+		"action": {
+			"type": "firstchild"
+		}
+	},
+
+	"admin/network/isc-dhcp/general": {
+		"title": "General",
+		"order": 30,
+		"action": {
+			"type": "view",
+			"path": "isc-dhcp/general"
+		}
+	},
+
+	"admin/network/isc-dhcp/dynamicdns": {
+		"title": "Dynamic DNS",
+		"order": 40,
+		"action": {
+			"type": "view",
+			"path": "isc-dhcp/dynamicdns"
+		}
+	}
+}

--- a/applications/luci-app-isc-dhcp/root/usr/share/rpcd/acl.d/luci-app-isc-dhcp.json
+++ b/applications/luci-app-isc-dhcp/root/usr/share/rpcd/acl.d/luci-app-isc-dhcp.json
@@ -1,0 +1,11 @@
+{
+	"luci-app-isc-dhcp" : {
+		"description" : "Grant access to LuCI app ISC DHCP",
+		"read" : {
+			"uci": [ "dhcp" ]
+		},
+		"write" : {
+			"uci": [ "dhcp" ]
+		}
+	}
+}


### PR DESCRIPTION
LuCI Support for ISC DHCP

**We also need https://github.com/openwrt/packages/pull/19413**

Screenshots from the new Luci App ISC DHCP:

General
![OpenWrt-General-LuCI](https://user-images.githubusercontent.com/479974/191241335-7c05aaf0-ce80-4934-a5fc-61c689797afa.png)

Dynamic DNS
![OpenWrt-Dynamic-DNS-LuCI](https://user-images.githubusercontent.com/479974/191241368-896312e1-d835-4324-97be-d59d83d8666b.png)
