### PR TITLE
luci-mod-network: 'mxhosts' tab added

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -255,6 +255,7 @@ return view.extend({
 		s.tab('advanced', _('Advanced Settings'));
 		s.tab('leases', _('Static Leases'));
 		s.tab('hosts', _('Hostnames'));
+		s.tab('mxhosts', _('MX'));
 		s.tab('ipsets', _('IP Sets'));
 
 		s.taboption('general', form.Flag, 'domainneeded',
@@ -546,6 +547,33 @@ return view.extend({
 		Object.values(L.uci.sections('dhcp', 'dnsmasq')).forEach(function(val, index) {
 			so.value(index, '%s (Domain: %s, Local: %s)'.format(index, val.domain || '?', val.local || '?'));
 		});
+
+		o = s.taboption('mxhosts', form.SectionValue, '__mxhosts__', form.TableSection, 'mxhost', null,
+			_('Bind service records to a domain name: specify the location of services.')
+			 + '<br />' + ('You may add multiple records for the same domain.'));
+
+		ss = o.subsection;
+
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable  = true;
+		ss.rowcolors = true;
+		ss.nodescriptions = true;
+
+		so = ss.option(form.Value, 'domain', _('Domain'));
+		so.rmempty = false;
+		so.datatype = 'hostname';
+		so.placeholder = 'example.com';
+
+		so = ss.option(form.Value, 'relay', _('Relay'));
+		so.rmempty = false;
+		so.datatype = 'hostname';
+		so.placeholder = 'relay.example.com';
+
+		so = ss.option(form.Value, 'pref', _('Priority'), _('Ordinal: lower comes first.'));
+		so.rmempty = true;
+		so.datatype = 'range(0,65535)';
+		so.placeholder = '0';
 
 		o = s.taboption('hosts', form.SectionValue, '__hosts__', form.GridSection, 'domain', null,
 			_('Hostnames are used to bind a domain name to an IP address. This setting is redundant for hostnames already configured with static leases, but it can be useful to rebind an FQDN.'));


### PR DESCRIPTION
sub area: luci-app-dhcp

DHCP Help does not document mxhost, but they are available in dnsmasq.

This effectively implements MX records within DNS.

Tested on 22.03.2

Signed-off-by: Paul Dee <itsascambutmailmeanyway@gmail.com>

![mx](https://user-images.githubusercontent.com/647633/196834022-df588b5e-76f0-4827-af76-6cde5a12871a.png)

