### PR TITLE
luci-app-dockerman: allow creation of new Docker containers with default kernel

### DIFF
--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newcontainer.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newcontainer.lua
@@ -720,7 +720,7 @@ m.handle = function(self, state, data)
 	local memory = data.memory or 0
 	local cpu_shares = data.cpu_shares or 0
 	local cpus = data.cpus or 0
-	local blkio_weight = data.blkio_weight or 500
+	local blkio_weight = data.blkio_weight or nil
 
 	local portbindings = {}
 	local exposedports = {}


### PR DESCRIPTION
Most of the work was done already, simply changing the default option for blkio_weight to allow for no input.  
#5327 

Signed-off-by: Jonathon Walker<jonathon.l.walker@gmail.com>