### PR TITLE
luci-mod-network: 'relay' tab added

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -231,7 +231,8 @@ return view.extend({
 		return Promise.all([
 			callHostHints(),
 			callDUIDHints(),
-			getDHCPPools()
+			getDHCPPools(),
+			network.getDevices()
 		]);
 	},
 
@@ -240,6 +241,7 @@ return view.extend({
 		    hosts = hosts_duids_pools[0],
 		    duids = hosts_duids_pools[1],
 		    pools = hosts_duids_pools[2],
+		    ndevs = hosts_duids_pools[3],
 		    m, s, o, ss, so;
 
 		m = new form.Map('dhcp', _('DHCP and DNS'),
@@ -250,6 +252,7 @@ return view.extend({
 		s.addremove = false;
 
 		s.tab('general', _('General Settings'));
+		s.tab('relay', _('Relay'));
 		s.tab('files', _('Resolv and Hosts Files'));
 		s.tab('pxe_tftp', _('PXE/TFTP Settings'));
 		s.tab('advanced', _('Advanced Settings'));
@@ -339,6 +342,66 @@ return view.extend({
 			_('Do not listen on the specified interfaces.'));
 		o.optional = true;
 		o.placeholder = 'loopback';
+
+		o = s.taboption('relay', form.SectionValue, '__relays__', form.TableSection, 'relay', null,
+			_('Relay DHCP requests elsewhere. OK: v4<->v4, v6<->v6. Not OK: v4<->v6, v6<->v4.')
+			+ '<br />' + _('Note: you may also need a DHCP Proxy (currently unavailable) when specifying a non-standard Relay To port(<code>addr#port</code>).')
+			+ '<br />' + _('You may add multiple unique Relay To on the same Listen addr.'));
+
+		ss = o.subsection;
+
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable  = true;
+		ss.rowcolors = true;
+		ss.nodescriptions = true;
+
+		so = ss.option(form.Value, 'id', _('ID'));
+		so.rmempty = false;
+		so.optional = true;
+
+		so = ss.option(widgets.NetworkSelect, 'interface', _('Interface'));
+		so.optional = true;
+		so.rmempty = false;
+		so.placeholder = 'lan';
+
+		so = ss.option(form.Value, 'local_addr', _('Listen address'));
+		so.rmempty = false;
+		so.datatype = 'ipaddr';
+
+		for (var family = 4; family <= 6; family += 2) {
+			for (var i = 0; i < ndevs.length; i++) {
+				var addrs = (family == 6) ? ndevs[i].getIP6Addrs() : ndevs[i].getIPAddrs();
+				for (var j = 0; j < addrs.length; j++)
+					so.value(addrs[j].split('/')[0]);
+			}
+		}
+
+		so = ss.option(form.Value, 'server_addr', _('Relay To address'));
+		so.rmempty = false;
+		so.optional = false;
+		so.placeholder = '192.168.10.1#535';
+
+		so.validate = function(section, value) {
+			var m = this.section.formvalue(section, 'local_addr'),
+			    n = this.section.formvalue(section, 'server_addr'),
+			    p;
+			if (n != null && n != '')
+			    p = n.split('#');
+				if (p.length > 1 && !/^[0-9]+$/.test(p[1]))
+					return _('Expected port number.');
+				else
+					n = p[0];
+
+			if ((m == null || m == '') && (n == null || n == ''))
+				return _('Both Listen addr and Relay To must be specified.');
+
+			if ((validation.parseIPv6(m) && validation.parseIPv6(n)) ||
+				validation.parseIPv4(m) && validation.parseIPv4(n))
+				return true;
+			else
+				return _('Listen and Relay To IP family must be homogeneous.')
+		};
 
 		s.taboption('files', form.Flag, 'readethers',
 			_('Use <code>/etc/ethers</code>'),


### PR DESCRIPTION
Adds LuCI GUI for dnsmasq DHCP 'relays'.

The helper functions in dnsmasq/files/dnsmasq.init limit behaviour whereby it is not possible to omit server_addr, where to omit it (dnsmasq supported) would result in a broad- or multicast further on.

Tested on 22.03.2

Signed-off-by: Paul Dee <itsascambutmailmeanyway@gmail.com>

![relaynew](https://user-images.githubusercontent.com/647633/197069231-7bcab873-ccc2-4708-baa5-f7fbe88f9cd4.png)
