### PR TITLE
luci-mod-network: remove uppercase for interface name on overview page

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1199,7 +1199,7 @@ return view.extend({
 					'class': 'ifacebox-head',
 					'style': firewall.getZoneColorStyle(zone),
 					'title': zone ? _('Part of zone %q').format(zone.getName()) : _('No zone assigned')
-				}, E('strong', net.getName().toUpperCase())),
+				}, E('strong', net.getName())),
 				E('div', {
 					'class': 'ifacebox-body',
 					'id': '%s-ifc-devices'.format(section_id),


### PR DESCRIPTION
In the overview page, the name of the interface is converted to uppercase. However, this is not the name in the configuration. From my point of view, this makes no sense. The name displayed should correspond exactly to the name in the configuration.

Signed-off-by: Florian Eckert <fe@dev.tdt.de>