### PR TITLE
luci-base: add alphanumeric validators in validation.js

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -236,6 +236,14 @@ var ValidatorFactory = baseclass.extend({
 	},
 
 	types: {
+		alphanumeric: function() {
+			return this.assert(this.value.match(/^[a-zA-Z0-9]+$/), _('string with characters and numbers only.'));
+		},
+
+		alphanumericspace: function() {
+			return this.assert(this.value.match(/^[a-zA-Z0-9 ]+$/), _('string with characters, numbers and spaces only.'));
+		},
+
 		integer: function() {
 			return this.assert(!isNaN(this.factory.parseInteger(this.value)), _('valid integer value'));
 		},


### PR DESCRIPTION
This adds two validators in the validation class. One validator for alphanumeric strings [A-z0-9] and one for alpha numeric strings with spaces [A-z0-9 ]. These come in very handy for validating input strings which aren't allowed to contain any characters that could be used in valid code statements.

Signed-off-by: Martin Hübner <martin.hubner@web.de>

We need theses validators for a App, we are currently working on at Freifunk Berlin. Description of Freifunk-Services must not contain any other characters than alphanumeric and whitespace.