### PR TITLE
luci-app-dhcp: 'addresses' helptext improvement with info from manpage.

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -4608,7 +4608,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "قائمة المجالات التي تسمح باستجابات RFC1918 ل"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "قائمة المجالات التي سيتم فرضها على عنوان IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -4548,7 +4548,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -4490,7 +4490,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -4557,7 +4557,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -4620,7 +4620,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Seznam domén, pro které povolit odpovědi podle RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -4723,7 +4723,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Liste over domæner, som der skal tillades RFC1918-svar for."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Liste over domæner, der skal tvinges til en IP-adresse."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -4761,7 +4761,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Liste von Domains für welche RFC1918-Antworten erlaubt sind"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Liste von erzwungenen Domain-IP-Adressen-Zuordnungen."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -4590,7 +4590,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -4494,7 +4494,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -4787,7 +4787,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Lista de dominios para permitir respuestas RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Lista de dominios para forzar a una dirección IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -4631,7 +4631,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Luettelo verkkotunnuksista, joille sallitaan RFC1918-vastaukset"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Lista verkkoalueista sekä käytettävistä IP-osoitteista."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -4771,7 +4771,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Liste des domaines où sont permises les réponses de type RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Liste des domaines à forcer à une adresse IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -4513,7 +4513,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -4492,7 +4492,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -4638,7 +4638,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Tartományok listája, amelyeknél az RFC1918 válaszok engedélyezettek"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -4619,7 +4619,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Elenco di domini per cui consentire risposte RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Elenco di domini da forzare a un indirizzo IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -4652,7 +4652,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "RFC1918の応答を許可するドメインのリスト"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "これはIPアドレスに強制的に設定するドメインのリスト。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -4545,7 +4545,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -4490,7 +4490,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -4510,7 +4510,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -4562,7 +4562,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Liste over domener hvor en tillater RFC1918 svar"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -4503,7 +4503,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -4741,7 +4741,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Lista domen zezwalających na odpowiedzi RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Lista wymuszonych domen na adres IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -4724,7 +4724,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Lista de domínios para quais permitir respostas de RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Lista de domínios a forçar para um endereço IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -4800,7 +4800,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Lista dos domínios com permissão para respostas RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Lista dos domínios que serão impostos num endereço IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -4752,7 +4752,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Lista domeniilor pentru care se permit răspunsurile RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Lista domeniilor care trebuie forțate la o adresă IP."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -4745,7 +4745,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Список доменов, для которых разрешены ответы RFC1918."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Список доменов для принудительного преобразования в IP-адрес."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -4522,7 +4522,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -4531,7 +4531,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -4481,7 +4481,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -4711,7 +4711,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "RFC1918 yanıtlarına izin verilecek etki alanlarının listesi."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Bir IP adresine zorlanacak etki alanlarının listesi."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -4754,7 +4754,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Список доменів, для яких дозволено RFC1918-відповіді"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "Список доменів для примусового перетворення у IP-адреси."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -4489,7 +4489,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -4591,7 +4591,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "Danh sách tên miền chấp nhận phản hồi RFC1918"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -4584,7 +4584,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "允许 RFC1918 响应的域名列表。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "此列表将域名强制指向某个 IP 地址。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -4603,7 +4603,7 @@ msgid "List of domains to allow RFC1918 responses for."
 msgstr "列出允許RFC1918文件虛擬IP回應的網域."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:290
-msgid "List of domains to force to an IP address."
+msgid "Resolve specified FQDNs to an IP."
 msgstr "列出網域以便強制到某個IP位址."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:283

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -287,9 +287,12 @@ return view.extend({
 
 		o = s.taboption('general', form.DynamicList, 'address',
 			_('Addresses'),
-			_('List of domains to force to an IP address.'));
+			_('Resolve specified FQDNs to an IP.') + '<br />' +
+			_('Syntax: <code>/fqdn[/fqdn...]/[ipaddr]</code>.&nbsp;') + '<br />' +
+			_('<code>/#/</code> matches any domain. <code>/asdf.com/</code> returns NXDOMAIN.&nbsp;') + '<br />' +
+			_('<code>/asdf.com/#</code> returns NULL addresses (<code>0.0.0.0</code> and <code>::</code>) for asdf.com and its subdomains.'));
 		o.optional = true;
-		o.placeholder = '/router.local/192.168.0.1';
+		o.placeholder = '/router.local/router.lan/192.168.0.1';
 
 		o = s.taboption('general', form.DynamicList, 'ipset',
 			_('IP sets'),


### PR DESCRIPTION
Placeholder hint also reflects syntax.

Signed-off-by: Paul Dee <itsascambutmailmeanyway@gmail.com>

Tested on 22.03.2

![Screenshot 2022-10-19 at 18 05 41](https://user-images.githubusercontent.com/647633/196746321-24803717-ff29-4bb3-b258-bfce5ab8f104.png)
