### PR TITLE
luci-lua-runtime: add again removed footer and header

### DIFF
--- a/modules/luci-lua-runtime/luasrc/view/footer.htm
+++ b/modules/luci-lua-runtime/luasrc/view/footer.htm
@@ -1,0 +1,27 @@
+<%#
+ Copyright 2008 Steven Barth <steven@midlink.org>
+ Copyright 2008-2019 Jo-Philipp Wich <jo@mein.io>
+ Licensed to the public under the Apache License 2.0.
+-%>
+
+<%
+	local is_rollback_pending, rollback_time_remaining, rollback_session, rollback_token = luci.model.uci:rollback_pending()
+
+	if is_rollback_pending or trigger_apply or trigger_revert then
+%>
+	<script type="text/javascript">
+		document.addEventListener("luci-loaded", function() {
+			<% if trigger_apply then -%>
+				L.ui.changes.apply(true);
+			<%- elseif trigger_revert then -%>
+				L.ui.changes.revert();
+			<%- else -%>
+				L.ui.changes.confirm(true, Date.now() + <%=rollback_time_remaining%> * 1000, <%=luci.http.write_json(rollback_token)%>);
+			<%- end %>
+		});
+	</script>
+<%
+	end
+
+	include("themes/" .. theme .. "/footer")
+%>

--- a/modules/luci-lua-runtime/luasrc/view/header.htm
+++ b/modules/luci-lua-runtime/luasrc/view/header.htm
@@ -1,0 +1,38 @@
+<%#
+ Copyright 2008 Steven Barth <steven@midlink.org>
+ Copyright 2008-2019 Jo-Philipp Wich <jo@mein.io>
+ Licensed to the public under the Apache License 2.0.
+-%>
+
+<%
+	if not luci.dispatcher.context.template_header_sent then
+		include("themes/" .. theme .. "/header")
+		luci.dispatcher.context.template_header_sent = true
+	end
+
+	local applyconf = luci.config and luci.config.apply
+%>
+
+<script type="text/javascript" src="<%=resource%>/promis.min.js"></script>
+<script type="text/javascript" src="<%=resource%>/luci.js"></script>
+<script type="text/javascript">
+	L = new LuCI(<%= luci.http.write_json({
+		token          = token,
+		media          = media,
+		resource       = resource,
+		scriptname     = luci.http.getenv("SCRIPT_NAME"),
+		pathinfo       = luci.http.getenv("PATH_INFO"),
+		documentroot   = luci.http.getenv("DOCUMENT_ROOT"),
+		requestpath    = luci.dispatcher.context.requestpath,
+		dispatchpath   = luci.dispatcher.context.path,
+		pollinterval   = luci.config.main.pollinterval or 5,
+		ubuspath       = luci.config.main.ubuspath or '/ubus/',
+		sessionid      = luci.dispatcher.context.authsession,
+		nodespec       = luci.dispatcher.context.dispatched,
+		apply_rollback = math.max(applyconf and applyconf.rollback or 90, 90),
+		apply_holdoff  = math.max(applyconf and applyconf.holdoff or 4, 1),
+		apply_timeout  = math.max(applyconf and applyconf.timeout or 5, 1),
+		apply_display  = math.max(applyconf and applyconf.display or 1.5, 1),
+		rollback_token = rollback_token
+	}) %>);
+</script>


### PR DESCRIPTION
The footer.htm and header.htm were removed during the conversion to ucode.
In order for the applications that use SimpleForm, for example, to still work, these files must be present.
This fixes #6054