### PR TITLE
luci-mod-system: allow ecdsa-sk and ed25519-sk key types

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/sshkeys.js
@@ -22,7 +22,7 @@ var SSHPubkeyDecoder = baseclass.singleton({
 
 	decode: function(s)
 	{
-		var parts = s.trim().match(/^((?:(?:^|,)[^ =,]+(?:=(?:[^ ",]+|"(?:[^"\\]|\\.)*"))?)+ +)?(ssh-dss|ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp[0-9]+) +([^ ]+)( +.*)?$/);
+		var parts = s.trim().match(/^((?:(?:^|,)[^ =,]+(?:=(?:[^ ",]+|"(?:[^"\\]|\\.)*"))?)+ +)?(ssh-dss|ssh-rsa|ssh-ed25519|ecdsa-sha2-nistp[0-9]+|sk-ecdsa-sha2-nistp256@openssh\.com|sk-ssh-ed25519@openssh\.com) +([^ ]+)( +.*)?$/);
 
 		if (!parts)
 			return null;
@@ -99,6 +99,12 @@ var SSHPubkeyDecoder = baseclass.singleton({
 
 		case 'ecdsa-sha2':
 			return { type: 'ECDSA', curve: curve, comment: comment, options: options, fprint: fprint, src: s };
+		
+		case 'sk-ecdsa-sha2-nistp256@openssh.com':
+			return { type: 'ECDSA-SK', curve: 'NIST P-256', comment: comment, options: options, fprint: fprint, src: s };
+		
+		case 'sk-ssh-ed25519@openssh.com':
+			return { type: 'EdDSA-SK', curve: 'Curve25519', comment: comment, options: options, fprint: fprint, src: s };
 
 		default:
 			return null;


### PR DESCRIPTION
Allow importing SSH public keys of types "ecdsa-sk" and "ed25519-sk" via LuCI.
These key types can be generated via the -t flag in ssh-keygen and are supported in recent versions of dropbear. As ssh-keygen ignores the -b flag when generating ecdsa-sk and ed25519-sk keys, I've set the curve field in the objects returned by the decode function to fixed strings for both ecdsa-sk and ed25519-sk input strings. This is in contrast to ecdsa keys for which various curves can be provided during generation (e.g., NIST P-256, NIST P-384, and NIST P-521).

Signed-off-by: Eric McDonald <eric.mcdonald@protonmail.com>