### PR TITLE
luci-mod-network: rename button reset to delete on device page

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -2017,6 +2017,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "احدف"
 
@@ -9070,10 +9071,6 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
 msgstr "الثواني غير المتاحة (UAS)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -1983,6 +1983,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Изтрий"
 
@@ -8892,10 +8893,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -1961,6 +1961,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr ""
 
@@ -8820,10 +8821,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -2001,6 +2001,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Suprimeix"
 
@@ -8933,10 +8934,6 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr ""
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Desconfigura"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr ""
@@ -10211,6 +10208,9 @@ msgstr "sí"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Enrere"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Desconfigura"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Enrere a la configuració"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -2016,6 +2016,7 @@ msgstr "Delegovat prefix IPv6"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Odstranit"
 
@@ -9098,10 +9099,6 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
 msgstr "Počet nedostupných sekund (UAS)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -2081,6 +2081,7 @@ msgstr "Delegere IPv6-præfikser"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Slet"
 
@@ -9401,10 +9402,6 @@ msgstr "PIN-koden kunne ikke bekræftes"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Ikke-tilgængelige sekunder (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Afkonfigurer"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -10741,6 +10738,9 @@ msgstr "ja"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Tilbage"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Afkonfigurer"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Tilbage til konfiguration"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -2092,6 +2092,7 @@ msgstr "IPv6-Präfix-Delegation"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Löschen"
 
@@ -9512,10 +9513,6 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Nicht verfügbare Sekunden (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Dekonfigurieren"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr ""
@@ -10858,6 +10855,9 @@ msgstr "ja"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Zurück"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Dekonfigurieren"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Zurück zur Konfiguration"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -2022,6 +2022,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Διαγραφή"
 
@@ -8954,10 +8955,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -1965,6 +1965,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr ""
 
@@ -8824,10 +8825,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -2127,6 +2127,7 @@ msgstr "Delegar prefijos de IPv6"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -9549,10 +9550,6 @@ msgstr "No se puede verificar el PIN"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Segundos no disponibles (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Desconfigurar"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 #, fuzzy
 msgid "Unet"
@@ -10903,6 +10900,9 @@ msgstr "sí"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Volver"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Desconfigurar"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Volver a la configuración"

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -2027,6 +2027,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Poista"
 
@@ -9152,10 +9153,6 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
 msgstr "Saavuttamattomissa (UAS)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -2106,6 +2106,7 @@ msgstr "Déléguer les préfixes IPv6"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Effacer"
 
@@ -9505,10 +9506,6 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Secondes non disponibles (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Annuler la configuration"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr ""
@@ -10851,6 +10848,9 @@ msgstr "oui"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Retour"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Annuler la configuration"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Retour à la configuration"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -1982,6 +1982,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "למחוק"
 
@@ -8849,10 +8850,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -1963,6 +1963,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr ""
 
@@ -8822,10 +8823,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -2033,6 +2033,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Törlés"
 
@@ -9138,10 +9139,6 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
 msgstr "Elérhetetlen másodpercek (UAS)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -2036,6 +2036,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Elimina"
 
@@ -9089,10 +9090,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -2039,6 +2039,7 @@ msgstr "IPv6 プレフィックスの委任"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "削除"
 
@@ -9181,10 +9182,6 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "使用不可秒数（UAS）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "設定解除"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr ""
@@ -10492,6 +10489,9 @@ msgstr "はい"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 戻る"
+
+#~ msgid "Unconfigure"
+#~ msgstr "設定解除"
 
 #~ msgid "Back to configuration"
 #~ msgstr "設定へ戻る"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -1994,6 +1994,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "삭제"
 
@@ -8947,10 +8948,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -1961,6 +1961,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "हटवा"
 
@@ -8820,10 +8821,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -1964,6 +1964,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Padam"
 
@@ -8859,10 +8860,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -1999,6 +1999,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Slett"
 
@@ -8956,10 +8957,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -1971,6 +1971,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -8837,10 +8838,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -2089,6 +2089,7 @@ msgstr "Delegowanie prefiksów IPv6"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Usuń"
 
@@ -9446,10 +9447,6 @@ msgstr "Nie można zweryfikować kodu PIN"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Czas niedostępnośći (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Dekonfiguruj"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -10795,6 +10792,9 @@ msgstr "tak"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Wróć"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Dekonfiguruj"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Wróć do konfiguracji"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -2079,6 +2079,7 @@ msgstr "Delegue prefixos IPv6"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Apagar"
 
@@ -9376,10 +9377,6 @@ msgstr ""
 "Segundos de indisponibilidade (<abbr title=\"Unavailable Seconds\">UAS</"
 "abbr>)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Desconfigurar"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr ""
@@ -10710,6 +10707,9 @@ msgstr "sim"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Desconfigurar"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Voltar à configuração"

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -2128,6 +2128,7 @@ msgstr "Delegue prefixos IPv6"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Apagar"
 
@@ -9539,10 +9540,6 @@ msgstr ""
 "Segundos de indisponibilidade (<abbr title=\"Unavailable Seconds\">UAS</"
 "abbr>)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Desconfigurar"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -10892,6 +10889,9 @@ msgstr "sim"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Voltar"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Desconfigurar"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Voltar para configuração"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -2094,6 +2094,7 @@ msgstr "Delegați prefixele IPv6"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Ștergeți"
 
@@ -9477,10 +9478,6 @@ msgstr "Nu se poate verifica PIN-ul"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Secunde indisponibile (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Neconfigurați"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -10824,6 +10821,9 @@ msgstr "da"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Înapoi"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Neconfigurați"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Înapoi la configurare"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -2105,6 +2105,7 @@ msgstr "Делегировать IPv6 префиксы"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Удалить"
 
@@ -9464,10 +9465,6 @@ msgstr "Не удается проверить PIN-код"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Секунды неготовности (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Сброс"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -10815,6 +10812,9 @@ msgstr "да"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Сброс"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Назад к настройкам"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -1982,6 +1982,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Odstrániť"
 
@@ -8891,10 +8892,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -1986,6 +1986,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Radera"
 
@@ -8860,10 +8861,6 @@ msgstr ""
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
 msgstr "Otillgängliga Sekunder (UAS)"
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -1952,6 +1952,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr ""
 
@@ -8811,10 +8812,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -2080,6 +2080,7 @@ msgstr "IPv6 öneklerini temsil et"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Sil"
 
@@ -9404,10 +9405,6 @@ msgstr "PIN doğrulanamadı"
 msgid "Unavailable Seconds (UAS)"
 msgstr "Kullanılamayan Saniyeler (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Yapılandırmayı kaldır"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -10745,6 +10742,9 @@ msgstr "evet"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Geri"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Yapılandırmayı kaldır"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Yapılandırmaya dön"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -2092,6 +2092,7 @@ msgstr "Делегувати префікси IPv6"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Видалити"
 
@@ -9439,10 +9440,6 @@ msgstr ""
 msgid "Unavailable Seconds (UAS)"
 msgstr "Недоступні секунди (<abbr title=\"Unavailable Seconds\">UAS</abbr>)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "Скасувати налаштування"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr ""
@@ -10776,6 +10773,9 @@ msgstr "так"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« Назад"
+
+#~ msgid "Unconfigure"
+#~ msgstr "Скасувати налаштування"
 
 #~ msgid "Back to configuration"
 #~ msgstr "Повернутися до конфігурування"

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -1960,6 +1960,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr ""
 
@@ -8821,10 +8822,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -2004,6 +2004,7 @@ msgstr ""
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "Xóa"
 
@@ -9037,10 +9038,6 @@ msgstr ""
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js:33
 msgid "Unavailable Seconds (UAS)"
-msgstr ""
-
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
 msgstr ""
 
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -2013,6 +2013,7 @@ msgstr "委托 IPv6 前缀"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "删除"
 
@@ -9058,10 +9059,6 @@ msgstr "无法验证 PIN"
 msgid "Unavailable Seconds (UAS)"
 msgstr "不可用秒数（UAS）"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "取消配置"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -10359,6 +10356,9 @@ msgstr "是"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 后退"
+
+#~ msgid "Unconfigure"
+#~ msgstr "取消配置"
 
 #~ msgid "Back to configuration"
 #~ msgstr "返回至配置"

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -2014,6 +2014,7 @@ msgstr "委派 IPv6 首碼"
 #: modules/luci-compat/luasrc/view/cbi/nsection.htm:11
 #: modules/luci-compat/luasrc/view/cbi/tblsection.htm:162
 #: modules/luci-compat/luasrc/view/cbi/tsection.htm:16
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
 msgid "Delete"
 msgstr "刪除"
 
@@ -9072,10 +9073,6 @@ msgstr "無法驗證 PIN"
 msgid "Unavailable Seconds (UAS)"
 msgstr "不可用秒數 (UAS)"
 
-#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1301
-msgid "Unconfigure"
-msgstr "取消配置"
-
 #: protocols/luci-proto-unet/htdocs/luci-static/resources/protocol/unet.js:8
 msgid "Unet"
 msgstr "Unet"
@@ -10368,6 +10365,9 @@ msgstr "是"
 #: modules/luci-compat/luasrc/view/cbi/delegator.htm:20
 msgid "« Back"
 msgstr "« 倒退"
+
+#~ msgid "Unconfigure"
+#~ msgstr "取消配置"
 
 #~ msgid "Back to configuration"
 #~ msgstr "返回至設定"

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1298,7 +1298,7 @@ return view.extend({
 			var trEl = this.super('renderRowActions', [ section_id, _('Configure…') ]),
 			    deleteBtn = trEl.querySelector('button:last-child');
 
-			deleteBtn.firstChild.data = _('Unconfigure');
+			deleteBtn.firstChild.data = _('Delete');
 			deleteBtn.setAttribute('title', _('Remove related device settings from the configuration'));
 			deleteBtn.disabled = section_id.match(/^dev:/) ? true : null;
 


### PR DESCRIPTION
If a device is created that did not exist before, the description
deconfigure is not correct. When the 'Deconfigure' button is pressed,
the interface is deleted and removed from the list. This is not what one
would expect. Therefore, it is more appropriate to rename the button to
delete. This is rather the function that is executed when the button is
pressed. Devices that cannot be created dynamically cannot be
deconfigured and thus deleted.
![Screenshot 2022-10-27 at 14-21-31 VR2-103954 - Interfaces - LuCI](https://user-images.githubusercontent.com/553091/198282894-bef965ef-2a3b-4160-82d2-7268ba88e041.png)

