### PR TITLE
luci-app-ddns: fix creation of custom service (fix #4926)

### DIFF
--- a/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
+++ b/applications/luci-app-ddns/htdocs/luci-static/resources/view/ddns/overview.js
@@ -477,7 +477,9 @@ return view.extend({
 
 			return m.save(function() {
 				uci.add('ddns', 'service', section_id);
-				uci.set('ddns', section_id, 'service_name', service_value);
+				if (service_value != '-') {
+					uci.set('ddns', section_id, 'service_name', service_value);
+				}
 				uci.set('ddns', section_id, 'use_ipv6', ipv6_value);
 			}).then(L.bind(m.children[1].renderMoreOptionsModal, m.children[1], section_id));
 		};


### PR DESCRIPTION
The `service_name` option must be empty for custom services, otherwise an error is raised in `dynamic_dns_updater.sh`.

Signed-off-by: Julien Cassette <julien.cassette@gmail.com>