### PR TITLE
[openwrt-22.03] luci-app-smartdns: update to 1.2022.38

### DIFF
--- a/applications/luci-app-smartdns/Makefile
+++ b/applications/luci-app-smartdns/Makefile
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Nick Peng <pymumu@gmail.com>
-PKG_VERSION:=1.2020.30
-PKG_RELEASE:=1
+PKG_VERSION:=1.2022.38
+PKG_RELEASE:=2
 
 LUCI_TITLE:=LuCI for smartdns
 LUCI_DESCRIPTION:=Provides Luci for smartdns

--- a/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
+++ b/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
@@ -21,8 +21,10 @@
 'require fs';
 'require uci';
 'require form';
-'require rpc';
 'require view';
+'require poll';
+'require rpc';
+'require ui';
 
 var conf = 'smartdns';
 var callServiceList = rpc.declare({
@@ -31,8 +33,9 @@ var callServiceList = rpc.declare({
 	params: ['name'],
 	expect: { '': {} }
 });
+var pollAdded = false;
 
-function getPidOfSmartdns() {
+function getServiceStatus() {
 	return L.resolveDefault(callServiceList(conf), {})
 		.then(function (res) {
 			var isrunning = false;
@@ -43,43 +46,19 @@ function getPidOfSmartdns() {
 		});
 }
 
-function getIPTablesRedirect() {
-	return fs.exec('/usr/sbin/iptables', ['-t', 'nat', '-nL', 'PREROUTING']).then(function (res) {
-		if (res.code === 0) {
-			return res.stdout.trim();
-		} else {
-			return "";
-		}
-	});
-}
-
-function getIP6TablesRedirect() {
-	return fs.exec('/usr/sbin/ip6tables', ['-t', 'nat', '-nL', 'PREROUTING']).then(function (res) {
-		if (res.code === 0) {
-			return res.stdout.trim();
-		} else {
-			return "";
-		}
-	});
-}
-
 function smartdnsServiceStatus() {
 	return Promise.all([
-		getPidOfSmartdns(),
-		getIPTablesRedirect(),
-		getIP6TablesRedirect()
+		getServiceStatus()
 	]);
 }
 
 function smartdnsRenderStatus(res) {
 	var renderHTML = "";
 	var isRunning = res[0];
-	var ipt = res[1];
-	var ip6t = res[2];
 
-	var serverPort = uci.get_first('smartdns', 'smartdns', 'port');
-	var redirectMode = uci.get_first('smartdns', 'smartdns', 'redirect');
-	var ipv6Enabled = uci.get_first('smartdns', 'smartdns', 'ipv6_server');
+	var autoSetDnsmasq = uci.get_first('smartdns', 'smartdns', 'auto_set_dnsmasq');
+	var smartdnsPort = uci.get_first('smartdns', 'smartdns', 'port');
+	var dnsmasqServer = uci.get_first('dhcp', 'dnsmasq', 'server');
 
 	if (isRunning) {
 		renderHTML += "<span style=\"color:green;font-weight:bold\">SmartDNS - " + _("RUNNING") + "</span>";
@@ -88,28 +67,13 @@ function smartdnsRenderStatus(res) {
 		return renderHTML;
 	}
 
-	if (redirectMode === "dnsmasq-upstream") {
-		var matchLine = "127.0.0.1#" + serverPort;
-		var dnsmasqServer = uci.get_first('dhcp', 'dnsmasq', 'server') || "";
+	if (autoSetDnsmasq === '1' && smartdnsPort != '53') {
+		var matchLine = "127.0.0.1#" + smartdnsPort;
 
-		if (dnsmasqServer.indexOf(matchLine) < 0) {
+		uci.unload('dhcp');
+		uci.load('dhcp');
+		if (dnsmasqServer == undefined || dnsmasqServer.indexOf(matchLine) < 0) {
 			renderHTML += "<br /><span style=\"color:red;font-weight:bold\">" + _("Dnsmasq Forwared To Smartdns Failure") + "</span>";
-		}
-	} else if (redirectMode === "redirect") {
-		var redirectRules = (ipt || '').split(/\n/).filter(function (rule) {
-			return rule.match(/REDIRECT/) && rule.match(/dpt:53/) && rule.match("ports " + serverPort);
-		});
-
-		if (redirectRules.length <= 0) {
-			renderHTML += "<br /><span style=\"color:red;font-weight:bold\">" + _("IPV4 53 Port Redirect Failure") + "</span>";
-			if (ipv6Enabled) {
-				var redirectRules = (ip6t || '').split(/\n/).filter(function (rule) {
-					return rule.match(/REDIRECT/) && rule.match(/dpt:53/) && rule.match("ports " + serverPort);
-				});
-				if (redirectRules.length <= 0) {
-					renderHTML += "<br /><span style=\"color:red;font-weight:bold\">" + _("IPV6 53 Port Redirect Failure") + "</span>";
-				}
-			}
 		}
 	}
 
@@ -119,8 +83,8 @@ function smartdnsRenderStatus(res) {
 return view.extend({
 	load: function () {
 		return Promise.all([
+			uci.load('dhcp'),
 			uci.load('smartdns'),
-			uci.load('dhcp')
 		]);
 	},
 	render: function (stats) {
@@ -134,19 +98,26 @@ return view.extend({
 		s = m.section(form.NamedSection, '_status');
 		s.anonymous = true;
 		s.render = function (section_id) {
-			L.Poll.add(function () {
+			var renderStatus = function () {
 				return L.resolveDefault(smartdnsServiceStatus()).then(function (res) {
 					var view = document.getElementById("service_status");
+					if (view == null) {
+						return;
+					}
+
 					view.innerHTML = smartdnsRenderStatus(res);
 				});
-			});
+			}
 
-			return E('div', { class: 'cbi-map' },
-				E('div', { class: 'cbi-section' }, [
-					E('div', { id: 'service_status' },
-						_('Collecting data ...'))
-				])
-			);
+			if (pollAdded == false) {
+				poll.add(renderStatus, 1);
+				pollAdded = true;
+			}
+
+			return E('div', { class: 'cbi-section' }, [
+				E('div', { id: 'service_status' },
+					_('Collecting data ...'))
+			]);
 		}
 
 		// Basic;
@@ -157,10 +128,9 @@ return view.extend({
 		s.tab("seconddns", _("Second Server Settings"));
 		s.tab("custom", _("Custom Settings"));
 
-		// Eanble;
 		o = s.taboption("settings", form.Flag, "enabled", _("Enable"), _("Enable or disable smartdns server"));
+		o.rmempty = false;
 		o.default = o.disabled;
-		o.rempty = false;
 
 		// server name;
 		o = s.taboption("settings", form.Value, "server_name", _("Server Name"), _("Smartdns server name"));
@@ -169,9 +139,10 @@ return view.extend({
 		o.rempty = false;
 
 		// Port;
-		o = s.taboption("settings", form.Value, "port", _("Local Port"), _("Smartdns local server port"));
-		o.placeholder = 6053;
-		o.default = 6053;
+		o = s.taboption("settings", form.Value, "port", _("Local Port"),
+			_("Smartdns local server port, smartdns will be automatically set as main dns when the port is 53."));
+		o.placeholder = 53;
+		o.default = 53;
 		o.datatype = "port";
 		o.rempty = false;
 
@@ -189,7 +160,7 @@ return view.extend({
 		o = s.taboption("settings", form.Flag, "dualstack_ip_selection", _("Dual-stack IP Selection"),
 			_("Enable IP selection between IPV4 and IPV6"));
 		o.rmempty = false;
-		o.default = o.disabled;
+		o.default = o.enabled;
 
 		// Domain prefetch load ;
 		o = s.taboption("settings", form.Flag, "prefetch_domain", _("Domain prefetch"),
@@ -201,20 +172,31 @@ return view.extend({
 		o = s.taboption("settings", form.Flag, "serve_expired", _("Serve expired"),
 			_("Attempts to serve old responses from cache with a TTL of 0 in the response without waiting for the actual resolution to finish."));
 		o.rmempty = false;
-		o.default = o.disabled;
-
-		// Redirect;
-		o = s.taboption("settings", form.ListValue, "redirect", _("Redirect"), _("SmartDNS redirect mode"));
-		o.placeholder = "none";
-		o.value("none", _("none"));
-		o.value("dnsmasq-upstream", _("Run as dnsmasq upstream server"));
-		o.value("redirect", _("Redirect 53 port to SmartDNS"));
-		o.default = "none";
-		o.rempty = false;
+		o.default = o.enabled;
 
 		// cache-size;
 		o = s.taboption("settings", form.Value, "cache_size", _("Cache Size"), _("DNS domain result cache size"));
 		o.rempty = true;
+
+		// cache-size;
+		o = s.taboption("settings", form.Flag, "resolve_local_hostnames", _("Resolve Local Hostnames"), _("Resolve local hostnames by reading Dnsmasq lease file."));
+		o.rmempty = false;
+		o.default = o.enabled;
+
+		// auto-conf-dnsmasq;
+		o = s.taboption("settings", form.Flag, "auto_set_dnsmasq", _("Automatically Set Dnsmasq"), _("Automatically set as upstream of dnsmasq when port changes."));
+		o.rmempty = false;
+		o.default = o.enabled;
+
+		// Force AAAA SOA
+		o = s.taboption("settings", form.Flag, "force_aaaa_soa", _("Force AAAA SOA"), _("Force AAAA SOA."));
+		o.rmempty = false;
+		o.default = o.disabled;
+
+		// Force HTTPS SOA
+		o = s.taboption("settings", form.Flag, "force_https_soa", _("Force HTTPS SOA"), _("Force HTTPS SOA."));
+		o.rmempty = false;
+		o.default = o.disabled;
 
 		// rr-ttl;
 		o = s.taboption("settings", form.Value, "rr_ttl", _("Domain TTL"), _("TTL for all domain result."));
@@ -224,16 +206,21 @@ return view.extend({
 		o = s.taboption("settings", form.Value, "rr_ttl_min", _("Domain TTL Min"),
 			_("Minimum TTL for all domain result."));
 		o.rempty = true;
-		o.placeholder = "300";
-		o.default = 300;
+		o.placeholder = "600";
+		o.default = 600;
 		o.optional = true;
 
-		// second dns server;
 		// rr-ttl-max;
 		o = s.taboption("settings", form.Value, "rr_ttl_max", _("Domain TTL Max"),
 			_("Maximum TTL for all domain result."));
 		o.rempty = true;
 
+		// rr-ttl-reply-max;
+		o = s.taboption("settings", form.Value, "rr_ttl_reply_max", _("Reply Domain TTL Max"),
+			_("Reply maximum TTL for all domain result."));
+		o.rempty = true;
+
+		// second dns server;
 		// Eanble;
 		o = s.taboption("seconddns", form.Flag, "seconddns_enabled", _("Enable"),
 			_("Enable or disable second DNS server."));
@@ -300,7 +287,7 @@ return view.extend({
 		o.default = o.disabled;
 
 		// Force AAAA SOA
-		o = s.taboption("seconddns", form.Flag, "force_aaaa_soa", _("Force AAAA SOA"), _("Force AAAA SOA."));
+		o = s.taboption("seconddns", form.Flag, "seconddns_force_aaaa_soa", _("Force AAAA SOA"), _("Force AAAA SOA."));
 		o.rmempty = false;
 		o.default = o.disabled;
 
@@ -313,7 +300,12 @@ return view.extend({
 			return fs.trimmed('/etc/smartdns/custom.conf');
 		};
 		o.write = function (section_id, formvalue) {
-			return fs.write('/etc/smartdns/custom.conf', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			return this.cfgvalue(section_id).then(function (value) {
+				if (value == formvalue) {
+					return
+				}
+				return fs.write('/etc/smartdns/custom.conf', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			});
 		};
 
 		o = s.taboption("custom", form.Flag, "coredump", _("Generate Coredump"),
@@ -390,6 +382,15 @@ return view.extend({
 		o.depends("type", "tls")
 		o.depends("type", "https")
 
+		// certificate verify
+		o = s.taboption("advanced", form.Flag, "no_check_certificate", _("No check certificate"),
+			_("Do not check certificate."))
+		o.rmempty = false
+		o.default = o.disabled
+		o.modalonly = true;
+		o.depends("type", "tls")
+		o.depends("type", "https")
+
 		// SNI host name
 		o = s.taboption("advanced", form.Value, "host_name", _("TLS SNI name"),
 			_("Sets the server name indication for query."))
@@ -443,7 +444,12 @@ return view.extend({
 			return fs.trimmed('/etc/smartdns/address.conf');
 		};
 		o.write = function (section_id, formvalue) {
-			return fs.write('/etc/smartdns/address.conf', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			return this.cfgvalue(section_id).then(function (value) {
+				if (value == formvalue) {
+					return
+				}
+				return fs.write('/etc/smartdns/address.conf', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			});
 		};
 
 		// IP Blacklist;
@@ -455,7 +461,12 @@ return view.extend({
 			return fs.trimmed('/etc/smartdns/blacklist-ip.conf');
 		};
 		o.write = function (section_id, formvalue) {
-			return fs.write('/etc/smartdns/blacklist-ip.conf', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			return this.cfgvalue(section_id).then(function (value) {
+				if (value == formvalue) {
+					return
+				}
+				return fs.write('/etc/smartdns/blacklist-ip.conf', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			});
 		};
 
 		// Doman addresss;
@@ -479,6 +490,17 @@ return view.extend({
 			window.open("https://pymumu.github.io/smartdns/#donate", '_blank');
 		};
 
+		o = s.option(form.DummyValue, "_restart", _("Restart Service"));
+		o.renderWidget = function () {
+			return E('button', {
+				'class': 'btn cbi-button cbi-button-apply',
+				'id': 'btn_restart',
+				'click': ui.createHandlerFn(this, function () {
+					return fs.exec('/etc/init.d/smartdns', ['restart'])
+						.catch(function (e) { ui.addNotification(null, E('p', e.message), 'error') });
+				})
+			}, [_("Restart")]);
+		}
 		return m.render();
 	}
 });

--- a/applications/luci-app-smartdns/po/de/smartdns.po
+++ b/applications/luci-app-smartdns/po/de/smartdns.po
@@ -1,29 +1,29 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-07-06 15:20+0000\n"
-"Last-Translator: Christian Sch. <pr0byt3@web.de>\n"
+"PO-Revision-Date: 2022-10-10 21:04+0000\n"
+"Last-Translator: Steffen Möller <steffen_moeller@gmx.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationssmartdns/de/>\n"
 "Language: de\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13.1-dev\n"
+"X-Generator: Weblate 4.14.1\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Additional Args for upstream dns servers"
 msgstr "Zusätzliche Argumente für Upstream-DNS-Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:424
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Additional Server Args"
 msgstr "Zusätzliche Server Parameter"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:331
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
@@ -31,15 +31,23 @@ msgstr ""
 "Versuche, eine alte Antwort vom Cache mit TTL 0 zurückzugeben, ohne auf die "
 "eigentliche Auflösung zu warten."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically Set Dnsmasq"
+msgstr "Dnsmasq automatisch setzen"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically set as upstream of dnsmasq when port changes."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "Cache Size"
 msgstr "Zwischenspeichergröße"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
 msgid "Collecting data ..."
 msgstr "Ermittle Daten..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
@@ -47,417 +55,443 @@ msgstr ""
 "Definition einer IP basierten Blockierliste, welche Ergebnisse eines "
 "spezifischen DNS Servers filtert."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:158
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
 msgid "Custom Settings"
 msgstr "Benutzerdefinierte Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
 msgid "DNS Server Name"
 msgstr "DNS Server Name"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid ""
 "DNS Server group belongs to, used with nameserver, such as office, home."
 msgstr "DNS-Server-Gruppe, zu der der Nameserver gehört, z. B. Büro, Zuhause."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "DNS Server ip"
 msgstr "DNS-Server IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "DNS Server port"
 msgstr "DNS-Server-Port"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "DNS Server type"
 msgstr "DNS-Server Typ"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "DNS domain result cache size"
 msgstr "DNS Domain Ergebnisspeichergröße"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
 msgid "Dnsmasq Forwared To Smartdns Failure"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:264
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+msgid "Do not check certificate."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
 msgid "Do not check speed."
 msgstr "Geschwindigkeit nicht testen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Domain Address"
 msgstr "Domain Adresse"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "Domain TTL"
 msgstr "Domain TTL"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:233
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
 msgid "Domain TTL Max"
 msgstr "Domain TTL Max"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
 msgid "Domain TTL Min"
-msgstr ""
+msgstr "Domain TTL Min"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:195
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
 msgid "Domain prefetch"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:476
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
 msgid "Donate"
 msgstr "Spenden"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:475
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
 msgid "Donate to smartdns"
 msgstr "An smartdns spenden"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:189
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
 msgid "Dual-stack IP Selection"
 msgstr "Dual-Stack-IP-Auswahl"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:334
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
 msgid "Enable"
 msgstr "Aktivieren"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:190
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "Aktiviere Wahl zwischen IPv4 und IPv6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "Enable IPV6 DNS Server"
 msgstr "Aktivere IPv6 DNS-Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "Enable TCP DNS Server"
 msgstr "Aktiviere TCP DNS Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr ""
 "Aktivieren Sie Domänen-Prefetch, um die Reaktionsgeschwindigkeit der Domäne "
 "zu beschleunigen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:239
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
 msgid "Enable or disable second DNS server."
 msgstr "Aktivieren oder deaktivieren des zweiten DNS-Servers."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
 msgid "Enable or disable smartdns server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:378
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
 msgid "Filtering IP with blacklist"
-msgstr ""
+msgstr "Filtern von IP mit negativ-Liste"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA"
-msgstr ""
+msgstr "Erzwinge AAAA SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA."
-msgstr ""
+msgstr "Erzwinge AAAA SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:156
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:330
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA"
+msgstr "Erzwinge HTTPS SOA"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA."
+msgstr "Erzwinge HTTPS SOA."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:319
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
 msgid "Generate Coredump"
-msgstr ""
+msgstr "Generiere Coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:320
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
 msgstr ""
+"Erzeugt eine Coredump-Datei, wenn smartdns abstürzt. Die Coredump-Datei "
+"befindet sich unter /tmp/smartdns.xxx.core."
 
 #: applications/luci-app-smartdns/root/usr/share/rpcd/acl.d/luci-app-smartdns.json:3
 msgid "Grant access to LuCI app smartdns"
-msgstr ""
+msgstr "Zugriff auf die LuCI-App smartdns gewähren"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:404
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
 msgid "HTTP Host"
-msgstr ""
+msgstr "HTTP-Host"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "IP Blacklist"
-msgstr ""
+msgstr "IP Negativ-Liste"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
 msgid "IP Blacklist Filtering"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:104
-msgid "IPV4 53 Port Redirect Failure"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:110
-msgid "IPV6 53 Port Redirect Failure"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "IPV6 Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:463
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr ""
+"Wenn Ihnen diese Software gefällt, spendieren Sie mir bitte eine Tasse "
+"Kaffee."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Local Port"
-msgstr ""
+msgstr "Lokaler Port"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
 msgid "Maximum TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
 msgid "Minimum TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:87
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr "LÄUFT NICHT"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+msgid "No check certificate"
+msgstr "Kein Check der Zertifikate"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:85
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:64
 msgid "RUNNING"
 msgstr "LÄUFT"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "Redirect"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+msgid "Reply Domain TTL Max"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:211
-msgid "Redirect 53 port to SmartDNS"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+msgid "Reply maximum TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
-msgid "Run as dnsmasq upstream server"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve Local Hostnames"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:157
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve local hostnames by reading Dnsmasq lease file."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+msgid "Restart Service"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Second Server Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:201
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
 msgid "Serve expired"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid "Server Group"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Server Name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Set Specific domain ip address."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "Set Specific ip blacklist."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:385
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Set TLS hostname to verify."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
 msgid "Sets the server name indication for query."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
 msgid "Skip Address Rules"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:292
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
 msgid "Skip Dualstack Selection"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:293
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
 msgid "Skip Dualstack Selection."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:281
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
 msgid "Skip Ipset Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
 msgid "Skip Nameserver Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:287
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
 msgid "Skip SOA Address Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:288
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
 msgid "Skip SOA address rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
 msgid "Skip Speed Check"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:270
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
 msgid "Skip address rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
 msgid "Skip ipset rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:276
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
 msgid "Skip nameserver rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:130
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
 msgid "SmartDNS Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:467
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
 msgid "SmartDNS official website"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "SmartDNS redirect mode"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Smartdns local server port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+msgid ""
+"Smartdns local server port, smartdns will be automatically set as main dns "
+"when the port is 53."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Smartdns server name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:439
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
 "IP address which may be IPv4 or IPv6."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "TCP Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
 msgid "TLS Hostname Verify"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:394
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
 msgid "TLS SNI name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:413
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "TLS SPKI Pinning"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:462
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
 msgid "Technical Support"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
 msgid "Upstream Servers"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:325
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
 "verified."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:362
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
 msgid "https"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "ip"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
-msgid "none"
-msgstr "kein"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:468
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
 msgid "open website"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:309
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
 msgid "smartdns custom settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
 msgid "tcp"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:361
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
 msgid "tls"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "type"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:359
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
 msgid "udp"
 msgstr ""
+
+#~ msgid "none"
+#~ msgstr "kein"

--- a/applications/luci-app-smartdns/po/es/smartdns.po
+++ b/applications/luci-app-smartdns/po/es/smartdns.po
@@ -13,20 +13,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.8-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Additional Args for upstream dns servers"
 msgstr "Args adicionales para servidores DNS aguas arriba"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:424
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Additional Server Args"
 msgstr "Args adicionales del servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:331
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
@@ -34,15 +34,23 @@ msgstr ""
 "Intenta servir respuestas antiguas de la memoria caché con un TTL de 0 en la "
 "respuesta sin esperar a que finalice la resolución real."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically Set Dnsmasq"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically set as upstream of dnsmasq when port changes."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "Cache Size"
 msgstr "Tamaño del caché"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
 msgid "Collecting data ..."
 msgstr "Recolectando datos..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
@@ -50,133 +58,147 @@ msgstr ""
 "Configure listas negras de IP que se filtrarán de los resultados de un "
 "servidor DNS específico."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:158
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
 msgid "Custom Settings"
 msgstr "Configuraciones personalizadas"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
 msgid "DNS Server Name"
 msgstr "Nombre del servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid ""
 "DNS Server group belongs to, used with nameserver, such as office, home."
 msgstr ""
 "El grupo del servidor DNS pertenece a, usado con el servidor de nombres, "
 "como la oficina, el hogar."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "DNS Server ip"
 msgstr "IP del servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "DNS Server port"
 msgstr "Puerto del servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "DNS Server type"
 msgstr "Tipo de servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "DNS domain result cache size"
 msgstr "Tamaño del caché de resultados del dominio DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
 msgid "Dnsmasq Forwared To Smartdns Failure"
 msgstr "Fallo en el reenvío de dnsmasq a SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:264
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+msgid "Do not check certificate."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
 msgid "Do not check speed."
 msgstr "No verifique la velocidad."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Domain Address"
 msgstr "Dirección de dominio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "Domain TTL"
 msgstr "TTL del dominio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:233
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
 msgid "Domain TTL Max"
 msgstr "TTL Máx. del dominio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
 msgid "Domain TTL Min"
 msgstr "TTL Mín. del dominio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:195
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
 msgid "Domain prefetch"
 msgstr "Prebúsqueda de dominios"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:476
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
 msgid "Donate"
 msgstr "Donar"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:475
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
 msgid "Donate to smartdns"
 msgstr "Donar a smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:189
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
 msgid "Dual-stack IP Selection"
 msgstr "Selección de IP de doble pila"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:334
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
 msgid "Enable"
 msgstr "Activar"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:190
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "Activar la selección de IP entre IPv4 e IPv6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "Enable IPV6 DNS Server"
 msgstr "Activar servidor DNS IPv6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "Enable TCP DNS Server"
 msgstr "Activar el servidor DNS TCP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr ""
 "Active la captación previa del dominio, acelere la velocidad de respuesta "
 "del dominio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:239
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
 msgid "Enable or disable second DNS server."
 msgstr "Activar o desactivar el segundo servidor DNS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
 msgid "Enable or disable smartdns server"
 msgstr "Activar o desactivar el servidor smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:378
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
 msgid "Filtering IP with blacklist"
 msgstr "Filtrado de IP con lista negra"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA"
 msgstr "Forzar AAAA SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA."
 msgstr "Forzar AAAA SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:156
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:330
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
 msgid "General Settings"
 msgstr "Configuración general"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:319
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
 msgid "Generate Coredump"
 msgstr "Generar Coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:320
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -188,104 +210,112 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "Conceder acceso a la aplicación LuCI smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:404
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
 msgid "HTTP Host"
 msgstr "Host HTTP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "IP Blacklist"
 msgstr "Lista negra de IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
 msgid "IP Blacklist Filtering"
 msgstr "Filtrado de la lista negra de IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:104
-msgid "IPV4 53 Port Redirect Failure"
-msgstr "Error de reenvío de puerto IPv4 53"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:110
-msgid "IPV6 53 Port Redirect Failure"
-msgstr "Error de reenvío de puerto IPv6 53"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "IPV6 Server"
 msgstr "Servidor IPv6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:463
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr "Si le gusta este software, cómpreme una taza de café."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Local Port"
 msgstr "Puerto local"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
 msgid "Maximum TTL for all domain result."
 msgstr "TTL máximo para todos los resultados de dominio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
 msgid "Minimum TTL for all domain result."
 msgstr "TTL mínimo para todos los resultados de dominio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:87
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 #, fuzzy
 msgid "NOT RUNNING"
 msgstr "NO SE ESTÁ EJECUTANDO"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+msgid "No check certificate"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr ""
 "Consulta DNS a través de un grupo de servidores dns específico, como "
 "oficina, hogar."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:85
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:64
 msgid "RUNNING"
 msgstr "EJECUTANDO"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "Redirect"
-msgstr "Redirigir"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+msgid "Reply Domain TTL Max"
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:211
-msgid "Redirect 53 port to SmartDNS"
-msgstr "Redirigir el puerto 53 a SmartDNS"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+msgid "Reply maximum TTL for all domain result."
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
-msgid "Run as dnsmasq upstream server"
-msgstr "Ejecutar como servidor dnsmasq aguas arriba"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve Local Hostnames"
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:157
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve local hostnames by reading Dnsmasq lease file."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+msgid "Restart Service"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Second Server Settings"
 msgstr "Segunda configuración del servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:201
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
 msgid "Serve expired"
 msgstr "Servir expirado"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid "Server Group"
 msgstr "Grupo de servidores"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Server Name"
 msgstr "Nombre del servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Set Specific domain ip address."
 msgstr "Establecer dirección IP de dominio específico."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "Set Specific ip blacklist."
 msgstr "Establecer lista negra de IP específica."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:385
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Set TLS hostname to verify."
 msgstr "Establezca el nombre de host TLS para verificar."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
@@ -293,76 +323,76 @@ msgstr ""
 "Establezca el host HTTP utilizado para la consulta. Use este parámetro "
 "cuando el host de la dirección URL sea una dirección IP."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
 msgid "Sets the server name indication for query."
 msgstr "Establece la indicación del nombre del servidor para la consulta."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
 msgid "Skip Address Rules"
 msgstr "Omitir reglas de dirección"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache"
 msgstr "Omitir caché"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache."
 msgstr "Omitir caché."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:292
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
 msgid "Skip Dualstack Selection"
 msgstr "Omitir selección de pila doble"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:293
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
 msgid "Skip Dualstack Selection."
 msgstr "Omitir selección de pila doble."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:281
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
 msgid "Skip Ipset Rule"
 msgstr "Omitir regla de Ipset"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
 msgid "Skip Nameserver Rule"
 msgstr "Omitir regla de servidor de nombres"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:287
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
 msgid "Skip SOA Address Rule"
 msgstr "Omitir regla de dirección SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:288
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
 msgid "Skip SOA address rules."
 msgstr "Omita las reglas de dirección SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
 msgid "Skip Speed Check"
 msgstr "Omitir comprobación de velocidad"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:270
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
 msgid "Skip address rules."
 msgstr "Omitir reglas de dirección."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
 msgid "Skip ipset rules."
 msgstr "Omitir las reglas de ipset."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:276
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
 msgid "Skip nameserver rules."
 msgstr "Omitir las reglas del servidor de nombres."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr "SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:130
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
 msgid "SmartDNS Server"
 msgstr "Servidor SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
@@ -371,24 +401,25 @@ msgstr ""
 "la IP más rápida, admite el filtrado de anuncios y evita el envenenamiento "
 "de DNS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:467
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
 msgid "SmartDNS official website"
 msgstr "Sitio web oficial de SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "SmartDNS redirect mode"
-msgstr "Modo de redireccionamiento SmartDNS"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Smartdns local server port"
 msgstr "Puerto del servidor local Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+msgid ""
+"Smartdns local server port, smartdns will be automatically set as main dns "
+"when the port is 53."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Smartdns server name"
 msgstr "Nombre del servidor de Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:439
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
@@ -398,36 +429,36 @@ msgstr ""
 "dominios dados, las consultas en los dominios nunca se reenvían y siempre se "
 "responden con la dirección IP especificada que puede ser IPv4 o IPv6."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "TCP Server"
 msgstr "Servidor TCP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
 msgid "TLS Hostname Verify"
 msgstr "Verificar nombre de host TLS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:394
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
 msgid "TLS SNI name"
 msgstr "Nombre SNI de TLS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:413
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "TLS SPKI Pinning"
 msgstr "TLS SPKI Anclado"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "TTL for all domain result."
 msgstr "TTL para todos los resultados de dominio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:462
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
 msgid "Technical Support"
 msgstr "Soporte técnico"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
 msgid "Upstream Servers"
 msgstr "Servidores aguas arriba"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:325
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -435,7 +466,7 @@ msgstr ""
 "Servidores aguas arriba, soporte UDP, protocolo TCP. Configure varios "
 "servidores DNS, incluidos varios servidores DNS externos."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -445,42 +476,90 @@ msgstr ""
 "digital SPKI codificada en Base64, y se deja en blanco para indicar que no "
 "se verifica la validez de TLS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:362
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "ip"
 msgstr "ip"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
-msgid "none"
-msgstr "ninguno"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:468
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
 msgid "open website"
 msgstr "abrir sitio web"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "port"
 msgstr "puerto"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:309
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
 msgid "smartdns custom settings"
 msgstr "configuraciones personalizadas de smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:361
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "type"
 msgstr "tipo"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:359
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
 msgid "udp"
 msgstr "udp"
+
+#~ msgid "IPV4 53 Port Redirect Failure"
+#~ msgstr "Error de reenvío de puerto IPv4 53"
+
+#~ msgid "IPV6 53 Port Redirect Failure"
+#~ msgstr "Error de reenvío de puerto IPv6 53"
+
+#~ msgid "Redirect"
+#~ msgstr "Redirigir"
+
+#~ msgid "Redirect 53 port to SmartDNS"
+#~ msgstr "Redirigir el puerto 53 a SmartDNS"
+
+#~ msgid "Run as dnsmasq upstream server"
+#~ msgstr "Ejecutar como servidor dnsmasq aguas arriba"
+
+#~ msgid "SmartDNS redirect mode"
+#~ msgstr "Modo de redireccionamiento SmartDNS"
+
+#~ msgid "none"
+#~ msgstr "ninguno"
+
+#~ msgid "DNS Server group belongs to,"
+#~ msgstr "El grupo del servidor DNS pertenece a,"
+
+#~ msgid ""
+#~ "SmartDNS is a local high-performance DNS server, supports finding fastest "
+#~ "IP,"
+#~ msgstr ""
+#~ "SmartDNS es un servidor DNS local de alto rendimiento, admite la búsqueda "
+#~ "de IP más rápida,"
+
+#~ msgid ""
+#~ "Specify an IP address to return for any host in the given domains, "
+#~ "Queries in the domains are never"
+#~ msgstr ""
+#~ "Especifique una dirección IP para devolver para cualquier host en los "
+#~ "dominios dados, las consultas en los dominios nunca son"
+
+#~ msgid ""
+#~ "Upstream Servers, support UDP, TCP protocol. Please configure multiple "
+#~ "DNS servers,"
+#~ msgstr ""
+#~ "Servidores aguas arriba, soporte UDP, protocolo TCP. Configura varios "
+#~ "servidores DNS,"
+
+#~ msgid ""
+#~ "Used to verify the validity of the TLS server, The value is Base64 "
+#~ "encoded SPKI fingerprint,"
+#~ msgstr ""
+#~ "Se utiliza para verificar la validez del servidor TLS. El valor es la "
+#~ "huella digital SPKI codificada en Base64,"

--- a/applications/luci-app-smartdns/po/pt-BR/smartdns.po
+++ b/applications/luci-app-smartdns/po/pt-BR/smartdns.po
@@ -10,20 +10,20 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.14.1-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Additional Args for upstream dns servers"
 msgstr "Args adicionais para servidores dns upstream"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:424
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Additional Server Args"
 msgstr "Args Adicionais Sobre o Servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:331
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
 msgid "Advanced Settings"
 msgstr "Configurações Avançadas"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
@@ -31,15 +31,24 @@ msgstr ""
 "Tentativas de servir respostas antigas do cache com um TTL de 0 na resposta "
 "sem esperar o término da resolução real."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically Set Dnsmasq"
+msgstr "Definir o Dnsmasq automaticamente"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically set as upstream of dnsmasq when port changes."
+msgstr ""
+"Definido automaticamente como upstream do dnsmasq quando a porta se alterar."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "Cache Size"
 msgstr "Tamanho do Cache"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
 msgid "Collecting data ..."
 msgstr "Coletando dados ..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
@@ -47,133 +56,147 @@ msgstr ""
 "Configure as listas negras dos IP que serão filtradas a partir dos "
 "resultados de um servidor DNS específico."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:158
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
 msgid "Custom Settings"
 msgstr "Configurações Personalizadas"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
 msgid "DNS Server Name"
 msgstr "Nome do Servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid ""
 "DNS Server group belongs to, used with nameserver, such as office, home."
 msgstr ""
 "O grupo do Servidor DNS pertence a, usado em conjunto com o nameserver (nome "
 "do servidor), assim como em office, em casa."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "DNS Server ip"
 msgstr "Endereço IP do Servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "DNS Server port"
 msgstr "Porta do Servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "DNS Server type"
 msgstr "Tipo do Servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "DNS domain result cache size"
 msgstr "Tamanho do cache para o resultado do domínio DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
 msgid "Dnsmasq Forwared To Smartdns Failure"
 msgstr "Encaminhamento do Dnsmasq para Falha do Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:264
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+msgid "Do not check certificate."
+msgstr "Não verifique o certificado."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
 msgid "Do not check speed."
 msgstr "Não verifique a velocidade."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Domain Address"
 msgstr "Endereço do domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "Domain TTL"
 msgstr "TTL do domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:233
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
 msgid "Domain TTL Max"
 msgstr "TTL Max. do Domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
 msgid "Domain TTL Min"
 msgstr "TTL Min. do Domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:195
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
 msgid "Domain prefetch"
 msgstr "Pré-aquisição do Domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:476
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
 msgid "Donate"
 msgstr "Doe"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:475
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
 msgid "Donate to smartdns"
 msgstr "Doar para o smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:189
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
 msgid "Dual-stack IP Selection"
 msgstr "Seleção IP com pilha dupla"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:334
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
 msgid "Enable"
 msgstr "Ativar"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:190
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "Ative a seleção do IP entre o IPV4 e o IPV6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "Enable IPV6 DNS Server"
 msgstr "Ativar o Servidor IPV6 do DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "Enable TCP DNS Server"
 msgstr "Ative o TCP do servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr ""
 "Ative a pré-aquisição do domínio, acelera a velocidade de resposta do "
 "domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:239
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
 msgid "Enable or disable second DNS server."
 msgstr "Ative ou desative o segundo servidor DNS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
 msgid "Enable or disable smartdns server"
 msgstr "Ative ou desative o servidor smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:378
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
 msgid "Filtering IP with blacklist"
 msgstr "Filtrando o IP com um alista negra"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA"
 msgstr "Impor AAAA SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA."
 msgstr "Impor AAAA SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:156
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:330
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA"
+msgstr "Impor o HTTPS SOA"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA."
+msgstr "Impor o HTTPS SOA."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
 msgid "General Settings"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:319
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
 msgid "Generate Coredump"
 msgstr "Gerar Coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:320
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -185,103 +208,111 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "Conceda acesso ao LuCI app smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:404
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
 msgid "HTTP Host"
 msgstr "Host HTTP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "IP Blacklist"
 msgstr "Lista negra de IPs"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
 msgid "IP Blacklist Filtering"
 msgstr "Filtragem da Lista Negra dos IPs"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:104
-msgid "IPV4 53 Port Redirect Failure"
-msgstr "Falha no Redirecionamento da Porta IPV4 53"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:110
-msgid "IPV6 53 Port Redirect Failure"
-msgstr "Falha no Redirecionamento da Porta IPV6 53"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "IPV6 Server"
 msgstr "Servidor IPV6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:463
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr "Caso goste deste software, por favor, me pague uma xícara de café."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Local Port"
 msgstr "Porta Local"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
 msgid "Maximum TTL for all domain result."
 msgstr "TTL máximo para todos os resultados do domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
 msgid "Minimum TTL for all domain result."
 msgstr "TTL mínimo para todos os resultados do domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:87
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr "NÃO ESTÁ EM EXECUÇÃO"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+msgid "No check certificate"
+msgstr "Não verifique o certificado"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr ""
 "Consulta o DNS através de um grupo específico de servidores dns, como "
 "office, casa."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:85
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:64
 msgid "RUNNING"
 msgstr "EM EXECUÇÃO"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "Redirect"
-msgstr "Redirecione"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+msgid "Reply Domain TTL Max"
+msgstr "Responda ao domínio com TTL Max"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:211
-msgid "Redirect 53 port to SmartDNS"
-msgstr "Redirecionar a porta 53 para o SmartDNS"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+msgid "Reply maximum TTL for all domain result."
+msgstr "Responda com TTL máximo em todos os resultados do domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
-msgid "Run as dnsmasq upstream server"
-msgstr "Executar como servidor dnsmasq upstream"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve Local Hostnames"
+msgstr "Resolve os nomes dos host locais"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:157
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve local hostnames by reading Dnsmasq lease file."
+msgstr "Resolve os nomes dos hosts lendo o arquivo de concessão do Dnsmasq."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+msgid "Restart Service"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Second Server Settings"
 msgstr "Configurações do Segundo Servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:201
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
 msgid "Serve expired"
 msgstr "O servir expirou"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid "Server Group"
 msgstr "Grupo dos Servidores"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Server Name"
 msgstr "Nome do Servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Set Specific domain ip address."
 msgstr "Defina um endereço IP específico para o domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "Set Specific ip blacklist."
 msgstr "Defina um IP específico para a lista negra."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:385
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Set TLS hostname to verify."
 msgstr "Defina o nome do host TLS para verificar."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
@@ -289,76 +320,76 @@ msgstr ""
 "Defina o host HTTP utilizado para a consulta. Use este parâmetro quando o "
 "host da URL do endereço for um endereço IP."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
 msgid "Sets the server name indication for query."
 msgstr "Define a indicação do nome do servidor para consulta."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
 msgid "Skip Address Rules"
 msgstr "Ignora as Regras do Endereço"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache"
 msgstr "Ignora a Cache"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache."
 msgstr "Ignora a Cache."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:292
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
 msgid "Skip Dualstack Selection"
 msgstr "Ignora a Seleção da Pilha Dupla"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:293
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
 msgid "Skip Dualstack Selection."
 msgstr "Ignora a Seleção da Pilha Dupla."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:281
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
 msgid "Skip Ipset Rule"
 msgstr "Ignora a Regra Ipset"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
 msgid "Skip Nameserver Rule"
 msgstr "Ignora a Regra do Servidor de Nomes"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:287
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
 msgid "Skip SOA Address Rule"
 msgstr "Ignorar a Regra do Endereço SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:288
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
 msgid "Skip SOA address rules."
 msgstr "Ignorar a Regra do Endereço SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
 msgid "Skip Speed Check"
 msgstr "Ignorar a Verificação da Velocidade"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:270
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
 msgid "Skip address rules."
 msgstr "Ignora as Regras do Endereço."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
 msgid "Skip ipset rules."
 msgstr "Ignore as regras do ipset."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:276
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
 msgid "Skip nameserver rules."
 msgstr "Ignora a regra do servidor de nomes."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr "SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:130
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
 msgid "SmartDNS Server"
 msgstr "Servidor SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
@@ -367,24 +398,27 @@ msgstr ""
 "localização rápida do IP, suporta filtragem de anúncios e previne o "
 "envenenamento do DNS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:467
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
 msgid "SmartDNS official website"
 msgstr "Site oficial do SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "SmartDNS redirect mode"
-msgstr "SmartDNS, modo de redirecionamento"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Smartdns local server port"
 msgstr "Porta do servidor local Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+msgid ""
+"Smartdns local server port, smartdns will be automatically set as main dns "
+"when the port is 53."
+msgstr ""
+"Porta do servidor local do Smartdns, o smartdns será automaticamente "
+"definido como dns principal quando a porta for 53."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Smartdns server name"
 msgstr "Nome do servidor Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:439
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
@@ -395,36 +429,36 @@ msgstr ""
 "respondidas de forma especificada com o endereço IP que tanto pode ser IPv4 "
 "ou IPv6."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "TCP Server"
 msgstr "Servidor TCP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
 msgid "TLS Hostname Verify"
 msgstr "Verificar o Nome do Host TLS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:394
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
 msgid "TLS SNI name"
 msgstr "Nome TLS SNI"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:413
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "TLS SPKI Pinning"
 msgstr "Fixação TLS SPKI"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "TTL for all domain result."
 msgstr "O TTL para todos os resultados do domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:462
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
 msgid "Technical Support"
 msgstr "Suporte Técnico"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
 msgid "Upstream Servers"
 msgstr "Servidores upstream"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:325
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -432,7 +466,7 @@ msgstr ""
 "Servidores upstream, suporte UDP, protocolo TCP. Configure os vários "
 "servidores DNS, incluindo vários servidores DNS externos."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -442,42 +476,59 @@ msgstr ""
 "digital SPKI codificada com base64, deixando em branco para indicar que a "
 "validade do TLS não será verificada."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:362
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "ip"
 msgstr "IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
-msgid "none"
-msgstr "nenhum"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:468
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
 msgid "open website"
 msgstr "abrir o website"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "port"
 msgstr "porta"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:309
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
 msgid "smartdns custom settings"
 msgstr "configurações personalizadas do smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:361
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "type"
 msgstr "tipo"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:359
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
 msgid "udp"
 msgstr "udp"
+
+#~ msgid "IPV4 53 Port Redirect Failure"
+#~ msgstr "Falha no Redirecionamento da Porta IPV4 53"
+
+#~ msgid "IPV6 53 Port Redirect Failure"
+#~ msgstr "Falha no Redirecionamento da Porta IPV6 53"
+
+#~ msgid "Redirect"
+#~ msgstr "Redirecione"
+
+#~ msgid "Redirect 53 port to SmartDNS"
+#~ msgstr "Redirecionar a porta 53 para o SmartDNS"
+
+#~ msgid "Run as dnsmasq upstream server"
+#~ msgstr "Executar como servidor dnsmasq upstream"
+
+#~ msgid "SmartDNS redirect mode"
+#~ msgstr "SmartDNS, modo de redirecionamento"
+
+#~ msgid "none"
+#~ msgstr "nenhum"

--- a/applications/luci-app-smartdns/po/templates/smartdns.pot
+++ b/applications/luci-app-smartdns/po/templates/smartdns.pot
@@ -1,162 +1,184 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Additional Args for upstream dns servers"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:424
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Additional Server Args"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:331
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically Set Dnsmasq"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically set as upstream of dnsmasq when port changes."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "Cache Size"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:158
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
 msgid "Custom Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
 msgid "DNS Server Name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid ""
 "DNS Server group belongs to, used with nameserver, such as office, home."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "DNS Server ip"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "DNS Server port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "DNS Server type"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "DNS domain result cache size"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
 msgid "Dnsmasq Forwared To Smartdns Failure"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:264
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+msgid "Do not check certificate."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
 msgid "Do not check speed."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Domain Address"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "Domain TTL"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:233
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
 msgid "Domain TTL Max"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
 msgid "Domain TTL Min"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:195
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
 msgid "Domain prefetch"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:476
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
 msgid "Donate"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:475
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
 msgid "Donate to smartdns"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:189
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
 msgid "Dual-stack IP Selection"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:334
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:190
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "Enable IPV6 DNS Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "Enable TCP DNS Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:239
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
 msgid "Enable or disable second DNS server."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
 msgid "Enable or disable smartdns server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:378
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
 msgid "Filtering IP with blacklist"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:156
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:330
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:319
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
 msgid "Generate Coredump"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:320
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -166,283 +188,288 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:404
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
 msgid "HTTP Host"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "IP Blacklist"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
 msgid "IP Blacklist Filtering"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:104
-msgid "IPV4 53 Port Redirect Failure"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:110
-msgid "IPV6 53 Port Redirect Failure"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "IPV6 Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:463
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Local Port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
 msgid "Maximum TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
 msgid "Minimum TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:87
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+msgid "No check certificate"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:85
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:64
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "Redirect"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+msgid "Reply Domain TTL Max"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:211
-msgid "Redirect 53 port to SmartDNS"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+msgid "Reply maximum TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
-msgid "Run as dnsmasq upstream server"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve Local Hostnames"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:157
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve local hostnames by reading Dnsmasq lease file."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+msgid "Restart Service"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Second Server Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:201
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
 msgid "Serve expired"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid "Server Group"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Server Name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Set Specific domain ip address."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "Set Specific ip blacklist."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:385
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Set TLS hostname to verify."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
 msgid "Sets the server name indication for query."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
 msgid "Skip Address Rules"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:292
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
 msgid "Skip Dualstack Selection"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:293
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
 msgid "Skip Dualstack Selection."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:281
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
 msgid "Skip Ipset Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
 msgid "Skip Nameserver Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:287
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
 msgid "Skip SOA Address Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:288
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
 msgid "Skip SOA address rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
 msgid "Skip Speed Check"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:270
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
 msgid "Skip address rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
 msgid "Skip ipset rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:276
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
 msgid "Skip nameserver rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:130
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
 msgid "SmartDNS Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:467
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
 msgid "SmartDNS official website"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "SmartDNS redirect mode"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Smartdns local server port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+msgid ""
+"Smartdns local server port, smartdns will be automatically set as main dns "
+"when the port is 53."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Smartdns server name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:439
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
 "IP address which may be IPv4 or IPv6."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "TCP Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
 msgid "TLS Hostname Verify"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:394
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
 msgid "TLS SNI name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:413
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "TLS SPKI Pinning"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:462
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
 msgid "Technical Support"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
 msgid "Upstream Servers"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:325
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
 "verified."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:362
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
 msgid "https"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "ip"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
-msgid "none"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:468
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
 msgid "open website"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:309
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
 msgid "smartdns custom settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
 msgid "tcp"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:361
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
 msgid "tls"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "type"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:359
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
 msgid "udp"
 msgstr ""

--- a/applications/luci-app-smartdns/po/zh_Hans/smartdns.po
+++ b/applications/luci-app-smartdns/po/zh_Hans/smartdns.po
@@ -10,162 +10,184 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.14.1-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Additional Args for upstream dns servers"
 msgstr "额外的上游 DNS 服务器参数"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:424
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Additional Server Args"
 msgstr "额外的服务器参数"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:331
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
 msgstr "查询性能优化，有请求时尝试回应TTL为0的过期记录，以避免查询等待。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically Set Dnsmasq"
+msgstr "自动设置Dnsmasq"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+msgid "Automatically set as upstream of dnsmasq when port changes."
+msgstr "端口更改时自动设为 dnsmasq 的上游。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "Cache Size"
 msgstr "缓存大小"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
 msgid "Collecting data ..."
 msgstr "正在收集数据..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
 msgstr "配置需要从指定域名服务器结果过滤的IP黑名单。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:158
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
 msgid "Custom Settings"
 msgstr "自定义设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
 msgid "DNS Server Name"
 msgstr "DNS服务器名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid ""
 "DNS Server group belongs to, used with nameserver, such as office, home."
 msgstr "DNS服务器所属组， 配合nameserver使用，例如：office，home。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "DNS Server ip"
 msgstr "DNS服务器IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "DNS Server port"
 msgstr "DNS服务器端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "DNS Server type"
 msgstr "协议类型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
 msgid "DNS domain result cache size"
 msgstr "缓存DNS的结果，缓存大小，配置零则不缓存"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
 msgid "Dnsmasq Forwared To Smartdns Failure"
 msgstr "重定向dnsmasq到smartdns失败"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:264
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+msgid "Do not check certificate."
+msgstr "不校验证书的合法性。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
 msgid "Do not check speed."
 msgstr "禁用测速。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Domain Address"
 msgstr "域名地址"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "Domain TTL"
 msgstr "域名TTL"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:233
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
 msgid "Domain TTL Max"
 msgstr "域名TTL最大值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
 msgid "Domain TTL Min"
 msgstr "域名TTL最小值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:195
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
 msgid "Domain prefetch"
 msgstr "域名预加载"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:476
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
 msgid "Donate"
 msgstr "捐助"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:475
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
 msgid "Donate to smartdns"
 msgstr "捐助smartdns项目"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:189
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
 msgid "Dual-stack IP Selection"
 msgstr "双栈IP优选"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:334
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
 msgid "Enable"
 msgstr "启用"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:190
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "启用 IPV4 和 IPV6 间的 IP 优选策略"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "Enable IPV6 DNS Server"
 msgstr "启用IPV6服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "Enable TCP DNS Server"
 msgstr "启用TCP服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr "启用域名预加载，加速域名响应速度。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:239
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
 msgid "Enable or disable second DNS server."
 msgstr "是否启用第二DNS服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
 msgid "Enable or disable smartdns server"
 msgstr "启用或禁用SmartDNS服务"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:378
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
 msgid "Filtering IP with blacklist"
 msgstr "使用IP黑名单过滤"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA"
 msgstr "停用IPV6地址解析"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
 msgid "Force AAAA SOA."
 msgstr "停用IPV6地址解析。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:156
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:330
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA"
+msgstr "停用HTTPS地址解析"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+msgid "Force HTTPS SOA."
+msgstr "停用HTTPS地址解析。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
 msgid "General Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:319
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
 msgid "Generate Coredump"
 msgstr "生成coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:320
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -176,199 +198,209 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "授予访问 LuCI 应用 smartdns 的权限"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:404
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
 msgid "HTTP Host"
 msgstr "HTTP主机"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "IP Blacklist"
 msgstr "IP黑名单"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
 msgid "IP Blacklist Filtering"
 msgstr "IP黑名单过滤"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:104
-msgid "IPV4 53 Port Redirect Failure"
-msgstr "IPV4 53端口重定向失败"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:110
-msgid "IPV6 53 Port Redirect Failure"
-msgstr "IPV6 53端口重定向失败"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:184
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
 msgid "IPV6 Server"
 msgstr "IPV6服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:463
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr "如果本软件对你有帮助，请给作者加个蛋。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Local Port"
 msgstr "本地端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
 msgid "Maximum TTL for all domain result."
 msgstr "所有域名的最大 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
 msgid "Minimum TTL for all domain result."
 msgstr "所有域名的最小 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:87
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr "未运行"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+msgid "No check certificate"
+msgstr "停用证书校验"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr "使用指定服务器组查询，比如office, home。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:85
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:64
 msgid "RUNNING"
 msgstr "运行中"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "Redirect"
-msgstr "重定向"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+msgid "Reply Domain TTL Max"
+msgstr "回应的域名TTL最大值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:211
-msgid "Redirect 53 port to SmartDNS"
-msgstr "重定向53端口到SmartDNS"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+msgid "Reply maximum TTL for all domain result."
+msgstr "设置返回给客户端的域名TTL最大值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
-msgid "Run as dnsmasq upstream server"
-msgstr "作为dnsmasq的上游服务器"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve Local Hostnames"
+msgstr "解析本地主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:157
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+msgid "Resolve local hostnames by reading Dnsmasq lease file."
+msgstr "读取Dnsmasq的租约文件解析本地主机名。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+msgid "Restart"
+msgstr "重启"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+msgid "Restart Service"
+msgstr "重启服务"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Second Server Settings"
 msgstr "第二DNS服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:201
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
 msgid "Serve expired"
 msgstr "缓存过期服务"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:368
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
 msgid "Server Group"
 msgstr "服务器组"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Server Name"
 msgstr "服务器名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:434
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
 msgid "Set Specific domain ip address."
 msgstr "设置指定域名的IP地址。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
 msgid "Set Specific ip blacklist."
 msgstr "设置指定的 IP 黑名单列表。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:385
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Set TLS hostname to verify."
 msgstr "设置校验TLS主机名。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
 msgstr "设置查询时使用的HTTP主机，当URL地址的host是IP地址时，使用此参数。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
 msgid "Sets the server name indication for query."
 msgstr "设置查询时使用的服务器SNI名称。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
 msgid "Skip Address Rules"
 msgstr "跳过address规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache"
 msgstr "跳过cache"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:298
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
 msgid "Skip Cache."
 msgstr "跳过cache。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:292
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
 msgid "Skip Dualstack Selection"
 msgstr "跳过双栈优选"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:293
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
 msgid "Skip Dualstack Selection."
 msgstr "跳过双栈优选。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:281
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
 msgid "Skip Ipset Rule"
 msgstr "跳过ipset规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
 msgid "Skip Nameserver Rule"
 msgstr "跳过Nameserver规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:287
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
 msgid "Skip SOA Address Rule"
 msgstr "跳过address SOA(#)规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:288
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
 msgid "Skip SOA address rules."
 msgstr "跳过address SOA(#)规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
 msgid "Skip Speed Check"
 msgstr "跳过测速"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:270
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
 msgid "Skip address rules."
 msgstr "跳过address规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
 msgid "Skip ipset rules."
 msgstr "跳过ipset规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:276
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
 msgid "Skip nameserver rules."
 msgstr "跳过Nameserver规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr "SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:130
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
 msgid "SmartDNS Server"
 msgstr "SmartDNS 服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
 msgstr "SmartDNS是一个本地高性能DNS服务器，支持返回最快IP，支持广告过滤。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:467
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
 msgid "SmartDNS official website"
 msgstr "SmartDNS官方网站"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
-msgid "SmartDNS redirect mode"
-msgstr "SmartDNS 重定向模式"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
 msgid "Smartdns local server port"
 msgstr "SmartDNS本地服务端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+msgid ""
+"Smartdns local server port, smartdns will be automatically set as main dns "
+"when the port is 53."
+msgstr ""
+"SmartDNS本地服务端口，当端口号设置为53时，smartdns将会自动配置为主dns。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
 msgid "Smartdns server name"
 msgstr "SmartDNS的服务器名称，默认为smartdns，留空为主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:439
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
@@ -377,36 +409,36 @@ msgstr ""
 "配置特定域名返回特定的IP地址，域名查询将不到上游服务器请求，直接返回配置的IP"
 "地址，可用于广告屏蔽。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:179
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
 msgid "TCP Server"
 msgstr "TCP服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
 msgid "TLS Hostname Verify"
 msgstr "校验TLS主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:394
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
 msgid "TLS SNI name"
 msgstr "TLS SNI名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:413
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "TLS SPKI Pinning"
 msgstr "TLS SPKI 指纹"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
 msgid "TTL for all domain result."
 msgstr "设置所有域名的 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:462
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
 msgid "Technical Support"
 msgstr "技术支持"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
 msgid "Upstream Servers"
 msgstr "上游服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:325
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -414,7 +446,7 @@ msgstr ""
 "上游 DNS 服务器，支持 UDP，TCP 协议。请配置多个上游 DNS 服务器，包括多个国内"
 "外服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -423,42 +455,59 @@ msgstr ""
 "用于校验 TLS 服务器的有效性，数值为 Base64 编码的 SPKI 指纹，留空表示不验证 "
 "TLS 的合法性。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:362
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:343
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
 msgid "ip"
 msgstr "ip"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
-msgid "none"
-msgstr "无"
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:468
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
 msgid "open website"
 msgstr "打开网站"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:348
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
 msgid "port"
 msgstr "端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:309
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
 msgid "smartdns custom settings"
 msgstr "smartdns 自定义设置，具体配置参数参考指导"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:361
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:357
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
 msgid "type"
 msgstr "类型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:359
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
 msgid "udp"
 msgstr "udp"
+
+#~ msgid "IPV4 53 Port Redirect Failure"
+#~ msgstr "IPV4 53端口重定向失败"
+
+#~ msgid "IPV6 53 Port Redirect Failure"
+#~ msgstr "IPV6 53端口重定向失败"
+
+#~ msgid "Redirect"
+#~ msgstr "重定向"
+
+#~ msgid "Redirect 53 port to SmartDNS"
+#~ msgstr "重定向53端口到SmartDNS"
+
+#~ msgid "Run as dnsmasq upstream server"
+#~ msgstr "作为dnsmasq的上游服务器"
+
+#~ msgid "SmartDNS redirect mode"
+#~ msgstr "SmartDNS 重定向模式"
+
+#~ msgid "none"
+#~ msgstr "无"

--- a/applications/luci-app-smartdns/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
+++ b/applications/luci-app-smartdns/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
@@ -3,10 +3,7 @@
 		"description": "Grant access to LuCI app smartdns",
 		"read": {
 			"file": {
-				"/etc/smartdns/*": [ "read" ],
-				"/usr/sbin/iptables -t nat -nL PREROUTING": [ "exec" ],
-				"/usr/sbin/ip6tables -t nat -nL PREROUTING": [ "exec" ],
-				"/usr/sbin/smartdns": [ "exec" ]
+				"/etc/smartdns/*": [ "read" ]
 			},
 			"ubus": {
 				"service": [ "list" ]
@@ -15,7 +12,8 @@
 		},
 		"write": {
 			"file": {
-				"/etc/smartdns/*": [ "write" ]
+				"/etc/smartdns/*": [ "write" ],
+				"/etc/init.d/smartdns restart": [ "exec" ]
 			},
 			"uci": [ "smartdns" ]
 		}


### PR DESCRIPTION
Maintainer: me
Compile tested: TL-WR703N/22.03-SNAPSHOT r19160+542-7ea2f3d6e2
backport [luci-app-smartdns: Fix RPC error and add restart button](https://github.com/openwrt/luci/pull/6012)
Depends on https://github.com/openwrt/packages/pull/19594