### PR TITLE
luci-app-smartdns: remove unnecessary permissions

### DIFF
--- a/applications/luci-app-smartdns/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
+++ b/applications/luci-app-smartdns/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
@@ -3,9 +3,7 @@
 		"description": "Grant access to LuCI app smartdns",
 		"read": {
 			"file": {
-				"/etc/smartdns/*": [ "read" ],
-				"/usr/sbin/smartdns": [ "exec" ],
-				"/etc/init.d/smartdns restart" : [ "exec" ]
+				"/etc/smartdns/*": [ "read" ]
 			},
 			"ubus": {
 				"service": [ "list" ]
@@ -14,7 +12,8 @@
 		},
 		"write": {
 			"file": {
-				"/etc/smartdns/*": [ "write" ]
+				"/etc/smartdns/*": [ "write" ],
+				"/etc/init.d/smartdns restart": [ "exec" ]
 			},
 			"uci": [ "smartdns" ]
 		}


### PR DESCRIPTION
Maintainer: me
Compile tested: TL-WR703N/22.03-SNAPSHOT r19160+542-7ea2f3d6e2
Resolve Review Conversation: https://github.com/openwrt/luci/pull/6018