### PR TITLE
luci-app-wireguard: trivial fix to separate a peer's multiple IPs

### DIFF
--- a/applications/luci-app-wireguard/htdocs/luci-static/resources/view/wireguard/status.js
+++ b/applications/luci-app-wireguard/htdocs/luci-static/resources/view/wireguard/status.js
@@ -115,7 +115,7 @@ function parsePeerData(peer) {
 		['endpoint', _('Endpoint'),
 			peer.endpoint == '(none)' ? null : peer.endpoint],
 		['allowed_ips', _('Allowed IPs'),
-			peer.allowed_ips.length == 0 ? null : peer.allowed_ips.join('\n')],
+			peer.allowed_ips.length == 0 ? null : peer.allowed_ips.join(', ')],
 		['persistent_keepalive', _('Persistent Keepalive'),
 			peer.persistent_keepalive == 'off' ? null : peer.persistent_keepalive + 's'],
 		['latest_handshake', _('Latest Handshake'),


### PR DESCRIPTION
Attempts to address issue #6003

Signed-off-by: Paul Dee <itsascambutmailmeanyway@gmail.com>

Tested on 22.03.0