### PR TITLE
luci-app-https-dns-proxy: update to 2021-11-22-7 (settings for Canary…

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2021-09-27-3
+PKG_VERSION:=2021-11-22-7
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -132,7 +132,17 @@ d1.default = '*'
 f1 = c:option(ListValue, "force_dns", translate("Force Router DNS"), translate("Forces Router DNS use on local devices, also known as DNS Hijacking."))
 f1:value("0", translate("Let local devices use their own DNS servers if set"))
 f1:value("1", translate("Force Router DNS server to all local devices"))
-f1.default = '1'
+f1.default = "1"
+cdi = c:option(ListValue, "canary_domains_icloud", translate("Canary Domains iCloud"), translatef("Blocks access to iCloud Private Relay resolvers, forcing local devices to use router for DNS resolution (%smore information%s).", "<a href=\"" .. readmeURL .. "#canary_domains_icloud" .. "\" target=\"_blank\">", "</a>"))
+cdi:value("0", translate("Let local devices use iCloud Private Relay"))
+cdi:value("1", translate("Force Router DNS server to all local devices"))
+cdi:depends({force_dns="1"}) 
+cdi.default = "1"
+cdm = c:option(ListValue, "canary_domains_mozilla", translate("Canary Domains Mozilla"), translatef("Blocks access to Mozilla resolvers, forcing local devices to use router for DNS resolution (%smore information%s).", "<a href=\"" .. readmeURL .. "#canary_domains_mozilla" .. "\" target=\"_blank\">", "</a>"))
+cdm:value("0", translate("Let local devices use Mozilla resolvers"))
+cdm:value("1", translate("Force Router DNS server to all local devices"))
+cdm:depends({force_dns="1"}) 
+cdm.default = "1"
 
 createHelperText()
 s3 = m:section(TypedSection, "https-dns-proxy", translate("Instances"), 

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -93,6 +93,18 @@ msgstr ""
 msgid "BlahDNS - SG"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:141
+msgid ""
+"Blocks access to Mozilla resolvers, forcing local devices to use router for "
+"DNS resolution (%smore information%s)."
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:136
+msgid ""
+"Blocks access to iCloud Private Relay resolvers, forcing local devices to "
+"use router for DNS resolution (%smore information%s)."
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/net.cfiec.dns.lua:3
 msgid "CFIEC Public DNS (IPv6 Only)"
 msgstr ""
@@ -107,6 +119,14 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/ca.cira.canadianshield.protected.lua:3
 msgid "CIRA Canadian Shield (Protected)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:141
+msgid "Canary Domains Mozilla"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:136
+msgid "Canary Domains iCloud"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/org.cleanbrowsing.doh-adult.lua:3
@@ -145,17 +165,14 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware-ads-social.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p3.lua:3
 msgid "ControlD (Block Malware + Ads + Social)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware-ads.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p2.lua:3
 msgid "ControlD (Block Malware + Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p1.lua:3
 msgid "ControlD (Block Malware)"
 msgstr ""
@@ -165,7 +182,6 @@ msgid "ControlD (Family)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p0.lua:3
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.unfiltered.lua:3
 msgid "ControlD (Unfiltered)"
 msgstr ""
 
@@ -205,7 +221,7 @@ msgstr ""
 msgid "DNSlify DNS"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:195
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:205
 msgid "DSCP Codepoint"
 msgstr ""
 
@@ -242,6 +258,8 @@ msgid "Force Router DNS"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:134
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:138
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:143
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
@@ -276,12 +294,20 @@ msgid ""
 "information%s)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:138
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:148
 msgid "Instances"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/fi.lelux.resolver-eu.lua:3
 msgid "Lelux DNS - FI"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:142
+msgid "Let local devices use Mozilla resolvers"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:137
+msgid "Let local devices use iCloud Private Relay"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:133
@@ -296,11 +322,11 @@ msgstr ""
 msgid "LibreDNS - GR (No Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:178
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:188
 msgid "Listen Address"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:191
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:201
 msgid "Listen Port"
 msgstr ""
 
@@ -340,7 +366,7 @@ msgstr ""
 msgid "OpenDNS (Family Shield)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:199
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:209
 msgid "Proxy Server"
 msgstr ""
 
@@ -368,7 +394,7 @@ msgstr ""
 msgid "Reload"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:145
+#: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:155
 msgid "Resolver"
 msgstr ""
 


### PR DESCRIPTION
… Domains)

Depends on https://github.com/openwrt/packages/pull/19527

Signed-off-by: Stan Grishin <stangri@melmac.ca>