### PR TITLE
luci-app-adblock: sync with adblock 4.1.5

### DIFF
--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2017-2021 Dirk Brenken (dev@brenken.org)
+# Copyright 2017-2022 Dirk Brenken (dev@brenken.org)
 # This is free software, licensed under the Apache License, Version 2.0
 
 include $(TOPDIR)/rules.mk

--- a/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
+++ b/applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js
@@ -139,7 +139,20 @@ function handleAction(ev) {
 		L.ui.showModal(_('Refresh DNS Report'), [
 			E('div', { 'class': 'left', 'style': 'display:flex; flex-direction:column' }, [
 				E('label', { 'class': 'cbi-input-select', 'style': 'padding-top:.5em' }, [
-					E('select', { 'class': 'cbi-input-select', 'id': 'count' }, [
+					E('select', { 'class': 'cbi-input-select', 'id': 'top_count' }, [
+						E('option', { 'value': '10' }, '10'),
+						E('option', { 'value': '20' }, '20'),
+						E('option', { 'value': '30' }, '30'),
+						E('option', { 'value': '40' }, '40'),
+						E('option', { 'value': '50' }, '50')
+					]),
+					'\xa0\xa0\xa0',
+					_('max. top statistics')
+				])
+			]),
+			E('div', { 'class': 'left', 'style': 'display:flex; flex-direction:column' }, [
+				E('label', { 'class': 'cbi-input-select', 'style': 'padding-top:.5em' }, [
+					E('select', { 'class': 'cbi-input-select', 'id': 'res_count' }, [
 						E('option', { 'value': '50' }, '50'),
 						E('option', { 'value': '100' }, '100'),
 						E('option', { 'value': '150' }, '150'),
@@ -166,9 +179,10 @@ function handleAction(ev) {
 					'class': 'btn cbi-button-action',
 					'id': 'refresh',
 					'click': ui.createHandlerFn(this, async function(ev) {
-						var count = document.getElementById('count').value;
+						var top_count = document.getElementById('top_count').value;
+						var res_count = document.getElementById('res_count').value;
 						var search = document.getElementById('search').value.trim().replace(/[^\w\.\-\:]/g,'') || '+';
-						L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', 'gen', count, search]),'');
+						L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', 'gen', top_count, res_count, search]),'');
 						var running = 1;
 						while (running === 1) {
 							await new Promise(r => setTimeout(r, 1000));
@@ -190,7 +204,7 @@ function handleAction(ev) {
 
 return view.extend({
 	load: function() {
-		return L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', 'json', '50', '+']),'');
+		return L.resolveDefault(fs.exec_direct('/etc/init.d/adblock', ['report', 'json', '10', '50', '+']),'');
 	},
 
 	render: function(dnsreport) {
@@ -331,7 +345,7 @@ return view.extend({
 			]),
 			E('div', { 'class': 'cbi-section' }, [
 				E('div', { 'class': 'left' }, [
-					E('h3', _('Top 10 Statistics')),
+					E('h3', _('Top Statistics')),
 					tbl_top
 				])
 			]),

--- a/applications/luci-app-adblock/po/bg/adblock.po
+++ b/applications/luci-app-adblock/po/bg/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Действие"
 
@@ -77,7 +77,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr ""
 
@@ -102,7 +102,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -117,11 +117,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Отмени"
@@ -161,11 +161,11 @@ msgstr "Отмени"
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Клиент"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -177,9 +177,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -223,11 +223,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr "Включи подрбони журнали в случай на раб
 msgid "Enabled"
 msgstr "Разрешен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -701,13 +701,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -721,15 +721,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -774,8 +774,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/bn_BD/adblock.po
+++ b/applications/luci-app-adblock/po/bn_BD/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr ""
 
@@ -77,7 +77,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr ""
 
@@ -102,7 +102,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -117,11 +117,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "বাতিল করুন"
@@ -161,11 +161,11 @@ msgstr "বাতিল করুন"
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -177,9 +177,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -223,11 +223,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "সক্রিয়"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -701,13 +701,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -721,15 +721,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -774,8 +774,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/ca/adblock.po
+++ b/applications/luci-app-adblock/po/ca/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Acció"
 
@@ -79,7 +79,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Resposta"
 
@@ -104,7 +104,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Llista negra..."
 
@@ -119,11 +119,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Peticions DNS blocades"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Dominis blocats"
@@ -136,7 +136,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Cancel•lar"
@@ -163,11 +163,11 @@ msgstr "Cancel•lar"
 msgid "Categories"
 msgstr "Categories"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -179,9 +179,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Recompte"
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Data"
 
@@ -225,11 +225,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domini"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -335,7 +335,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Last Run"
 msgstr "Darrera execució"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Actualitza"
 
@@ -511,7 +511,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -703,13 +703,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -723,15 +723,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -776,8 +776,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/cs/adblock.po
+++ b/applications/luci-app-adblock/po/cs/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.14-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Akce"
 
@@ -78,7 +78,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Odpověd"
 
@@ -107,7 +107,7 @@ msgstr ""
 "Změny blacklistu byly uloženy. Obnovte své adblockové seznamy, aby se změny "
 "projevily."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Blacklist..."
 
@@ -122,11 +122,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blokované domény"
@@ -139,7 +139,7 @@ msgstr "Záloha blokovacího seznamu"
 msgid "Blocklist Query"
 msgstr "Dotaz na blokovací seznam"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Dotaz na blokovací seznam..."
 
@@ -157,7 +157,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Storno"
@@ -166,11 +166,11 @@ msgstr "Storno"
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -182,9 +182,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Počet"
 
@@ -218,7 +218,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Datum"
 
@@ -230,11 +230,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domény"
 
@@ -312,7 +312,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Zapnuto"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -405,7 +405,7 @@ msgstr ""
 msgid "Last Run"
 msgstr "Poslední spuštění"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Poslední dotazy DNS"
 
@@ -510,7 +510,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Aktualizovat"
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -642,7 +642,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -718,13 +718,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Čas"
 
@@ -738,15 +738,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -775,7 +775,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -791,8 +791,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/da/adblock.po
+++ b/applications/luci-app-adblock/po/da/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12.1\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Handling"
 
@@ -82,7 +82,7 @@ msgstr ""
 "(RPZ-CLIENT-IP). Bemærk: Denne funktion er i øjeblikket kun understøttet af "
 "bind DNS backend."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Svar"
 
@@ -111,7 +111,7 @@ msgstr ""
 "Ændringerne på sortlisten er blevet gemt. Opdater dine adblock-lister, så "
 "ændringerne træder i kraft."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Sortliste..."
 
@@ -129,11 +129,11 @@ msgstr ""
 "(RPZ-CLIENT-IP). Bemærk: Denne funktion er i øjeblikket kun understøttet af "
 "bind DNS backend."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Blokerede DNS-anmodninger"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blokerede domæner"
@@ -146,7 +146,7 @@ msgstr "Blokliste Backup"
 msgid "Blocklist Query"
 msgstr "Blokliste Forespørgsel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Blokliste Forespørgsel..."
 
@@ -168,7 +168,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Annuller"
@@ -177,11 +177,11 @@ msgstr "Annuller"
 msgid "Categories"
 msgstr "Kategorier"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Klienter"
 
@@ -197,9 +197,9 @@ msgstr ""
 "openwrt/packages/blob/master/net/adblock/files/README.md\" target=\"_blank\" "
 "rel=\"noreferrer noopener\" >se online dokumentationen</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Tælle"
 
@@ -233,7 +233,7 @@ msgstr "DNS Rapport"
 msgid "DNS Restart Timeout"
 msgstr "Tidsgrænse for genstart af DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Dato"
 
@@ -245,11 +245,11 @@ msgstr "Deaktiver DNS Tillad"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Deaktiver selektiv DNS hvidlisting (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domæne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domæner"
 
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Aktiveret"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Sluttidsstempel"
 
@@ -363,7 +363,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Femte instans"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrer kriterier som dato, domæne eller klient (valgfrit)"
 
@@ -430,7 +430,7 @@ msgstr "Fængselsmappe"
 msgid "Last Run"
 msgstr "Sidste kørsel"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Seneste DNS-anmodninger"
 
@@ -543,7 +543,7 @@ msgstr ""
 "ressourcer fra systemet. Bemærk: Denne ændring kræver en fuldstændig "
 "genstart af adblock-tjenesten for at få virkning."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Opdater"
 
@@ -559,7 +559,7 @@ msgstr "Opdateringstimer"
 msgid "Refresh Timer..."
 msgstr "Opdateringstimer..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Opdater..."
 
@@ -680,7 +680,7 @@ msgstr ""
 "En liste over porte, der er separeret med mellemrum, og som anvendes af "
 "tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Start-tidsstempel"
 
@@ -764,7 +764,7 @@ msgstr ""
 "<br /> Bemærk: tilføj kun ét domæne pr. linje. Kommentarer indledt med '#' "
 "er tilladt - ip-adresser, wildcards og regex er ikke tilladt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -772,7 +772,7 @@ msgstr ""
 "Denne fane viser den sidst genererede DNS-rapport, tryk på knappen 'Opdater' "
 "for at få en aktuel rapport."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Tid"
 
@@ -788,15 +788,15 @@ msgstr ""
 "For at holde dine adblock-lister opdaterede, bør du konfigurere et "
 "automatisk opdateringsjob for disse lister."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Top 10 statistikker"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Emne for adblock-notifikations-e-mails."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Samlede DNS-anmodninger"
 
@@ -827,7 +827,7 @@ msgstr ""
 "Ændringerne i den Whitelist er blevet gemt. Opdater dine adblock-lister, så "
 "ændringerne træder i kraft."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Hvidliste..."
 
@@ -843,9 +843,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "max. resultatsæts størrelse"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -854,6 +858,9 @@ msgstr "rå (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Top 10 statistikker"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Deaktiver DNS genstarter"

--- a/applications/luci-app-adblock/po/de/adblock.po
+++ b/applications/luci-app-adblock/po/de/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.11.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Aktion"
 
@@ -82,7 +82,7 @@ msgstr ""
 "CLIENT-IP) erlauben. Bitte beachten: Diese Funktion wird derzeit nur vom "
 "bind DNS-Backend unterstützt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Antwort"
 
@@ -111,7 +111,7 @@ msgstr ""
 "Änderung der Blackliste gespeichert. Aktualisiere deine Adblock-Liste, um "
 "die Änderungen zu übernehmen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Blockierliste..."
 
@@ -129,11 +129,11 @@ msgstr ""
 "CLIENT-IP) blockieren. Bitte beachten: Diese Funktion wird derzeit nur vom "
 "bind DNS-Backend unterstützt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Geblockte DNS-Anfragen"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Gesperrte Domains"
@@ -146,7 +146,7 @@ msgstr "Sperrliste Backup"
 msgid "Blocklist Query"
 msgstr "Sperrlistenabfrage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Sperrlisten abfragen..."
 
@@ -167,7 +167,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Abbrechen"
@@ -176,11 +176,11 @@ msgstr "Abbrechen"
 msgid "Categories"
 msgstr "Kategorien"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Clientes"
 
@@ -196,9 +196,9 @@ msgstr ""
 "github.com/openwrt/packages/blob/master/net/adblock/files/README.md\" "
 "target=\"_blank\" rel=\"noreferrer noopener\" >Dokumentation</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Anzahl"
 
@@ -232,7 +232,7 @@ msgstr "DNS-Report"
 msgid "DNS Restart Timeout"
 msgstr "DNS-Restart-Timeout"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Datum"
 
@@ -244,11 +244,11 @@ msgstr "Deaktiviere DNS-Zulassen"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Das selektive DNS-Whitelisting deaktivieren (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domäne"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domänen"
 
@@ -329,7 +329,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Ende-Zeitstempel"
 
@@ -359,7 +359,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Fünfte Instanz"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filterkriterien wie z.B. Datum, Domain oder Client (optional)"
 
@@ -425,7 +425,7 @@ msgstr "Sperrverzeichnis"
 msgid "Last Run"
 msgstr "Letzter Durchgang"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Neueste DNS Anfragen"
 
@@ -541,7 +541,7 @@ msgstr ""
 "des Systems zu verringern. Hinweis: Diese Änderung benötigt einen Neustart "
 "des Adblock-Dienstes um in Kraft zu treten."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Aktualisieren"
 
@@ -557,7 +557,7 @@ msgstr "Timer"
 msgid "Refresh Timer..."
 msgstr "Timer..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Aktualisiere..."
 
@@ -677,7 +677,7 @@ msgstr "Quellen (Größe, Fokus)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Leerzeichengetrennte Liste an Ports die von tcpdump genutzt werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Start-Zeitstempel"
 
@@ -761,7 +761,7 @@ msgstr ""
 "Kommentare mit # am Anfang ebenfalls, nicht jedoch IP-Adressen, Wildcards "
 "und Regex-Ausdrücke."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -769,7 +769,7 @@ msgstr ""
 "Auf diesem Tab ist der letzte generierte DNS Report zu sehen, drücke "
 "'Aktualisieren' um ihn neu zu erstellen."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Zeit"
 
@@ -785,15 +785,15 @@ msgstr ""
 "Um die Adblock-Liste aktuell zu halten, sollte dafür ein automatischer "
 "Update-Job eingerichtet werden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Top-10 Statistiken"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Betreff für Adblock-Benachrichtigungsmails."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Gesamte DNS-Anfragen"
 
@@ -824,7 +824,7 @@ msgstr ""
 "Änderungen der Positivliste wurden gespeichert. Aktualisiere die adblock-"
 "Verarbeitung um die Änderung anzuwenden."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Positivliste..."
 
@@ -840,9 +840,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "Max. Größe des Result-Sets"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -851,6 +855,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Top-10 Statistiken"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "DNS-Neustarts deaktivieren"

--- a/applications/luci-app-adblock/po/el/adblock.po
+++ b/applications/luci-app-adblock/po/el/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.14.1\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Δράση"
 
@@ -77,7 +77,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Απάντηση"
 
@@ -102,7 +102,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -117,11 +117,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Αποκλεισμένα αιτήματα DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Ακύρωση"
@@ -161,11 +161,11 @@ msgstr "Ακύρωση"
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "πελάτης"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -177,9 +177,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Μέτρηση"
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Ημερομηνία"
 
@@ -223,11 +223,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Ενεργοποιήθηκε"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -701,13 +701,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -721,15 +721,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -774,8 +774,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/en/adblock.po
+++ b/applications/luci-app-adblock/po/en/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.13.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr ""
 
@@ -77,7 +77,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr ""
 
@@ -102,7 +102,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -117,11 +117,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
@@ -161,11 +161,11 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -177,9 +177,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -223,11 +223,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Enabled"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -701,13 +701,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -721,15 +721,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -774,8 +774,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/es/adblock.po
+++ b/applications/luci-app-adblock/po/es/adblock.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Acción"
 
@@ -85,7 +85,7 @@ msgstr ""
 "dirección IP (RPZ-CLIENT-IP). Tenga en cuenta: esta función actualmente solo "
 "es compatible con bind DNS backend."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Responder"
 
@@ -114,7 +114,7 @@ msgstr ""
 "Se han guardado los cambios en la lista negra. Actualice sus listas de "
 "bloqueos de anuncios para que los cambios surtan efecto."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
@@ -132,11 +132,11 @@ msgstr ""
 "dirección IP (RPZ-CLIENT-IP). Tenga en cuenta: esta función actualmente solo "
 "es compatible con bind DNS backend."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Peticiones DNS bloqueadas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Dominios bloqueados"
@@ -149,7 +149,7 @@ msgstr "Copia de seguridad de lista de bloqueo"
 msgid "Blocklist Query"
 msgstr "Consulta de lista de bloqueo"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Consulta de lista de bloqueo..."
 
@@ -171,7 +171,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Cancelar"
@@ -180,11 +180,11 @@ msgstr "Cancelar"
 msgid "Categories"
 msgstr "Categorías"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Clientes"
 
@@ -200,9 +200,9 @@ msgstr ""
 "openwrt/packages/blob/master/net/adblock/files/README.md\" target=\"_blank\" "
 "rel=\"noreferrer noopener\"> consulte la documentación en línea</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Contar"
 
@@ -236,7 +236,7 @@ msgstr "Informe DNS"
 msgid "DNS Restart Timeout"
 msgstr "Tiempo de espera de reinicio de DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Fecha"
 
@@ -248,11 +248,11 @@ msgstr "Desactivar Permitir DNS"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Desactivar la lista blanca selectiva de DNS (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Dominios"
 
@@ -334,7 +334,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Activado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Finalizar marca de tiempo"
 
@@ -367,7 +367,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Quinta instancia"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterios de filtro como fecha, dominio o cliente (opcional)"
 
@@ -434,7 +434,7 @@ msgstr "Directorio de la cárcel"
 msgid "Last Run"
 msgstr "Último inicio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Últimas peticiones DNS"
 
@@ -548,7 +548,7 @@ msgstr ""
 "tomar menos recursos del sistema. Tenga en cuenta: este cambio requiere un "
 "reinicio completo del servicio adblock para que surta efecto."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Refrescar"
 
@@ -564,7 +564,7 @@ msgstr "Temporizador de actualización"
 msgid "Refresh Timer..."
 msgstr "Actualizar temporizador..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Actualizar..."
 
@@ -686,7 +686,7 @@ msgstr "Fuentes (tamaño, enfoque)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista de puertos separados por espacios utilizados por tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Iniciar marca de tiempo"
 
@@ -775,7 +775,7 @@ msgstr ""
 "línea. Los comentarios introducidos con '#' están permitidos; las "
 "direcciones IP, comodines y expresiones regulares no."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -783,7 +783,7 @@ msgstr ""
 "Esta pestaña muestra el último informe DNS generado, presione el botón "
 "'Actualizar' para obtener uno actual."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Hora"
 
@@ -799,15 +799,15 @@ msgstr ""
 "Para mantener sus listas de bloqueos de anuncios actualizadas, debe "
 "configurar un trabajo de actualización automática para estas listas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Top 10 estadísticas"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Tema para los correos electrónicos de notificación de adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Peticiones DNS totales"
 
@@ -838,7 +838,7 @@ msgstr ""
 "Se han guardado los cambios en la lista blanca. Actualice sus listas de "
 "bloqueos de anuncios para que los cambios surtan efecto."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Lista blanca..."
 
@@ -854,9 +854,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "máx. tamaño del conjunto de resultados"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -865,6 +869,9 @@ msgstr "crudo (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Top 10 estadísticas"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Desactivar Reinicios de DNS"

--- a/applications/luci-app-adblock/po/fi/adblock.po
+++ b/applications/luci-app-adblock/po/fi/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Toiminta"
 
@@ -81,7 +81,7 @@ msgstr ""
 "CLIENT-IP) perusteella. Huomaa: Tätä ominaisuutta tukee tällä hetkellä vain "
 "bind DNS -taustajärjestelmä."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Vastaus"
 
@@ -110,7 +110,7 @@ msgstr ""
 "Kieltolistan muutokset on tallennettu. Virkistä adblock-listat ottaaksesi "
 "muutokset käyttöön."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Kieltolista..."
 
@@ -128,11 +128,11 @@ msgstr ""
 "CLIENT-IP) perusteella. Huomaa: Tätä ominaisuutta tukee tällä hetkellä vain "
 "bind DNS -taustajärjestelmä."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Estetyt DNS-pyynnöt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Estetyt verkkonimet"
@@ -145,7 +145,7 @@ msgstr "Kieltolistan varmuuskopio"
 msgid "Blocklist Query"
 msgstr "Estolistan kysely"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Estoluettelon kysely..."
 
@@ -167,7 +167,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Peruuta"
@@ -176,11 +176,11 @@ msgstr "Peruuta"
 msgid "Categories"
 msgstr "Luokat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Asiakas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Asiakkaat"
 
@@ -192,9 +192,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Määrä"
 
@@ -228,7 +228,7 @@ msgstr "DNS-raportti"
 msgid "DNS Restart Timeout"
 msgstr "DNS:n uudelleenkäynnistyksen aikaraja"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Päivä"
 
@@ -240,11 +240,11 @@ msgstr "Estä DNS:n salliminen"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Verkkotunnus"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Verkkotunnukset"
 
@@ -322,7 +322,7 @@ msgstr "Runsas lokisisältö toimintojen virheiden etsimistä varten."
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Loppumisaikaleima"
 
@@ -352,7 +352,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Viides instanssi"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Suodatintekijät kuten päivä, verkkonimi tai asiakas (valinnainen)"
 
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Last Run"
 msgstr "Viimeksi ajettu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Viimeiset DNS-kyselyt"
 
@@ -512,7 +512,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Päivitä"
 
@@ -528,7 +528,7 @@ msgstr "Päivitä ajastin"
 msgid "Refresh Timer..."
 msgstr "Päivitysajastin..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Päivitä..."
 
@@ -644,7 +644,7 @@ msgstr "Lähteet (koko, fokus)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -720,13 +720,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Aika"
 
@@ -740,15 +740,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Top 10 -tilastot"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -793,8 +793,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
@@ -804,6 +808,9 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Top 10 -tilastot"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Estä DNS:n uudelleenkäynnistykset"

--- a/applications/luci-app-adblock/po/fr/adblock.po
+++ b/applications/luci-app-adblock/po/fr/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.14-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Action"
 
@@ -82,7 +82,7 @@ msgstr ""
 "adresse IP (RPZ-CLIENT-IP). Remarque : Cette fonctionnalité n'est supportée "
 "actuellement que par lien d'arrière-plan DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Répondre"
 
@@ -111,7 +111,7 @@ msgstr ""
 "Les modifications dans la Liste noire ont été enregistrées. Actualisez vos "
 "listes Adblock pour que ces changements soient effectifs."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Liste noire ..."
 
@@ -129,11 +129,11 @@ msgstr ""
 "adresse IP (RPZ-CLIENT-IP). Remarque : Cette fonctionnalité n'est supportée "
 "actuellement que par lien d'arrière-plan DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Requêtes DNS bloquées"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domaines bloqués"
@@ -146,7 +146,7 @@ msgstr "Sauvegarde de la liste de blocage"
 msgid "Blocklist Query"
 msgstr "Demande à la Liste de blocage"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Demande à la liste de blocage..."
 
@@ -168,7 +168,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Annuler"
@@ -177,11 +177,11 @@ msgstr "Annuler"
 msgid "Categories"
 msgstr "Catégories"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Clients"
 
@@ -198,9 +198,9 @@ msgstr ""
 "target=\"_blank\" rel=\"noreferrer noopener\" >consulter la documentation en "
 "ligne</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Compteur"
 
@@ -234,7 +234,7 @@ msgstr "Rapport DNS"
 msgid "DNS Restart Timeout"
 msgstr "Délai de redémarrage DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Date"
 
@@ -246,11 +246,11 @@ msgstr "Désactiver l'autorisation DNS"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Désactiver les Listes blanches DNS séléctives (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domaine"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domaines"
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Activé"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Fin de l'horodatage"
 
@@ -366,7 +366,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Cinquième instance"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Critère filtre comme la date, domaine, client (option)"
 
@@ -433,7 +433,7 @@ msgstr "Répertoire des bannis"
 msgid "Last Run"
 msgstr "Dernière exécution"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Dernière Requêtes DNS"
 
@@ -552,7 +552,7 @@ msgstr ""
 "moins de ressources sur le système. Veuillez noter que ce changement "
 "nécessite un redémarrage complet du service AdBlock pour prendre effet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Actualiser"
 
@@ -568,7 +568,7 @@ msgstr "Minuteur d'actualisation"
 msgid "Refresh Timer..."
 msgstr "Minuteur d'actualisation..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Actualisation..."
 
@@ -690,7 +690,7 @@ msgstr "Sources (Taille, Focus)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Liste des ports utilisés par tcpdump, séparés par des espaces."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Démarrer l'horodatage"
 
@@ -779,7 +779,7 @@ msgstr ""
 "autorisés - les adresses IP, les caractères génériques et les expressions "
 "rationnelles ne le sont pas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -787,7 +787,7 @@ msgstr ""
 "Cet onglet montre le dernier rapport DNS généré, appuyer sur le bouton "
 "'Actualiser' pour le mettre à jour."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Heure"
 
@@ -803,15 +803,15 @@ msgstr ""
 "Pour maintenir vos listes adblock à jour, vous devez configurer un travail "
 "de mise à jour automatique de ces listes."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Top 10 Statistiques"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Objet pour les notifications par e-mails d'adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Total des requêtes DNS"
 
@@ -843,7 +843,7 @@ msgstr ""
 "Actualisez votre liste de blocage des publicités pour que les modifications "
 "prennent effet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Liste Blanche..."
 
@@ -859,9 +859,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "taille max. des résultats"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -870,6 +874,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Top 10 Statistiques"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Désactiver les redémarrages DNS"

--- a/applications/luci-app-adblock/po/he/adblock.po
+++ b/applications/luci-app-adblock/po/he/adblock.po
@@ -11,7 +11,7 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr ""
 
@@ -78,7 +78,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr ""
 
@@ -103,7 +103,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -118,11 +118,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "ביטול"
@@ -162,11 +162,11 @@ msgstr "ביטול"
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -178,9 +178,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -212,7 +212,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -224,11 +224,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -306,7 +306,7 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -334,7 +334,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -702,13 +702,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -722,15 +722,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -759,7 +759,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -775,8 +775,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/hi/adblock.po
+++ b/applications/luci-app-adblock/po/hi/adblock.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr ""
 
@@ -71,7 +71,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr ""
 
@@ -96,7 +96,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -111,11 +111,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -128,7 +128,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -146,7 +146,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
@@ -155,11 +155,11 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -171,9 +171,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -205,7 +205,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -217,11 +217,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -299,7 +299,7 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -327,7 +327,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -390,7 +390,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -487,7 +487,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -695,13 +695,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -715,15 +715,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -752,7 +752,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -768,8 +768,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/hu/adblock.po
+++ b/applications/luci-app-adblock/po/hu/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.11-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Művelet"
 
@@ -79,7 +79,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Válasz"
 
@@ -107,7 +107,7 @@ msgstr ""
 "Feketelista beállítások elmentve. Frissítsd az adblockodat az "
 "aktualizáláshoz."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Feketelista..."
 
@@ -122,11 +122,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blokkolt domainek"
@@ -139,7 +139,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Mégse"
@@ -167,11 +167,11 @@ msgstr "Mégse"
 msgid "Categories"
 msgstr "Kategóriák"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Ügyfél"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Kliensek"
 
@@ -183,9 +183,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Darabszám"
 
@@ -218,7 +218,7 @@ msgstr "DNS riport"
 msgid "DNS Restart Timeout"
 msgstr "DNS újraindítás időtúllépés"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Dátum"
 
@@ -230,11 +230,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Tartomány"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domainek"
 
@@ -314,7 +314,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -406,7 +406,7 @@ msgstr ""
 msgid "Last Run"
 msgstr "Utolsó futás"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -504,7 +504,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Frissítés"
 
@@ -521,7 +521,7 @@ msgstr "Időzítő frissítése"
 msgid "Refresh Timer..."
 msgstr "Időzítő frissítése..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Frissítés..."
 
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -717,7 +717,7 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -725,7 +725,7 @@ msgstr ""
 "Ez a fül az utoljára generált DNS jelentést tartalmazza, nyomja meg a "
 "'Frissítés' gombot, hogy egy frisset kapjon."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Idő"
 
@@ -739,15 +739,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Top 10 statisztika"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Összes DNS kérés"
 
@@ -778,7 +778,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Fehérlista..."
 
@@ -794,8 +794,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
@@ -805,6 +809,9 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Top 10 statisztika"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "DNS újraindítás kikapcsolása"

--- a/applications/luci-app-adblock/po/it/adblock.po
+++ b/applications/luci-app-adblock/po/it/adblock.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.14-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Azione"
 
@@ -83,7 +83,7 @@ msgstr ""
 "IP). Nota: questa funzionalità, in questo momento, è supportata solo dal "
 "backend di bind DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Risposta"
 
@@ -112,7 +112,7 @@ msgstr ""
 "Cambiamenti alla blacklist salvati. Ricaricare le liste di adblock per "
 "renderli effettivi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Lista nera..."
 
@@ -130,11 +130,11 @@ msgstr ""
 "IP). Nota: questa funzionalità, in questo momento, è supportata solo dal "
 "backend di bind DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Richieste DNS bloccate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domini bloccati"
@@ -147,7 +147,7 @@ msgstr "Backup lista di blocco"
 msgid "Blocklist Query"
 msgstr "Consulta lista di blocco"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Cerca lista di blocco..."
 
@@ -169,7 +169,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Annulla"
@@ -178,11 +178,11 @@ msgstr "Annulla"
 msgid "Categories"
 msgstr "Categorie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Client"
 
@@ -198,9 +198,9 @@ msgstr ""
 "github.com/openwrt/packages/blob/master/net/adblock/files/README.md\" "
 "target=\"_blank\" rel=\"noreferrer noopener\" >consulta la documentazione</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Numero"
 
@@ -234,7 +234,7 @@ msgstr "Report del DNS"
 msgid "DNS Restart Timeout"
 msgstr "Tempo di riavvio del DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Data"
 
@@ -246,11 +246,11 @@ msgstr "Disabilita Consenti DNS"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Disabilita whitelist DNS selettiva (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Dominio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domini"
 
@@ -331,7 +331,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Abilitato"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Fine timestamp"
 
@@ -362,7 +362,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Quinta istanza"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Parametri del filtro, come data, dominio o client (opzionale)"
 
@@ -429,7 +429,7 @@ msgstr "Cartella di detenzione"
 msgid "Last Run"
 msgstr "Ultimo Avvio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Ultima richiesta DNS"
 
@@ -543,7 +543,7 @@ msgstr ""
 "meno risorse dal sistema. Nota: per rendere effettiva questa modifica, è "
 "necessario un riavvio completo del servizio adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Ricaricare"
 
@@ -559,7 +559,7 @@ msgstr "Attualizza il timer"
 msgid "Refresh Timer..."
 msgstr "Attualizzando il timer..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Aggiorna..."
 
@@ -678,7 +678,7 @@ msgstr "Fonti (dimensioni, focus)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Elenco separato da spazi delle porte utilizzate da tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Avvia Timestamp"
 
@@ -765,7 +765,7 @@ msgstr ""
 "commenti introdotti con '#' sono consentiti - indirizzi IP, caratteri jolly "
 "e regex non lo sono."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -773,7 +773,7 @@ msgstr ""
 "Questa scheda mostra l'ultimo rapporto DNS generato, premi il pulsante "
 "\"Aggiorna\" per ottenerne uno corrente."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Tempo"
 
@@ -789,15 +789,15 @@ msgstr ""
 "Per mantenere aggiornati i tuoi elenchi di adblock, dovresti impostare un "
 "processo di aggiornamento automatico per questi elenchi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Le 10 migliori statistiche"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Argomento per le e-mail di notifica del blocco degli annunci."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Richieste DNS totali"
 
@@ -828,7 +828,7 @@ msgstr ""
 "Le modifiche alla whitelist sono state salvate. Aggiorna i tuoi elenchi di "
 "adblock in modo che le modifiche abbiano effetto."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Whitelist..."
 
@@ -844,9 +844,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "max. dimensione del set di risultati"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -855,6 +859,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Le 10 migliori statistiche"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Disabilita riavvio DNS"

--- a/applications/luci-app-adblock/po/ja/adblock.po
+++ b/applications/luci-app-adblock/po/ja/adblock.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "アクション"
 
@@ -80,7 +80,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "回答"
 
@@ -108,7 +108,7 @@ msgid ""
 msgstr ""
 "ブラックリストへの変更が保存されました。adblockを更新して変更を適用します。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "ブラックリスト..."
 
@@ -123,11 +123,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "ブロックされたDNSリクエスト"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "ブロックされたドメイン"
@@ -140,7 +140,7 @@ msgstr "ブロックリストのバックアップ"
 msgid "Blocklist Query"
 msgstr "ブロックリストのクエリ"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "ブロックリストのクエリ..."
 
@@ -161,7 +161,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "キャンセル"
@@ -170,11 +170,11 @@ msgstr "キャンセル"
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "クライアント"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -190,9 +190,9 @@ msgstr ""
 "files/README.md\" target=\"_blank\" rel=\"noreferrer noopener\" >オンラインド"
 "キュメント</a>を確認してください"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "カウント"
 
@@ -226,7 +226,7 @@ msgstr "DNSレポート"
 msgid "DNS Restart Timeout"
 msgstr "DNS再起動タイムアウト"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "日付"
 
@@ -238,11 +238,11 @@ msgstr "DNS許可を無効化"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "ドメイン"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -320,7 +320,7 @@ msgstr "エラーが発生した際に詳細なデバッグロギングを有効
 msgid "Enabled"
 msgstr "有効"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "終了タイムスタンプ"
 
@@ -352,7 +352,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "日付、ドメイン、クライアントなどのフィルター基準(オプション)"
 
@@ -418,7 +418,7 @@ msgstr "Jailディレクトリ"
 msgid "Last Run"
 msgstr "最終実行"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "最新のDNSリクエスト"
 
@@ -524,7 +524,7 @@ msgstr ""
 "ます。注意: この変更を有効にするには、完全なadblockサービスの再起動が必要で"
 "す。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "リフレッシュ"
 
@@ -540,7 +540,7 @@ msgstr "リフレッシュタイマー"
 msgid "Refresh Timer..."
 msgstr "タイマーをリフレッシュ..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "リフレッシュ..."
 
@@ -658,7 +658,7 @@ msgstr "ソース(サイズ、フォーカス)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdumpが使用するポートの、スペースで区切られたリスト。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "開始タイムスタンプ"
 
@@ -741,13 +741,13 @@ msgstr ""
 "す。<br /> 注意: 1行につきドメインを1つだけ追加してください。'#'で始まるコメ"
 "ントを追加できます - IPアドレス、ワイルドカード、正規表現は使用できません。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "時刻"
 
@@ -763,15 +763,15 @@ msgstr ""
 "adblockリストを常に最新にするには、自動更新をこれらのリストに設定する必要があ"
 "ります。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "上位10項目"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "adblockの通知Eメールのトピック。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "DNSリクエスト合計"
 
@@ -802,7 +802,7 @@ msgstr ""
 "ホワイトリストへの変更が保存されました。adblockのリストを更新して変更を適用し"
 "ます。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "ホワイトリスト..."
 
@@ -818,9 +818,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "最大の結果セットサイズ"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -829,6 +833,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "上位10項目"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "DNS再起動を無効化"

--- a/applications/luci-app-adblock/po/ko/adblock.po
+++ b/applications/luci-app-adblock/po/ko/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.14-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "액션"
 
@@ -77,7 +77,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 #, fuzzy
 msgid "Answer"
 msgstr "답변"
@@ -106,7 +106,7 @@ msgstr ""
 "블랙리스트 변경사항이 저장되었습니다. Adblock 리스트를 새로고침하여 변경사항"
 "을 적용하세요."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "블랙리스트..."
 
@@ -121,11 +121,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "차단된 DNS 요청"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "차단된 도메인들"
@@ -138,7 +138,7 @@ msgstr "차단목록 백업"
 msgid "Blocklist Query"
 msgstr "블록리스트 쿼리"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "블록리스트 등록..."
 
@@ -156,7 +156,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "취소"
@@ -165,11 +165,11 @@ msgstr "취소"
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "클라이언트"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -181,9 +181,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -227,11 +227,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -309,7 +309,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "활성화"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -337,7 +337,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -400,7 +400,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -513,7 +513,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -705,13 +705,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -725,15 +725,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -762,7 +762,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -778,8 +778,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/mr/adblock.po
+++ b/applications/luci-app-adblock/po/mr/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.11-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr ""
 
@@ -77,7 +77,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr ""
 
@@ -102,7 +102,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -117,11 +117,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
@@ -161,11 +161,11 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -177,9 +177,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -223,11 +223,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "सक्षम केले"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -701,13 +701,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -721,15 +721,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -774,8 +774,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/ms/adblock.po
+++ b/applications/luci-app-adblock/po/ms/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.10-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Tindakan"
 
@@ -77,7 +77,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Jawapan"
 
@@ -102,7 +102,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -117,11 +117,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
@@ -161,11 +161,11 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Pelanggan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -177,9 +177,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Kiraan"
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Tarikh"
 
@@ -223,11 +223,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -701,13 +701,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -721,15 +721,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -774,8 +774,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/nb_NO/adblock.po
+++ b/applications/luci-app-adblock/po/nb_NO/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Handling"
 
@@ -79,7 +79,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Svar"
 
@@ -107,7 +107,7 @@ msgstr ""
 "Svartelisteendringene har blitt lagret. Gjenoppfrisk dine "
 "reklameblokkeringslister slik at endringer trer i effekt."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Svartelist …"
 
@@ -122,11 +122,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Blokkerte DNS-forespørsler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blokkerte domener"
@@ -139,7 +139,7 @@ msgstr "Blokkeringslistesikkerhetskopi"
 msgid "Blocklist Query"
 msgstr "Blokkeringslistespørring"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Blokkeringslistespørring …"
 
@@ -157,7 +157,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Avbryt"
@@ -166,11 +166,11 @@ msgstr "Avbryt"
 msgid "Categories"
 msgstr "Kategorier"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -182,9 +182,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Antall"
 
@@ -216,7 +216,7 @@ msgstr "DNS-rapport"
 msgid "DNS Restart Timeout"
 msgstr "DNS-omstartstidsavbrudd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Dato"
 
@@ -228,11 +228,11 @@ msgstr "Skru av DNS-tillatelse"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domene"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -311,7 +311,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Påskrudd"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Slutt-tidsstempel"
 
@@ -339,7 +339,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -402,7 +402,7 @@ msgstr "Fengselsmappe"
 msgid "Last Run"
 msgstr "Sist kjørt"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Siste DNS-forespørsler"
 
@@ -499,7 +499,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Gjenoppfrisk"
 
@@ -515,7 +515,7 @@ msgstr "Gjenoppfrisk tidsur"
 msgid "Refresh Timer..."
 msgstr "Gjenoppfrisk tidsur …"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Gjenoppfrisk …"
 
@@ -635,7 +635,7 @@ msgstr "Kilder (størrelse, fokus)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Mellomromsinndelt liste over porter brukt av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 #, fuzzy
 msgid "Start Timestamp"
 msgstr "Start-tidsstempel"
@@ -712,13 +712,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Tid"
 
@@ -732,15 +732,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Topp 10-statistikk"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Totalt antall DNS-forespørsler"
 
@@ -769,7 +769,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Hvitliste …"
 
@@ -785,9 +785,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "maks. resultatsettstørrelse"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -797,6 +801,9 @@ msgstr "rå (/tmp)"
 #, fuzzy
 msgid "unbound (/var/lib/unbound)"
 msgstr "ubundet (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Topp 10-statistikk"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Skru av DNS-omstarter"

--- a/applications/luci-app-adblock/po/pl/adblock.po
+++ b/applications/luci-app-adblock/po/pl/adblock.po
@@ -11,7 +11,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12.1\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Akcja"
 
@@ -83,7 +83,7 @@ msgstr ""
 "adresów IP (RPZ-CLIENT-IP). Uwaga: ta funkcja jest obecnie obsługiwana tylko "
 "przez backend bind DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Odpowiedź"
 
@@ -112,7 +112,7 @@ msgstr ""
 "Zmiany czarnej listy zostały zapisane. Odśwież listę adblocków, aby zmiany "
 "zostały wprowadzone."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Czarna lista..."
 
@@ -130,11 +130,11 @@ msgstr ""
 "(RPZ-CLIENT-IP). Uwaga: ta funkcja jest obecnie obsługiwana tylko przez "
 "backend bind DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Zablokowane żądania DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Zablokowane domeny"
@@ -147,7 +147,7 @@ msgstr "Kopia zapasowa list blokujących"
 msgid "Blocklist Query"
 msgstr "Zapytanie do list blokujących"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Zapytanie..."
 
@@ -169,7 +169,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Anuluj"
@@ -178,11 +178,11 @@ msgstr "Anuluj"
 msgid "Categories"
 msgstr "Kategorie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Klienty"
 
@@ -198,9 +198,9 @@ msgstr ""
 "net/adblock/files/README.md\" target=\"_blank\" rel=\"noreferrer noopener\"> "
 "sprawdź dokumentację online </a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Licznik"
 
@@ -234,7 +234,7 @@ msgstr "Raport DNS"
 msgid "DNS Restart Timeout"
 msgstr "Limit czasu restartu DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Data"
 
@@ -246,11 +246,11 @@ msgstr "Wyłącz pozwolenie na DNS"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Wyłącz selektywne białe listy DNS (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domena"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domeny"
 
@@ -332,7 +332,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Włączone"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Sygnatura czasowa zakończenia"
 
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Instancja piąta"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Kryteria filtrowania takie jak data, domena lub klient (opcjonalnie)"
 
@@ -430,7 +430,7 @@ msgstr "Katalog więzienia"
 msgid "Last Run"
 msgstr "Ostatnie uruchomienie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Ostatnie zapytania DNS"
 
@@ -543,7 +543,7 @@ msgstr ""
 "Zmniejsz priorytet przetwarzania w tle, aby pobierać mniej zasobów systemu. "
 "Uwaga: wymagany restart usługi adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Odśwież"
 
@@ -559,7 +559,7 @@ msgstr "Zaktualizuj listy automatycznie"
 msgid "Refresh Timer..."
 msgstr "Harmonogram..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Odświeżanie..."
 
@@ -678,7 +678,7 @@ msgstr "Źródła (wielkość, skupienie)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Rozdzielona spacjami lista portów używanych przez tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Sygnatura czasowa uruchamiania"
 
@@ -765,7 +765,7 @@ msgstr ""
 "<br /> Uwaga: dodaj tylko jedną domenę na linię. Komentarze wprowadzone z "
 "'#' są dozwolone - adresy ip, wildcards i regex nie są dozwolone."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -773,7 +773,7 @@ msgstr ""
 "Ta zakładka pokazuje ostatni wygenerowany raport DNS, naciśnij przycisk "
 "'Odśwież', aby uzyskać aktualny raport."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Czas"
 
@@ -789,15 +789,15 @@ msgstr ""
 "Aby Twoje listy były aktualne, należy ustawić automatyczne zadanie "
 "aktualizacji tych list."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Top 10"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Temat dla powiadomień e-mail adblocka."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Łączna liczba żądań DNS"
 
@@ -828,7 +828,7 @@ msgstr ""
 "Zmiany na białej liście zostały zapisane. Odśwież listę, aby zmiany zostały "
 "wprowadzone."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Biała lista ..."
 
@@ -844,9 +844,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "maks. rozmiar zestawu wyników"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -855,6 +859,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Top 10"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Wyłącz restart DNS"

--- a/applications/luci-app-adblock/po/pt/adblock.po
+++ b/applications/luci-app-adblock/po/pt/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.11-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Ação"
 
@@ -82,7 +82,7 @@ msgstr ""
 "IP (RPZ-CLIENT-IP) deles. Nota: esta funcionalidade é atualmente suportada "
 "apenas pelo backend DNS do BIND."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Resposta"
 
@@ -112,7 +112,7 @@ msgstr ""
 "As alterações na lista negra foram gravadas. Atualize as suas listas de "
 "adblock para que as alterações entrem em vigor."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
@@ -130,11 +130,11 @@ msgstr ""
 "(RPZ-CLIENT-IP) deles. Atenção: esta funcionalidade é atualmente suportada "
 "apenas pelo backend DNS do BIND."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Solicitações de DNS bloqueadas"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
@@ -147,7 +147,7 @@ msgstr "Cópia de Segurança da Lista de Bloqueio"
 msgid "Blocklist Query"
 msgstr "Consulta na Lista de Bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Pesquisando a Lista de Bloqueio..."
 
@@ -169,7 +169,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Cancelar"
@@ -178,11 +178,11 @@ msgstr "Cancelar"
 msgid "Categories"
 msgstr "Categorias"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Clientes"
 
@@ -198,9 +198,9 @@ msgstr ""
 "packages/blob/master/net/adblock/files/README.md\" target=\"_blank\" "
 "rel=\"noreferrer noopener\" >verifique a documentação on-line</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Contagem"
 
@@ -234,7 +234,7 @@ msgstr "Relatório do DNS"
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Data"
 
@@ -246,11 +246,11 @@ msgstr "Desativar a opção DNS Permitir"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Desativar a lista branca de DNS (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domínios"
 
@@ -332,7 +332,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Carimbo de tempo final"
 
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Quinta instância"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
@@ -432,7 +432,7 @@ msgstr "Diretório Prisional"
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
@@ -548,7 +548,7 @@ msgstr ""
 "economizar os recursos do sistema. Nota: Esta alteração requer uma "
 "reinicialização completa do serviço adblock para que faça efeito."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -564,7 +564,7 @@ msgstr "Atualizar Temporizador"
 msgid "Refresh Timer..."
 msgstr "Atualizando o Temporizador..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Atualizar..."
 
@@ -684,7 +684,7 @@ msgstr "Fontes (Tamanho, Foco)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Carimbo de tempo incial"
 
@@ -771,7 +771,7 @@ msgstr ""
 "permitidos.<br /> Nota: adicione apenas um domínio por linha. Comentários "
 "introduzidos com '#' são permitidos - endereços ip, curingas e regex não são."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -779,7 +779,7 @@ msgstr ""
 "Esta guia mostra o último relatório DNS gerado, pressione o botão "
 "'Atualizar' para obter o relatório atual."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Tempo"
 
@@ -795,16 +795,16 @@ msgstr ""
 "Para manter as suas listas de adblock atualizadas, deve configurar uma "
 "tarefa de atualização automática para essas listas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "As 10 Estatísticas Principais"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos e-mails que serão usados nas notificações do adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Total de solicitações de DNS"
 
@@ -835,7 +835,7 @@ msgstr ""
 "As modificações feitas na lista branca foram salvas. Atualize a sua lista de "
 "adblock para que as modificações feitas tenham efeito."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
@@ -851,9 +851,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -862,6 +866,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "As 10 Estatísticas Principais"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Desativar as Reinicializações do DNS"

--- a/applications/luci-app-adblock/po/pt_BR/adblock.po
+++ b/applications/luci-app-adblock/po/pt_BR/adblock.po
@@ -13,7 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.11-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Ação"
 
@@ -22,7 +22,6 @@ msgid "Active Sources"
 msgstr "Fontes Ativas"
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:3
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:6
 msgid "Adblock"
 msgstr "Bloqueio de anúncios"
 
@@ -47,7 +46,6 @@ msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Adicione este (sub)domínio na sua lista branca local."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:470
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
 msgid "Additional Jail Blocklist"
 msgstr "Lista de Bloqueio Adicional"
 
@@ -74,12 +72,10 @@ msgid "Advanced Report Settings"
 msgstr "Configurações Avançadas do Relatório"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:464
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Allow Local Client IPs"
 msgstr "Permita os IPs dos clientes locais"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:464
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -89,22 +85,19 @@ msgstr ""
 "seu endereço IP (RPZ-CLIENT-IP). Observe: Este recurso só é compatível com a "
 "estrutura de DNS do bind."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Resposta"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Backup Directory"
 msgstr "Diretório da cópia de segurança"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Base Temp Directory"
 msgstr "Diretório Base Temporário"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -122,17 +115,15 @@ msgstr ""
 "As alterações na lista negra foram salvas. Atualize as suas listas de "
 "bloqueio de anúncios para que as alterações entrem em vigor."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Lista negra..."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Block Local Client IPs"
 msgstr "Bloqueie os IPs dos clientes locais"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
@@ -142,17 +133,16 @@ msgstr ""
 "base no seu endereço IP (RPZ-CLIENT-IP). Observe: Este recurso só é "
 "compatível com a estrutura de DNS do bind."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Requisições bloqueadas do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domínios Bloqueados"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "Blocklist Backup"
 msgstr "Cópia de Segurança da Lista de Bloqueio"
 
@@ -160,7 +150,7 @@ msgstr "Cópia de Segurança da Lista de Bloqueio"
 msgid "Blocklist Query"
 msgstr "Consulta na Lista de Bloqueio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Pesquisando a Lista de Bloqueio..."
 
@@ -169,7 +159,6 @@ msgid "Blocklist Sources"
 msgstr "Fontes das listas de bloqueio"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:470
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -183,21 +172,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Cancelar"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:573
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:586
 msgid "Categories"
 msgstr "Categorias"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Cliente"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Clientes"
 
@@ -210,17 +198,16 @@ msgid ""
 msgstr ""
 "Configuração do pacote de adblock para bloquear domínios de anúncio/abuso "
 "usando DNS. Para obter mais informações <a href=\"https://github.com/openwrt/"
-"packages/blob/master/net/adblock/files/README.md\" target=\"_blank\" rel="
-"\"noreferrer noopener\" >verifique a documentação on-line</a>"
+"packages/blob/master/net/adblock/files/README.md\" target=\"_blank\" "
+"rel=\"noreferrer noopener\" >verifique a documentação on-line</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Contagem"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -230,70 +217,59 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:418
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Backend"
 msgstr "Infraestrutura do DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
 msgid "DNS Directory"
 msgstr "Diretório DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "DNS Instance"
 msgstr "Instância DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 msgid "DNS Report"
 msgstr "Relatório do DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "DNS Restart Timeout"
 msgstr "Tempo Limite para Reiniciar o DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Dia"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:464
 msgid "Disable DNS Allow"
 msgstr "Desativar a opção DNS Permitir"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:464
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Desative a lista branca do DNS (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domínio"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domínios"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Don't check SSL server certificates during download."
 msgstr "Não verifique os certificados do servidor SSL durante o download."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Download Insecure"
 msgstr "Download inseguro"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "Download Parameters"
 msgstr "Parâmetros de Download"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Download Utility"
 msgstr "Ferramenta para Baixar"
 
@@ -302,12 +278,10 @@ msgid "E-Mail Notification"
 msgstr "Notificação por E-Mail"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:540
 msgid "E-Mail Notification Count"
 msgstr "Contagem de Notificações por E-Mail"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:523
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:536
 msgid "E-Mail Profile"
 msgstr "E-Mail do Perfil"
 
@@ -316,27 +290,22 @@ msgid "E-Mail Receiver Address"
 msgstr "Endereço de E-Mail do Destinatário"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:515
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:528
 msgid "E-Mail Sender Address"
 msgstr "Endereço de E-Mail do Remetente"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:532
 msgid "E-Mail Topic"
 msgstr "Assunto do E-Mail"
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:35
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:9
 msgid "Edit Blacklist"
 msgstr "Editar a Lista Negra"
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:43
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:10
 msgid "Edit Whitelist"
 msgstr "Editar a Lista Branca"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid ""
 "Empty the DNS cache before adblock processing starts to reduce the memory "
 "consumption."
@@ -366,7 +335,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Fim da marca temporal"
 
@@ -383,12 +352,10 @@ msgid "Existing job(s)"
 msgstr "Tarefa(s) existente(s)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "External DNS Lookup Domain"
 msgstr "Domínio de Pesquisa Externa do DNS"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -398,11 +365,10 @@ msgstr ""
 "verificação."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Fifth instance"
 msgstr "Quinta instância"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtrar critérios como data, domínio ou cliente (opcional)"
 
@@ -415,12 +381,10 @@ msgid "Firewall source zones that should be forced locally."
 msgstr "Zonas de origem do firewall que devem ser imposta localmente."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
 msgid "First instance (default)"
 msgstr "Primeira instância (padrão)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Flush DNS Cache"
 msgstr "Limpar a Cache do DNS"
 
@@ -437,7 +401,6 @@ msgid "Forced Zones"
 msgstr "Zonas Impostas"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Fourth instance"
 msgstr "Quarta instância"
 
@@ -465,7 +428,6 @@ msgid "Information"
 msgstr "Informações"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Jail Directory"
 msgstr "Diretório Prisional"
 
@@ -473,7 +435,7 @@ msgstr "Diretório Prisional"
 msgid "Last Run"
 msgstr "Última Execução"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "As últimas solicitações do DNS"
 
@@ -490,7 +452,6 @@ msgid "Line number to remove"
 msgstr "O número da linha para remover"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:499
 msgid "List of available network devices used by tcpdump."
 msgstr ""
 "Lista de dispositivos da rede disponíveis que foram usados pelo tcpdump."
@@ -505,7 +466,6 @@ msgstr ""
 "vez de um gatilho de rede."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:418
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -515,12 +475,10 @@ msgstr ""
 "DNS'."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista de ferramentas compatíveis e já pré-configuradas para download."
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 msgid "Log View"
 msgstr "Exiba o registro log"
 
@@ -529,7 +487,6 @@ msgid "Low Priority Service"
 msgstr "Serviço de Baixa Prioridade"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Manually override the pre-configured download options for the selected "
 "download utility."
@@ -546,12 +503,10 @@ msgid "No adblock related logs yet!"
 msgstr "Ainda não há registros relacionados ao bloqueio de anúncio!"
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:19
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:7
 msgid "Overview"
 msgstr "Visão geral"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:523
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:536
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Perfil dos E-Mails de notificação do bloqueio de anúncio utilizado por "
@@ -568,7 +523,6 @@ msgstr ""
 "domínio específico."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:540
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -601,7 +555,7 @@ msgstr ""
 "alteração requer uma reinicialização completa do serviço adblock para que "
 "surta efeito."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Atualizar"
 
@@ -617,7 +571,7 @@ msgstr "Atualize o Temporizador"
 msgid "Refresh Timer..."
 msgstr "Atualizando o Temporizador..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Atualizar..."
 
@@ -634,47 +588,38 @@ msgid "Remove an existing job"
 msgstr "Exclua uma tarefa já existente"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:495
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:508
 msgid "Report Chunk Count"
 msgstr "Contagem de Pedaços do Relatório"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:500
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Report Chunk Size"
 msgstr "Tamanho dos Pedaços do Relatório"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:491
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:504
 msgid "Report Directory"
 msgstr "Diretório do Relatório"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:499
 msgid "Report Interface"
 msgstr "Interface do Relatório"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:518
 msgid "Report Ports"
 msgstr "Relatório das Portas"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:495
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:508
 msgid "Report chunk count used by tcpdump."
 msgstr "Informar a contagem dos pedaços usados pelo tcpdump."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:500
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Informar o tamanho do pedaço utilizado pelo tcpdump em MByte."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:522
 msgid "Resolve IPs"
 msgstr "Resolva os IPs"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:522
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 "Resolva os endereços IP reportados usando a pesquisa reversa do DNS (PTR)."
@@ -710,7 +655,6 @@ msgid "Save"
 msgstr "Salvar"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Second instance"
 msgstr "Segunda instância"
 
@@ -723,7 +667,6 @@ msgstr ""
 "é necessário a instalação adicional do pacote 'msmtp'."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:515
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:528
 msgid "Sender address for adblock notification E-Mails."
 msgstr ""
 "Endereço E-Mail do remetente para as notificações do bloqueador de anúncios."
@@ -733,7 +676,6 @@ msgid "Set a new adblock job"
 msgstr "Defina uma nova tarefa ao adblock"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Set the dns backend instance used by adblock."
 msgstr "Defina a estrutura da instância do dns usado pelo adblock."
 
@@ -742,16 +684,14 @@ msgid "Settings"
 msgstr "Configurações"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:549
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:562
 msgid "Sources (Size, Focus)"
 msgstr "Fontes (Tamanho, Foco)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:518
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista separada por espaço das portas utilizadas pelo tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Início da marca temporal"
 
@@ -768,23 +708,19 @@ msgid "Suspend"
 msgstr "Suspender"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:491
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:504
 msgid "Target directory for DNS related report files."
 msgstr ""
 "Diretório de destino dos relatórios para os arquivos relacionados ao DNS."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Target directory for blocklist backups."
 msgstr "O diretório de destino para os backups da lista de bloqueio."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Caminho do diretório para a lista nega gerada 'adb_list.overall'."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 "Diretório de destino para a lista que for gerada pelo lista de bloqueio "
@@ -818,7 +754,6 @@ msgstr ""
 "Saída do syslog, previamente filtrada para mensagens relacionadas ao adblock."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Third instance"
 msgstr "Terceira instância"
 
@@ -844,7 +779,7 @@ msgstr ""
 "Comentários introduzidos com '#' são permitidos - endereços ip, curingas e "
 "regex não são."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -852,12 +787,11 @@ msgstr ""
 "Esta guia mostra o último relatório gerado do DNS, clique no botão "
 "'Atualizar' para obter o mais atual."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Tempo"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr "Tempo limite para aguardar o reinício bem sucedido do DNS."
 
@@ -869,18 +803,17 @@ msgstr ""
 "Para manter as suas listas de bloqueio de anúncios atualizadas, você deve "
 "configurar uma tarefa de atualização automática para essas listas."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "As 10 Estatísticas Principais"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:532
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 "Defina o assunto dos E-Mais que serão usados nas notificações do bloqueador "
 "de anúncios."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Total das solicitações do DNS"
 
@@ -895,8 +828,6 @@ msgstr "Impossível salvar as modificações: %s"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:588
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:604
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:601
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:617
 msgid "Variants"
 msgstr "Variantes"
 
@@ -913,62 +844,60 @@ msgstr ""
 "As modificações feitas na lista branca foram salvas. Atualize a sua lista de "
 "bloqueio de anúncios para que as modificações feitas surtam efeito."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Lista Branca..."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "bind (/var/lib/bind)"
 msgstr "bind (/var/lib/bind)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr "dnsmasq (/tmp/dnsmasq.d)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "def. a quantidade máxima de resultados"
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "raw (/tmp)"
 msgstr "raw (/tmp)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
-msgid "Disable DNS Restarts"
-msgstr "Desativar as Reinicializações do DNS"
+#~ msgid "Top 10 Statistics"
+#~ msgstr "As 10 Estatísticas Principais"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
-msgid ""
-"Disable adblock triggered restarts for dns backends with autoload/inotify "
-"functions."
-msgstr ""
-"Desative o bloqueador de anúncios que causar a reinicialização das funções "
-"autoload/inotify da infraestrutura do DNS."
+#~ msgid "Disable DNS Restarts"
+#~ msgstr "Desativar as Reinicializações do DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
-msgid "Download Queue"
-msgstr "Fila de Download"
+#~ msgid ""
+#~ "Disable adblock triggered restarts for dns backends with autoload/inotify "
+#~ "functions."
+#~ msgstr ""
+#~ "Desative o bloqueador de anúncios que causar a reinicialização das "
+#~ "funções autoload/inotify da infraestrutura do DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
-msgid ""
-"Size of the download queue for download processing (incl. sorting, merging "
-"etc.) in parallel."
-msgstr ""
-"Tamanho da fila de download para o processamento de download (incl. "
-"classificação, fusão etc.) em paralelo."
+#~ msgid "Download Queue"
+#~ msgstr "Fila de Download"
+
+#~ msgid ""
+#~ "Size of the download queue for download processing (incl. sorting, "
+#~ "merging etc.) in parallel."
+#~ msgstr ""
+#~ "Tamanho da fila de download para o processamento de download (incl. "
+#~ "classificação, fusão etc.) em paralelo."
 
 #~ msgid "Flush the DNS Cache before adblock processing as well."
 #~ msgstr "Também liberar o Cache do DNS antes do bloqueador de anúncios."

--- a/applications/luci-app-adblock/po/ro/adblock.po
+++ b/applications/luci-app-adblock/po/ro/adblock.po
@@ -11,7 +11,7 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 4.11-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Acțiune"
 
@@ -83,7 +83,7 @@ msgstr ""
 "(RPZ-CLIENT-IP). Rețineți: Această caracteristică este în prezent acceptată "
 "numai de backend-ul bind DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Răspuns"
 
@@ -112,7 +112,7 @@ msgstr ""
 "Schimbările la Lista de Interzise au fost salvate. Reîmprospătați lista "
 "adblock pentru ca schimbările să aibă efect."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Lista de Interzise..."
 
@@ -130,11 +130,11 @@ msgstr ""
 "acestora (RPZ-CLIENT-IP). Rețineți: Această funcție este în prezent "
 "suportată numai de backend-ul bind DNS."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Solicitări DNS blocate"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Domenii Blocate"
@@ -147,7 +147,7 @@ msgstr "Copie de Rezervă Pentru Lista de Blocate"
 msgid "Blocklist Query"
 msgstr "Interogare Lista de Blocare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Interogare Lista de Blocare..."
 
@@ -169,7 +169,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Anulare"
@@ -178,11 +178,11 @@ msgstr "Anulare"
 msgid "Categories"
 msgstr "Categorii"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Client"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Clienți"
 
@@ -199,9 +199,9 @@ msgstr ""
 "target=\"_blank\" rel=\"noreferrer noopener\" >verificați documentația "
 "online</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Număr"
 
@@ -235,7 +235,7 @@ msgstr "Raport DNS"
 msgid "DNS Restart Timeout"
 msgstr "Timp Repornire DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Data"
 
@@ -247,11 +247,11 @@ msgstr "Dezactivare Permite DNS"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Dezactivați lista albă DNS selectivă (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domeniu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domenii"
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Timestamp de final"
 
@@ -366,7 +366,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "A cincea instanță"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Criterii de filtrare precum dată, domeniu sau client (opțional)"
 
@@ -433,7 +433,7 @@ msgstr "Director Închisoare"
 msgid "Last Run"
 msgstr "Ultima rulare"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Ultimele Cereri DNS"
 
@@ -546,7 +546,7 @@ msgstr ""
 "puține resurse din sistem. Vă rugăm să rețineți: această modificare necesită "
 "o repornire completă a serviciului de blocare pentru a avea efect."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Reîmprospătare"
 
@@ -562,7 +562,7 @@ msgstr "Cronometru de reîmprospătare"
 msgid "Refresh Timer..."
 msgstr "Cronometru de reîmprospătare..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Reîmprospătați..."
 
@@ -682,7 +682,7 @@ msgstr "Surse (mărime, focalizare)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Lista de porturi utilizate de tcpdump, separate prin spații."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Timpul de pornire"
 
@@ -769,7 +769,7 @@ msgstr ""
 "domeniu pe linie. Comentariile introduse cu \"#\" sunt permise - adresele "
 "ip, wildcards și regex nu sunt permise."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -777,7 +777,7 @@ msgstr ""
 "Această filă afișează ultimul raport DNS generat; apăsați butonul "
 "'Actualizare' pentru a obține un raport actual."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Timp"
 
@@ -793,15 +793,15 @@ msgstr ""
 "Pentru a vă menține listele de adblock actualizate, ar trebui să configurați "
 "o sarcină de actualizare automată pentru aceste liste."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Top 10 statistici"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Subiect pentru e-mailuri de notificare adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Solicitări DNS totale"
 
@@ -832,7 +832,7 @@ msgstr ""
 "Modificările la lista albă au fost salvate. Actualizați listele adblock "
 "pentru ca modificările să intre în vigoare."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Lista albă..."
 
@@ -848,9 +848,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "dimensiunea maximă a setului de rezultate"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -859,6 +863,9 @@ msgstr "brut (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "fără legătură (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Top 10 statistici"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Dezactivare Repornire DNS"

--- a/applications/luci-app-adblock/po/ru/adblock.po
+++ b/applications/luci-app-adblock/po/ru/adblock.po
@@ -16,7 +16,7 @@ msgstr ""
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Действие"
 
@@ -87,7 +87,7 @@ msgstr ""
 "CLIENT-IP). Обратите внимание: В настоящее время эта функция поддерживается "
 "только DNS-сервером bind."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Ответ"
 
@@ -116,7 +116,7 @@ msgstr ""
 "Изменения чёрного списка сохранены. Для того, чтобы они вступили в силу, "
 "обновите списки блокировок."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Чёрный список..."
 
@@ -134,11 +134,11 @@ msgstr ""
 "(RPZ-CLIENT-IP). Обратите внимание: В настоящее время эта функция "
 "поддерживается только DNS-сервером bind."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Заблокированные DNS-запросы"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Блокируемые домены"
@@ -151,7 +151,7 @@ msgstr "Резервная копия чёрного списка"
 msgid "Blocklist Query"
 msgstr "Поиск по «чёрному списку»"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Поиск по чёрному списку..."
 
@@ -173,7 +173,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Отмена"
@@ -182,11 +182,11 @@ msgstr "Отмена"
 msgid "Categories"
 msgstr "Категории"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Клиент"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Клиенты"
 
@@ -202,9 +202,9 @@ msgstr ""
 "<a href=\"https://github.com/openwrt/packages/blob/master/net/adblock/files/"
 "README.md\" target=\"_blank\" rel=\"noreferrer noopener\" >документации</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Количество"
 
@@ -238,7 +238,7 @@ msgstr "Отчёт DNS"
 msgid "DNS Restart Timeout"
 msgstr "Тайм-аут перезапуска DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Дата"
 
@@ -250,11 +250,11 @@ msgstr "Отключить пропуск DNS"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Отключить выборочные белые списки DNS (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Домены"
 
@@ -333,7 +333,7 @@ msgstr "Включить подробное формирование отчёт�
 msgid "Enabled"
 msgstr "Включено"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Время окончания"
 
@@ -366,7 +366,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Пятая инстанция"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Критерии фильтрации, такие как дата, домен или клиент (необязательно)"
 
@@ -432,7 +432,7 @@ msgstr "Папка для «тюрьмы»"
 msgid "Last Run"
 msgstr "Последний запуск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Последние DNS-запросы"
 
@@ -546,7 +546,7 @@ msgstr ""
 "нагрузки на систему. Обратите внимание: для работы данной опции требуется "
 "полная перезагрузка службы блокировщика рекламы."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Обновить"
 
@@ -562,7 +562,7 @@ msgstr "Обновить таймер"
 msgid "Refresh Timer..."
 msgstr "Обновить таймер..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Обновить..."
 
@@ -680,7 +680,7 @@ msgstr "Источники (Размер, Фокусировка)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Разделенный пробелами список портов, используемых tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Время начала"
 
@@ -766,7 +766,7 @@ msgstr ""
 "на строку. Разрешается использование комментариев, начинающихся на '#'. IP-"
 "адреса и регулярные выражения не поддерживаются."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -774,7 +774,7 @@ msgstr ""
 "На этой вкладке показан последний созданный отчет DNS, нажмите кнопку "
 "'Обновить', чтобы получить текущий отчет."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Время"
 
@@ -788,15 +788,15 @@ msgid ""
 "job for these lists."
 msgstr "Чтобы списки были актуальны, настройте их автоматическое обновление."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Топ-10 статистики"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Тема, используемая для отправки электронных писем."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Всего DNS-запросов"
 
@@ -827,7 +827,7 @@ msgstr ""
 "Изменения в белом списке были сохранены. Обновите свои списки блокировок, "
 "чтобы изменения вступили в силу."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Белый список..."
 
@@ -843,9 +843,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "макс. размер списка результатов"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -854,6 +858,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Топ-10 статистики"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Отключить перезагрузки DNS"

--- a/applications/luci-app-adblock/po/si/adblock.po
+++ b/applications/luci-app-adblock/po/si/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr ""
 
@@ -77,7 +77,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "පිළිතුර"
 
@@ -102,7 +102,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -117,11 +117,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -134,7 +134,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -152,7 +152,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
@@ -161,11 +161,11 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -177,9 +177,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -223,11 +223,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -396,7 +396,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -493,7 +493,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -701,13 +701,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -721,15 +721,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -774,8 +774,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/sk/adblock.po
+++ b/applications/luci-app-adblock/po/sk/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.14.1\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Akcia"
 
@@ -80,7 +80,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Odpoveď"
 
@@ -107,7 +107,7 @@ msgstr ""
 "Zmeny v zozname zakázaných domén boli uložené. Obnovte zoznamy Adblocku aby "
 "sa prejavili."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Zoznam zakázaných domén..."
 
@@ -122,11 +122,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Zablokované požiadavky servera DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blokované domény"
@@ -139,7 +139,7 @@ msgstr "Záloha zoznamu blokovaných domén"
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -157,7 +157,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Zrušiť"
@@ -166,11 +166,11 @@ msgstr "Zrušiť"
 msgid "Categories"
 msgstr "Kategórie"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Klienti"
 
@@ -182,9 +182,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Počet"
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Dátum"
 
@@ -228,11 +228,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Doména"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domény"
 
@@ -310,7 +310,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Zapnuté"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -338,7 +338,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -401,7 +401,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -630,7 +630,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -706,13 +706,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -726,15 +726,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -779,8 +779,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/sv/adblock.po
+++ b/applications/luci-app-adblock/po/sv/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.10-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Åtgärd"
 
@@ -19,7 +19,6 @@ msgid "Active Sources"
 msgstr "Aktiva källor"
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:3
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:6
 msgid "Adblock"
 msgstr "Adblock"
 
@@ -44,7 +43,6 @@ msgid "Add this (sub-)domain to your local whitelist."
 msgstr "Lägg till denna (under-)domän i din lokala vitlista."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:470
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
 msgid "Additional Jail Blocklist"
 msgstr "Ytterligare arrest-blocklista"
 
@@ -71,34 +69,29 @@ msgid "Advanced Report Settings"
 msgstr "Avancerade rapportinställningar"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:464
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid "Allow Local Client IPs"
 msgstr "Tillåt lokala klienters IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:464
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:473
 msgid ""
 "Allow all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Svar"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Backup Directory"
 msgstr "Säkerhetskopiera mapp"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid "Base Temp Directory"
 msgstr "Tempkatalogbas"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
 msgid ""
 "Base Temp Directory for all adblock related runtime operations, e.g. "
 "downloading, sorting, merging etc."
@@ -115,34 +108,31 @@ msgstr ""
 "Ändringar av startlistan har sparats. Uppdatera dina annonsblockeringslistor "
 "för att ändringarna ska få verkan."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Svartlista..."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid "Block Local Client IPs"
 msgstr "Blockera lokala klienters IP"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:458
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:467
 msgid ""
 "Block all requests of certain DNS clients based on their IP address (RPZ-"
 "CLIENT-IP). Please note: This feature is currently only supported by bind "
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Blockerade DNS-uppslag"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Blockerade domäner"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid "Blocklist Backup"
 msgstr "Blockeringslistssäkerhetskopia"
 
@@ -150,7 +140,7 @@ msgstr "Blockeringslistssäkerhetskopia"
 msgid "Blocklist Query"
 msgstr "Blockeringslistsfråga"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Blockeringslistsfråga..."
 
@@ -159,7 +149,6 @@ msgid "Blocklist Sources"
 msgstr "Källor för blockeringslistor"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:470
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:479
 msgid ""
 "Builds an additional DNS blocklist to block access to all domains except "
 "those listed in the whitelist. Please note: You can use this restrictive "
@@ -172,21 +161,20 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Avbryt"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:573
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:586
 msgid "Categories"
 msgstr "Kategorier"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Klient"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Klienter"
 
@@ -202,14 +190,13 @@ msgstr ""
 "blob/master/net/adblock/files/README.md\" target=\"_blank\" rel=\"noreferrer "
 "noopener\" >online-dokumentationen</a> för mer information."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Räkna"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:390
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
 msgid ""
 "Create compressed blocklist backups, they will be used in case of download "
 "errors or during startup."
@@ -219,70 +206,59 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:237
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:418
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid "DNS Backend"
 msgstr "DNS-bakände"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
 msgid "DNS Directory"
 msgstr "DNS-mapp"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "DNS Instance"
 msgstr "DNS-instans"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:356
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:27
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:8
 msgid "DNS Report"
 msgstr "DNS-rapport"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "DNS Restart Timeout"
 msgstr "Tidsgräns för DNS-omstart"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Datum"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:464
 msgid "Disable DNS Allow"
 msgstr "Inaktivera DNS-tillåtelse"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:455
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:464
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Domän"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Domäner"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Don't check SSL server certificates during download."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:407
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:416
 msgid "Download Insecure"
 msgstr "Ladda ner osäkert"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid "Download Parameters"
 msgstr "Ladda ner parametrar"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "Download Utility"
 msgstr "Ladda ner verktyget"
 
@@ -291,12 +267,10 @@ msgid "E-Mail Notification"
 msgstr "E-postavisering"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:540
 msgid "E-Mail Notification Count"
 msgstr "Antal E-postaviseringar"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:523
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:536
 msgid "E-Mail Profile"
 msgstr "E-postprofil"
 
@@ -305,27 +279,22 @@ msgid "E-Mail Receiver Address"
 msgstr "E-postmottagaradress"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:515
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:528
 msgid "E-Mail Sender Address"
 msgstr "Avsändaradress för e-post"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:532
 msgid "E-Mail Topic"
 msgstr "E-postämne"
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:35
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:9
 msgid "Edit Blacklist"
 msgstr "Redigera svartlista"
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:43
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:10
 msgid "Edit Whitelist"
 msgstr "Redigera vitlista"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid ""
 "Empty the DNS cache before adblock processing starts to reduce the memory "
 "consumption."
@@ -351,7 +320,7 @@ msgstr "Aktivera utförlig avlusningsloggning i händelse av behandlingsfel."
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Sluttidstämpel"
 
@@ -366,12 +335,10 @@ msgid "Existing job(s)"
 msgstr "Befintliga jobb"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid "External DNS Lookup Domain"
 msgstr "Extern DNS-uppslagsdomän"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:447
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:456
 msgid ""
 "External domain to check for a successful DNS backend restart. Please note: "
 "To disable this check set this option to 'false'."
@@ -380,11 +347,10 @@ msgstr ""
 "Inaktivera denna verifiering genom att välja alternativet 'false'."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:446
 msgid "Fifth instance"
 msgstr "Femte instans"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Filtreringsvillkor som datum, domän eller klient (valfritt)"
 
@@ -397,12 +363,10 @@ msgid "Firewall source zones that should be forced locally."
 msgstr "Brandväggskällzoner som ska forceras lokalt."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
 msgid "First instance (default)"
 msgstr "Första instans (standard)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:452
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:461
 msgid "Flush DNS Cache"
 msgstr "Töm DNS-cache"
 
@@ -419,7 +383,6 @@ msgid "Forced Zones"
 msgstr "Forcerade zoner"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:436
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:445
 msgid "Fourth instance"
 msgstr "Fjärde instans"
 
@@ -447,7 +410,6 @@ msgid "Information"
 msgstr "Information"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Jail Directory"
 msgstr "Arrestkatalog"
 
@@ -455,7 +417,7 @@ msgstr "Arrestkatalog"
 msgid "Last Run"
 msgstr "Kördes senast"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Senaste DNS-begäranden"
 
@@ -472,7 +434,6 @@ msgid "Line number to remove"
 msgstr "Radnummer att ta bort"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:499
 msgid "List of available network devices used by tcpdump."
 msgstr "Lista med tillgängliga nätverksenheter använda av tcpdump."
 
@@ -486,7 +447,6 @@ msgstr ""
 "upstartstidsgräns istället för en nätverksaktivering."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:418
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:427
 msgid ""
 "List of supported DNS backends with their default list directory. To "
 "overwrite the default path use the 'DNS Directory' option."
@@ -495,12 +455,10 @@ msgstr ""
 "åsidosätta standardsökvägen; använd alternativet 'DNS-katalog'."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:399
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:408
 msgid "List of supported and fully pre-configured download utilities."
 msgstr "Lista över stödda och helt förkonfigurerade nedladdningsverktyg."
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:51
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:11
 msgid "Log View"
 msgstr "Logutsikt"
 
@@ -509,7 +467,6 @@ msgid "Low Priority Service"
 msgstr "Lågprioriterad tjänst"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:411
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
 msgid ""
 "Manually override the pre-configured download options for the selected "
 "download utility."
@@ -524,12 +481,10 @@ msgid "No adblock related logs yet!"
 msgstr "Inga annonsblockerinsrelaterade loggar ännu!"
 
 #: applications/luci-app-adblock/root/usr/share/luci/menu.d/luci-app-adblock.json:19
-#: applications/luci-app-adblock/luasrc/controller/adblock.lua:7
 msgid "Overview"
 msgstr "Överblick"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:523
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:536
 msgid "Profile used by 'msmtp' for adblock notification E-Mails."
 msgstr ""
 "Profil som används av 'msmtp' för annonsblockeringsaviserinse-"
@@ -544,7 +499,6 @@ msgid "Query active blocklists and backups for a specific domain."
 msgstr "Fråga aktiva svartlistor och säkerhetskopior efter en given domän."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:527
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:540
 msgid ""
 "Raise the notification count, to get E-Mails if the overall blocklist count "
 "is less or equal to the given limit."
@@ -574,7 +528,7 @@ msgstr ""
 "systemresurser i anspråk. Notera: Denna ändring kräver en fullständig "
 "omstart av annonsblockeringstjänsten för att ha verkan."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Uppdatera"
 
@@ -590,7 +544,7 @@ msgstr "Förnya stoppuret"
 msgid "Refresh Timer..."
 msgstr "Förnya stoppuret..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Fräscha upp..."
 
@@ -607,47 +561,38 @@ msgid "Remove an existing job"
 msgstr "Ta bort ett befintligt jobb"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:495
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:508
 msgid "Report Chunk Count"
 msgstr "Rapportera klimpantal"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:500
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Report Chunk Size"
 msgstr "Rapportera klimpstorlek"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:491
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:504
 msgid "Report Directory"
 msgstr "Rapportkatalog"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:486
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:499
 msgid "Report Interface"
 msgstr "Rapportgränssnitt"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:518
 msgid "Report Ports"
 msgstr "Rapporthamnar"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:495
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:508
 msgid "Report chunk count used by tcpdump."
 msgstr "Rapportera klimpantal använt av tcpdump."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:500
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:513
 msgid "Report chunk size used by tcpdump in MByte."
 msgstr "Rapportera klimpstorlek som används av tcpdump i MByte."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:522
 msgid "Resolve IPs"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:509
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:522
 msgid "Resolve reporting IP addresses by using reverse DNS (PTR) lookups."
 msgstr ""
 
@@ -682,7 +627,6 @@ msgid "Save"
 msgstr "Spara"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:434
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:443
 msgid "Second instance"
 msgstr "Andra instans"
 
@@ -695,7 +639,6 @@ msgstr ""
 "här kräver installation av 'msmtp'-paketet."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:515
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:528
 msgid "Sender address for adblock notification E-Mails."
 msgstr "Avsändaradress för adblock-aviseringar via e-post."
 
@@ -704,7 +647,6 @@ msgid "Set a new adblock job"
 msgstr "Ställ in ett nytt adblock-jobb"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:441
 msgid "Set the dns backend instance used by adblock."
 msgstr "Ställ in DNS-bakändens instans som används av adblock."
 
@@ -713,16 +655,14 @@ msgid "Settings"
 msgstr "Inställningar"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:549
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:562
 msgid "Sources (Size, Focus)"
 msgstr "Källor (Storlek, Fokus)"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:505
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:518
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Utrymmesseparerad lista över portar som används av tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -739,22 +679,18 @@ msgid "Suspend"
 msgstr "Stäng av"
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:491
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:504
 msgid "Target directory for DNS related report files."
 msgstr "Målmapp för DNS-relaterade rapport-filer."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:394
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:403
 msgid "Target directory for blocklist backups."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:428
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:437
 msgid "Target directory for the generated blocklist 'adb_list.overall'."
 msgstr "Målmapp för den genererade blockeringslistan 'adb_list.overall'."
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:474
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:483
 msgid "Target directory for the generated jail blocklist 'adb_list.jail'."
 msgstr ""
 
@@ -785,7 +721,6 @@ msgid "The syslog output, pre-filtered for adblock related messages only."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:435
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:444
 msgid "Third instance"
 msgstr ""
 
@@ -803,18 +738,17 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:442
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:451
 msgid "Timeout to wait for a successful DNS backend restart."
 msgstr ""
 
@@ -824,16 +758,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:532
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -848,8 +781,6 @@ msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:588
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:604
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:601
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:617
 msgid "Variants"
 msgstr ""
 
@@ -864,60 +795,50 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:422
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:431
 msgid "bind (/var/lib/bind)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:420
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:429
 msgid "dnsmasq (/tmp/dnsmasq.d)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:423
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:432
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr ""
 
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
+
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:433
 msgid "raw (/tmp)"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:430
 msgid "unbound (/var/lib/unbound)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
-msgid "Disable DNS Restarts"
-msgstr "Inaktivera DNS-omstarter"
+#~ msgid "Disable DNS Restarts"
+#~ msgstr "Inaktivera DNS-omstarter"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:488
-msgid ""
-"Disable adblock triggered restarts for dns backends with autoload/inotify "
-"functions."
-msgstr ""
-"Inaktivera annonsblockeringsstyrda omstarter av DNS-bakändar med autoload/"
-"inotify funktionalitet."
+#~ msgid ""
+#~ "Disable adblock triggered restarts for dns backends with autoload/inotify "
+#~ "functions."
+#~ msgstr ""
+#~ "Inaktivera annonsblockeringsstyrda omstarter av DNS-bakändar med autoload/"
+#~ "inotify funktionalitet."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
-msgid "Download Queue"
-msgstr "Nedladdningskö"
-
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:385
-msgid ""
-"Size of the download queue for download processing (incl. sorting, merging "
-"etc.) in parallel."
-msgstr ""
+#~ msgid "Download Queue"
+#~ msgstr "Nedladdningskö"
 
 #~ msgid "Flush the DNS Cache before adblock processing as well."
 #~ msgstr "Spola också DNS-cachen innan annonsblockeringshantering."

--- a/applications/luci-app-adblock/po/templates/adblock.pot
+++ b/applications/luci-app-adblock/po/templates/adblock.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr ""
 
@@ -68,7 +68,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr ""
 
@@ -93,7 +93,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -108,11 +108,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -125,7 +125,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -143,7 +143,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
@@ -152,11 +152,11 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -168,9 +168,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr ""
 
@@ -202,7 +202,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr ""
 
@@ -214,11 +214,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -296,7 +296,7 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -387,7 +387,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -616,7 +616,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -692,13 +692,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr ""
 
@@ -712,15 +712,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -749,7 +749,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -765,8 +765,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/tr/adblock.po
+++ b/applications/luci-app-adblock/po/tr/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.11-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Eylem"
 
@@ -81,7 +81,7 @@ msgstr ""
 "isteklerine izin verin. Lütfen dikkat: Bu özellik şu anda yalnızca bind DNS "
 "arka ucu tarafından desteklenmektedir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Cevap"
 
@@ -110,7 +110,7 @@ msgstr ""
 "Kara liste değişiklikleri kaydedildi. Değişikliklerin etkili olması için "
 "reklam engelleme listelerinizi yenileyin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Kara liste..."
 
@@ -128,11 +128,11 @@ msgstr ""
 "isteklerini engelleyin. Lütfen dikkat: Bu özellik şu anda yalnızca bind DNS "
 "arka ucu tarafından desteklenmektedir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Engellenen DNS İstekleri"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Engellenen Alan Adları"
@@ -145,7 +145,7 @@ msgstr "Engelleme Listesi Yedekleme"
 msgid "Blocklist Query"
 msgstr "Engelleme Listesi Sorgusu"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Engelleme Listesi Sorgusu..."
 
@@ -167,7 +167,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "İptal"
@@ -176,11 +176,11 @@ msgstr "İptal"
 msgid "Categories"
 msgstr "Kategoriler"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "İstemci"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "İstemciler"
 
@@ -197,9 +197,9 @@ msgstr ""
 "README.md\" target=\"_blank\" rel=\"noreferrer noopener\" > çevrimiçi "
 "belgelere </a> bakın."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Adet"
 
@@ -233,7 +233,7 @@ msgstr "DNS Raporu"
 msgid "DNS Restart Timeout"
 msgstr "DNS Yeniden Başlatma Zaman Aşımı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Tarih"
 
@@ -245,11 +245,11 @@ msgstr "DNS İzin Vermeyi Devre Dışı bırakın"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Seçici DNS beyaz listeyi (RPZ-PASSTHRU) devre dışı bırakın."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Alan"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Alan adları"
 
@@ -331,7 +331,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Etkin"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Zaman damgasını bitir"
 
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "Beşinci örnek"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Tarih, alan, client gibi filtre özellikleri (opsiyonel)"
 
@@ -431,7 +431,7 @@ msgstr "Kafes Dizini"
 msgid "Last Run"
 msgstr "Son çalışma zamanı"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Yeni DNS Sorguları"
 
@@ -548,7 +548,7 @@ msgstr ""
 "önceliğini azaltın. Lütfen dikkat: Bu değişikliğin yürürlüğe girmesi için "
 "adblock hizmetinin tam olarak yeniden başlatılması gerekir."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Yenile"
 
@@ -564,7 +564,7 @@ msgstr "Zamanlayıcıyı Yenile"
 msgid "Refresh Timer..."
 msgstr "Zamanlayıcıyı Yenile .."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Yenile.."
 
@@ -684,7 +684,7 @@ msgstr ""
 "Tcpdump tarafından kullanılan bağlantı noktalarının boşlukla ayrılmış "
 "listesi."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "Zaman Damgasını Başlat"
 
@@ -770,7 +770,7 @@ msgstr ""
 "alanı ekleyin. '#' İle tanıtılan yorumlara izin verilir - ip adresleri, "
 "joker karakterler ve normal ifadelere izin verilmez."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -778,7 +778,7 @@ msgstr ""
 "Bu sekme, oluşturulan son DNS Raporunu gösterir, güncel olanı almak için "
 "'Yenile' düğmesine basın."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Zaman"
 
@@ -794,15 +794,15 @@ msgstr ""
 "Reklam engelleme listelerinizi güncel tutmak için, bu listeler için otomatik "
 "bir güncelleme işi ayarlamalısınız."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "En İyi 10 İstatistik"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Adblock bildirim e-postaları için konu."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Toplam DNS İstekleri"
 
@@ -833,7 +833,7 @@ msgstr ""
 "Beyaz liste değişiklikleri kaydedildi. Değişikliklerin etkili olacağı "
 "adblock listelerinizi yenileyin."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Beyaz liste..."
 
@@ -849,9 +849,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "maks. sonuç kümesi boyutu"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -860,6 +864,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "En İyi 10 İstatistik"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "DNS Yeniden Başlatmalarını Devre Dışı bırakın"

--- a/applications/luci-app-adblock/po/uk/adblock.po
+++ b/applications/luci-app-adblock/po/uk/adblock.po
@@ -11,7 +11,7 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.14.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Дія"
 
@@ -81,7 +81,7 @@ msgstr ""
 "CLIENT-IP). Запримітьте: наразі ця функція підтримується лише DNS-сервером "
 "bind."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Відповідь"
 
@@ -110,7 +110,7 @@ msgstr ""
 "Зміни чорного списку збережено. Оновіть свої списки блокування реклами, щоб "
 "зміни вступили в силу."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "Чорний список..."
 
@@ -127,11 +127,11 @@ msgstr ""
 "Блокувати всі запити певних клієнтів DNS на основі їх IP-адреси (RPZ-CLIENT-"
 "IP). Запримітьте: наразі ця функція підтримується лише DNS-сервером bind."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "Заблоковані DNS-запити"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "Заблоковані домени"
@@ -144,7 +144,7 @@ msgstr "Резервна копія списку блокування"
 msgid "Blocklist Query"
 msgstr "Запит до списку блокування"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "Запит до списку блокування..."
 
@@ -166,7 +166,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "Скасувати"
@@ -175,11 +175,11 @@ msgstr "Скасувати"
 msgid "Categories"
 msgstr "Категорії"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Клієнт"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "Клієнти"
 
@@ -196,9 +196,9 @@ msgstr ""
 "target=\"_blank\" rel=\"noreferrer noopener\" >дивіться онлайн документацію</"
 "a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Кількість"
 
@@ -232,7 +232,7 @@ msgstr "Звіт DNS"
 msgid "DNS Restart Timeout"
 msgstr "Тайм-аут перезапуску DNS"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Дата"
 
@@ -244,11 +244,11 @@ msgstr "Вимкнути пропуск DNS"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "Вимкнути вибірковий білий список DNS (RPZ-PASSTHRU)."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "Домен"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "Домени"
 
@@ -329,7 +329,7 @@ msgstr "Увімкнути детальний звіт на випадок бу�
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "Час завершення"
 
@@ -362,7 +362,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "П'ятий екземпляр"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "Критерії фільтра, як дата, домен або клієнт (необов'язково)"
 
@@ -430,7 +430,7 @@ msgstr "Тека для «в'язниці» (jail)"
 msgid "Last Run"
 msgstr "Останній запуск"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "Останні DNS-запити"
 
@@ -546,7 +546,7 @@ msgstr ""
 "систему. Будь ласка, запримітьте: ця зміна вимагає повного перезапуску "
 "Adblock."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "Оновити"
 
@@ -562,7 +562,7 @@ msgstr "Оновити таймер"
 msgid "Refresh Timer..."
 msgstr "Оновити таймер..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "Оновити..."
 
@@ -693,7 +693,7 @@ msgstr "Джерела (Розмір, Фокусування)"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "Розділений пробілами список портів, які використовує tcpdump."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 #, fuzzy
 msgid "Start Timestamp"
 msgstr "Час початку"
@@ -784,7 +784,7 @@ msgstr ""
 "рядок. Дозволено використання коментарів, що починається з '#'; IP-адреси та "
 "регулярні вирази не підтримуються."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
@@ -792,7 +792,7 @@ msgstr ""
 "На цій вкладці відображається останній згенерований звіт DNS, натисніть "
 "кнопку «Оновити», щоб отримати поточний звіт."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Час"
 
@@ -808,15 +808,15 @@ msgstr ""
 "Щоб ваші списки блокування реклами залишалися актуальними, вам слід "
 "налаштувати завдання автоматичного оновлення для цих списків."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "Топ-10 статистики"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Тема E-Mail сповіщень про блокування реклами."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "Усього DNS-запитів"
 
@@ -847,7 +847,7 @@ msgstr ""
 "Зміни білого списку збережено. Оновіть свої списки блокування реклами, щоб "
 "зміни вступили в силу."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "Білий список..."
 
@@ -863,9 +863,13 @@ msgstr "dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "kresd (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "макс. розмір набору результатів"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -874,6 +878,9 @@ msgstr "raw (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "Топ-10 статистики"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "Вимкнути перезавантаження DNS"

--- a/applications/luci-app-adblock/po/vi/adblock.po
+++ b/applications/luci-app-adblock/po/vi/adblock.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "Hành động"
 
@@ -78,7 +78,7 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "Phản hồi"
 
@@ -103,7 +103,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr ""
 
@@ -118,11 +118,11 @@ msgid ""
 "DNS backend."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr ""
@@ -135,7 +135,7 @@ msgstr ""
 msgid "Blocklist Query"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr ""
 
@@ -153,7 +153,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr ""
@@ -162,11 +162,11 @@ msgstr ""
 msgid "Categories"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "Khách hàng"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr ""
 
@@ -178,9 +178,9 @@ msgid ""
 "noopener\" >check the online documentation</a>"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "Bộ đếm"
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "DNS Restart Timeout"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "Ngày"
 
@@ -225,11 +225,11 @@ msgstr ""
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgstr ""
 msgid "Enabled"
 msgstr "Bật"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr ""
 
@@ -335,7 +335,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Last Run"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgid ""
 "service restart to take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr ""
 
@@ -511,7 +511,7 @@ msgstr ""
 msgid "Refresh Timer..."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr ""
 
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Space separated list of ports used by tcpdump."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr ""
 
@@ -703,13 +703,13 @@ msgid ""
 "'#' are allowed - ip addresses, wildcards and regex are not."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "Thời gian"
 
@@ -723,15 +723,15 @@ msgid ""
 "job for these lists."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgid ""
 "take effect."
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr ""
 
@@ -777,8 +777,12 @@ msgstr ""
 msgid "kresd (/etc/kresd)"
 msgstr ""
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
+msgstr ""
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
 msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424

--- a/applications/luci-app-adblock/po/zh_Hans/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hans/adblock.po
@@ -17,7 +17,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.13.1-dev\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "操作"
 
@@ -86,7 +86,7 @@ msgstr ""
 "基于特定DNS客户端的IP地址允许这些客户端的所有请求（RPZ-CLIENT-IP)。请注意：眼"
 "下只有bind DNS后端支持此功能。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "回答"
 
@@ -111,7 +111,7 @@ msgid ""
 "take effect."
 msgstr "黑名单更改已保存。刷新您的广告拦截列表以使更改生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "黑名单..."
 
@@ -128,11 +128,11 @@ msgstr ""
 "基于特定DNS客户端的IP地址拦截它们的所有请求 (RPZ-CLIENT-IP)。请注意：眼下只有"
 "bind DNS 后端支持此功能。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "阻止的DNS请求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "已拦截域名"
@@ -145,7 +145,7 @@ msgstr "黑名单列表的备份"
 msgid "Blocklist Query"
 msgstr "拦截列表查询"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "黑名单查询..."
 
@@ -165,7 +165,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "取消"
@@ -174,11 +174,11 @@ msgstr "取消"
 msgid "Categories"
 msgstr "类别"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "客户端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "客户端"
 
@@ -193,9 +193,9 @@ msgstr ""
 "href=\"https://github.com/openwrt/packages/blob/master/net/adblock/files/"
 "README.md\" target=\"_blank\" rel=\"noreferrer noopener\" >查看在线文档</a>"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "计数"
 
@@ -227,7 +227,7 @@ msgstr "DNS报告"
 msgid "DNS Restart Timeout"
 msgstr "DNS重新启动超时"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "日期"
 
@@ -239,11 +239,11 @@ msgstr "禁用DNS允许"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "禁用选择性DNS白名单（RPZ-PASSTHRU）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "域名"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "域名"
 
@@ -321,7 +321,7 @@ msgstr "在出现任何处理错误时启用详细的调试日志。"
 msgid "Enabled"
 msgstr "已启用"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "结束时间戳"
 
@@ -351,7 +351,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "第五个实例"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "过滤条件，例如日期，域或客户（可选）"
 
@@ -416,7 +416,7 @@ msgstr "黑名单目录"
 msgid "Last Run"
 msgstr "最后运行"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "最新的DNS请求"
 
@@ -519,7 +519,7 @@ msgstr ""
 "降低adblock后台处理的优先级以减少系统资源.请注意：此更改要求重新启动完整的"
 "adblock服务才能生效."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "刷新"
 
@@ -535,7 +535,7 @@ msgstr "定时恢复"
 msgid "Refresh Timer..."
 msgstr "定时恢复中..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "刷新..."
 
@@ -651,7 +651,7 @@ msgstr "来源（大小，焦点）"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump使用的端口列表，用空格分隔端口。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "开始时间戳"
 
@@ -731,13 +731,13 @@ msgstr ""
 "这是本地adblock白名单，始终允许某些（子）域。<br />请注意：每行仅添加一个域。"
 "允许以“＃”开头的注释-不允许使用IP地址，通配符和正则表达式。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr "此选项卡显示上次生成的 DNS 报告，按“刷新”按钮获取当前报告。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "时间"
 
@@ -751,15 +751,15 @@ msgid ""
 "job for these lists."
 msgstr "为了使您的广告过滤列表保持最新，您应该为这些列表设置一个自动更新任务。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "前 10 统计数据"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "广告拦截通知邮件的主题。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "DNS 请求总数"
 
@@ -788,7 +788,7 @@ msgid ""
 "take effect."
 msgstr "白名单更改已保存。刷新您的广告拦截列表以使更改生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "白名单..."
 
@@ -804,9 +804,13 @@ msgstr "Dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "抑制 (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "最大结果集大小"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -815,6 +819,9 @@ msgstr "原始（/ tmp）"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "未绑定 (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "前 10 统计数据"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "禁用DNS重新启动"

--- a/applications/luci-app-adblock/po/zh_Hant/adblock.po
+++ b/applications/luci-app-adblock/po/zh_Hant/adblock.po
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12.1\n"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:258
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:272
 msgid "Action"
 msgstr "動作"
 
@@ -85,7 +85,7 @@ msgstr ""
 "基於特定 DNS 用戶端的 IP 位址允許這些用戶端的所有請求 (RPZ-CLIENT-IP)。請注"
 "意：目前只有 bind DNS 後端支援此功能。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:257
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:271
 msgid "Answer"
 msgstr "回答"
 
@@ -111,7 +111,7 @@ msgid ""
 "take effect."
 msgstr "黑名單變更已儲存；請重新整理您的 Adblock 清單來使變更生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:282
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:296
 msgid "Blacklist..."
 msgstr "黑名單…"
 
@@ -128,11 +128,11 @@ msgstr ""
 "基於特定 DNS 用戶端的 IP 位址封鎖它們的所有請求 (RPZ-CLIENT-IP)。請注意：目前"
 "只有 bind DNS 後端支援此功能。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:313
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:327
 msgid "Blocked DNS Requests"
 msgstr "封鎖的 DNS 請求"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:211
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:225
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:229
 msgid "Blocked Domains"
 msgstr "封鎖的域名"
@@ -145,7 +145,7 @@ msgstr "黑名單備份"
 msgid "Blocklist Query"
 msgstr "封鎖清單查詢"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:322
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:336
 msgid "Blocklist Query..."
 msgstr "黑名單查詢…"
 
@@ -165,7 +165,7 @@ msgstr ""
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:22
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:57
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:109
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:176
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:72
 msgid "Cancel"
 msgstr "取消"
@@ -174,11 +174,11 @@ msgstr "取消"
 msgid "Categories"
 msgstr "類別"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:255
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:269
 msgid "Client"
 msgstr "用戶端"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:207
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:221
 msgid "Clients"
 msgstr "用戶端"
 
@@ -194,9 +194,9 @@ msgstr ""
 "files/README.md\" target=\"_blank\" rel=\"noreferrer noopener\" >請參閱線上文"
 "件</a> 以獲得更多資訊"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:206
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:208
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:210
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:220
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:222
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:224
 msgid "Count"
 msgstr "計數"
 
@@ -228,7 +228,7 @@ msgstr "DNS 報告"
 msgid "DNS Restart Timeout"
 msgstr "DNS 重新啟動逾時值"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:253
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:267
 msgid "Date"
 msgstr "日期"
 
@@ -240,11 +240,11 @@ msgstr "停用 DNS 解析修改"
 msgid "Disable selective DNS whitelisting (RPZ-PASSTHRU)."
 msgstr "停用選擇性 DNS 白名單 (RPZ-PASSTHRU)。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:256
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:270
 msgid "Domain"
 msgstr "網域名稱"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:209
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:223
 msgid "Domains"
 msgstr "網域"
 
@@ -322,7 +322,7 @@ msgstr "在出現任何處理錯誤的情況下，請啟用詳細除錯日誌記
 msgid "Enabled"
 msgstr "啟用"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:305
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:319
 msgid "End Timestamp"
 msgstr "結束時間戳"
 
@@ -354,7 +354,7 @@ msgstr ""
 msgid "Fifth instance"
 msgstr "第五個實例"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:157
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:170
 msgid "Filter criteria like date, domain or client (optional)"
 msgstr "篩選器準則（例如：日期、域名或客戶端，可選）"
 
@@ -419,7 +419,7 @@ msgstr "Jail 檔案目錄"
 msgid "Last Run"
 msgstr "最後執行"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:341
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:355
 msgid "Latest DNS Requests"
 msgstr "最新 DNS 請求"
 
@@ -525,7 +525,7 @@ msgstr ""
 "降低 Adblock 後台行程的優先權以耗費更少的系統資源；請注意：此變更需要您完全重"
 "新啟動 Adblock 服務後才能生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:184
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:198
 msgid "Refresh"
 msgstr "重新整理"
 
@@ -541,7 +541,7 @@ msgstr "定時重整"
 msgid "Refresh Timer..."
 msgstr "定時重整中..."
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:329
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:343
 msgid "Refresh..."
 msgstr "重新整理…"
 
@@ -658,7 +658,7 @@ msgstr "來源（大小、聚焦的類別）"
 msgid "Space separated list of ports used by tcpdump."
 msgstr "tcpdump 使用的通訊埠號（以空格分隔）。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:301
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:315
 msgid "Start Timestamp"
 msgstr "啟動時間戳"
 
@@ -740,13 +740,13 @@ msgstr ""
 "入一個域名，允許使用 \"#\" 來引入註解，但不允許使用 IP 位址、萬用字元和正規表"
 "示式。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:298
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:312
 msgid ""
 "This tab shows the last generated DNS Report, press the 'Refresh' button to "
 "get a current one."
 msgstr "此頁籤顯示上次產生的 DNS 報告，按「更新」按鈕取得目前報告。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:254
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:268
 msgid "Time"
 msgstr "時間"
 
@@ -760,15 +760,15 @@ msgid ""
 "job for these lists."
 msgstr "要保持最新的 Adblock 清單，您應該設定這些清單的自動更新工作。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:334
-msgid "Top 10 Statistics"
-msgstr "前 10 統計"
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:348
+msgid "Top Statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:519
 msgid "Topic for adblock notification E-Mails."
 msgstr "Adblock 通知電子郵件的主旨。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:309
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:323
 msgid "Total DNS Requests"
 msgstr "DNS 請求總數"
 
@@ -797,7 +797,7 @@ msgid ""
 "take effect."
 msgstr "白名單變更已儲存；請重新整理您的 Adblock 清單來使變更生效。"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:274
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:288
 msgid "Whitelist..."
 msgstr "白名單..."
 
@@ -813,9 +813,13 @@ msgstr "Dnsmasq (/tmp/dnsmasq.d)"
 msgid "kresd (/etc/kresd)"
 msgstr "抑制 (/etc/kresd)"
 
-#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:163
 msgid "max. result set size"
 msgstr "最大結果集大小"
+
+#: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/dnsreport.js:150
+msgid "max. top statistics"
+msgstr ""
 
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:424
 msgid "raw (/tmp)"
@@ -824,6 +828,9 @@ msgstr "原始 (/tmp)"
 #: applications/luci-app-adblock/htdocs/luci-static/resources/view/adblock/overview.js:421
 msgid "unbound (/var/lib/unbound)"
 msgstr "Unbound (/var/lib/unbound)"
+
+#~ msgid "Top 10 Statistics"
+#~ msgstr "前 10 統計"
 
 #~ msgid "Disable DNS Restarts"
 #~ msgstr "停用 DNS 重新啟動"

--- a/applications/luci-app-adblock/root/usr/share/rpcd/acl.d/luci-app-adblock.json
+++ b/applications/luci-app-adblock/root/usr/share/rpcd/acl.d/luci-app-adblock.json
@@ -22,7 +22,7 @@
 				"/etc/init.d/adblock restart" : [ "exec" ],
 				"/etc/init.d/adblock suspend" : [ "exec" ],
 				"/etc/init.d/adblock resume" : [ "exec" ],
-				"/etc/init.d/adblock report [a-z]* [0-9]* *" : [ "exec" ],
+				"/etc/init.d/adblock report [a-z]* [0-9]* [0-9]* *" : [ "exec" ],
 				"/etc/init.d/adblock timer list" : [ "exec" ],
 				"/etc/init.d/adblock timer remove [0-9]*" : [ "exec" ],
 				"/etc/init.d/adblock timer add * [0-9]* [0-9*]* [0-6,-*]*" : [ "exec" ],


### PR DESCRIPTION
* add a new DNS report parameter to change the top statistics dynamically in the range of 10-50, see https://github.com/openwrt/packages/issues/19622 in the package repo for reference.
* sync translations

Signed-off-by: Dirk Brenken <dev@brenken.org>