### PR TITLE
luci-app-pbr: initial commit

### DIFF
--- a/applications/luci-app-ahcp/po/vi/ahcp.po
+++ b/applications/luci-app-ahcp/po/vi/ahcp.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2020-10-26 20:34+0000\n"
-"Last-Translator: 0x2f0713 <namhaiha0308@gmail.com>\n"
+"PO-Revision-Date: 2022-11-26 06:18+0000\n"
+"Last-Translator: Minh P <phandinhminh@protonmail.ch>\n"
 "Language-Team: Vietnamese <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsahcp/vi/>\n"
 "Language: vi\n"
@@ -10,12 +10,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.3.2-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-ahcp/luasrc/controller/ahcp.lua:11
 #: applications/luci-app-ahcp/luasrc/model/cbi/ahcp.lua:4
 msgid "AHCP Server"
-msgstr "AHCP Server"
+msgstr "Máy chủ AHCP"
 
 #: applications/luci-app-ahcp/luasrc/model/cbi/ahcp.lua:4
 #, fuzzy
@@ -64,7 +64,7 @@ msgstr "Đang lấy dữ liệu..."
 
 #: applications/luci-app-ahcp/luasrc/model/cbi/admin_network/proto_ahcp.lua:55
 msgid "Disable DNS setup"
-msgstr ""
+msgstr "Tắt cài đặt DNS"
 
 #: applications/luci-app-ahcp/luasrc/model/cbi/ahcp.lua:21
 msgid "Forwarder"
@@ -76,7 +76,7 @@ msgstr "Thiết lập chung"
 
 #: applications/luci-app-ahcp/root/usr/share/rpcd/acl.d/luci-app-ahcp.json:3
 msgid "Grant UCI access for luci-app-ahcp"
-msgstr ""
+msgstr "Cấp quyền truy cập UCI cho luci-app-ahcp"
 
 #: applications/luci-app-ahcp/luasrc/model/cbi/admin_network/proto_ahcp.lua:24
 #: applications/luci-app-ahcp/luasrc/model/cbi/ahcp.lua:61

--- a/applications/luci-app-aria2/po/da/aria2.po
+++ b/applications/luci-app-aria2/po/da/aria2.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-03-26 23:10+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsaria2/da/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:433
 msgid "<abbr title=\"Local Peer Discovery\">LPD</abbr> enabled"
@@ -85,7 +85,7 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:216
 msgid "Config file directory"
-msgstr ""
+msgstr "Konfigurationsfil mappe"
 
 #: applications/luci-app-aria2/root/usr/share/luci/menu.d/luci-app-aria2.json:15
 msgid "Configuration"
@@ -167,11 +167,11 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:206
 msgid "Enabled"
-msgstr ""
+msgstr "Aktiveret"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:234
 msgid "Error"
-msgstr ""
+msgstr "Fejl"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:619
 msgid "Extra Settings"
@@ -423,11 +423,11 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:265
 msgid "RPC password"
-msgstr ""
+msgstr "RPC kodeord"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:253
 msgid "RPC port"
-msgstr ""
+msgstr "RPC port"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:293
 msgid "RPC private key"
@@ -449,7 +449,7 @@ msgstr ""
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/config.js:262
 msgid "RPC username"
-msgstr ""
+msgstr "RPC brugernavn"
 
 #: applications/luci-app-aria2/htdocs/luci-static/resources/view/aria2/log.js:62
 msgid "Refresh every %s seconds."

--- a/applications/luci-app-commands/po/zh_Hant/commands.po
+++ b/applications/luci-app-commands/po/zh_Hant/commands.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2022-05-06 11:43+0000\n"
-"Last-Translator: 王攀 <41330784@qq.com>\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: James Tien <jamestien.1219@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationscommands/zh_Hant/>\n"
 "Language: zh_Hant\n"
@@ -15,7 +15,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.12.1\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-commands/htdocs/luci-static/resources/view/commands.js:19
 msgid "A short textual description of the configured command"
@@ -57,7 +57,7 @@ msgstr "指令成功執行。"
 
 #: applications/luci-app-commands/ucode/template/commands_public.ut:34
 msgid "Command exited with status code %d"
-msgstr ""
+msgstr "指令執行完的得到的狀態碼爲%d"
 
 #: applications/luci-app-commands/ucode/template/commands.ut:67
 msgid "Command failed"

--- a/applications/luci-app-dockerman/po/da/dockerman.po
+++ b/applications/luci-app-dockerman/po/da/dockerman.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-12-03 21:07+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsdockerman/da/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.10-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/newcontainer.lua:604
 msgid "A list of kernel capabilities to add to the container"
@@ -382,7 +382,7 @@ msgstr "Gateway"
 
 #: applications/luci-app-dockerman/luasrc/model/cbi/dockerman/configuration.lua:10
 msgid "Global settings"
-msgstr ""
+msgstr "Globale indstillinger"
 
 #: applications/luci-app-dockerman/luasrc/view/dockerman/cbi/inlinevalue.htm:4
 msgid "Go to relevant configuration page"

--- a/applications/luci-app-frpc/po/da/frpc.po
+++ b/applications/luci-app-frpc/po/da/frpc.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-02-26 03:55+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsfrpc/da/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.11.1-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
 msgid "Add new proxy..."
@@ -106,7 +106,7 @@ msgstr ""
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
 msgid "Encryption"
-msgstr ""
+msgstr "Kryptering"
 
 #: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:15
 msgid "Environment variable"

--- a/applications/luci-app-https-dns-proxy/po/da/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/da/https-dns-proxy.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-10-18 21:23+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationshttps-dns-proxy/da/>\n"
@@ -473,7 +473,7 @@ msgstr "Tiarap Offentlig DNS - SG"
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.edu.tsinghua.tuna.dns.lua:3
 msgid "Tsinghua University Secure DNS - CN"
-msgstr ""
+msgstr "Tsinghua University Secure DNS - CN"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:65
 msgid "Unknown Provider"

--- a/applications/luci-app-https-dns-proxy/po/pt_BR/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/pt_BR/https-dns-proxy.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-11-05 16:57+0000\n"
+"PO-Revision-Date: 2022-11-23 11:36+0000\n"
 "Last-Translator: Wellington Terumi Uemura <wellingtonuemura@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationshttps-dns-proxy/pt_BR/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.14.2\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:92
 msgid "%s DoH at %s:%s"
@@ -501,7 +501,7 @@ msgstr "e"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:101
 msgid "disabled"
-msgstr "desabilitado"
+msgstr "desativado"
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.rubyfish.dns.lua:3
 msgid "rubyfish.cn"

--- a/applications/luci-app-https-dns-proxy/po/zh_Hant/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/zh_Hant/https-dns-proxy.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2022-10-18 16:08+0000\n"
-"Last-Translator: Hulen <shift0106@gmail.com>\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: James Tien <jamestien.1219@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationshttps-dns-proxy/zh_Hant/>\n"
 "Language: zh_Hant\n"
@@ -500,7 +500,7 @@ msgstr "和"
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:101
 msgid "disabled"
-msgstr "已停用"
+msgstr "已禁用"
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.rubyfish.dns.lua:3
 msgid "rubyfish.cn"

--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -1,0 +1,17 @@
+# Copyright 2017-2022 Stan Grishin (stangri@melmac.ca)
+# This is free software, licensed under the GNU General Public License v3.
+
+include $(TOPDIR)/rules.mk
+
+PKG_LICENSE:=GPL-3.0-or-later
+PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
+PKG_VERSION:=0.9.9-45
+
+LUCI_TITLE:=Policy Based Routing Service Web UI
+LUCI_DESCRIPTION:=Provides Web UI for Policy Based Routing Service.
+LUCI_DEPENDS:=+luci-mod-admin-full +jsonfilter +pbr
+LUCI_PKGARCH:=all
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js
@@ -1,0 +1,313 @@
+// Copyright 2022 Stan Grishin <stangri@melmac.ca>
+// This code wouldn't have been possible without help from [@vsviridov](https://github.com/vsviridov)
+
+"require ui";
+"require rpc";
+"require uci";
+"require form";
+"require baseclass";
+
+var pkg = {
+	get Name() {
+		return "pbr";
+	},
+	get URL() {
+		return "https://docs.openwrt.melmac.net/" + pkg.Name + "/";
+	},
+};
+
+var getGateways = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getGateways",
+	params: ["name"],
+});
+
+var getInitList = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getInitList",
+	params: ["name"],
+});
+
+var getInitStatus = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getInitStatus",
+	params: ["name"],
+});
+
+var getInterfaces = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getInterfaces",
+	params: ["name"],
+});
+
+var getPlatformSupport = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getPlatformSupport",
+	params: ["name"],
+});
+
+var _setInitAction = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "setInitAction",
+	params: ["name", "action"],
+	expect: { result: false },
+});
+
+var RPC = {
+	listeners: [],
+	on: function on(event, callback) {
+		var pair = { event: event, callback: callback }
+		this.listeners.push(pair);
+		return function unsubscribe() {
+			this.listeners = this.listeners.filter(function (listener) {
+				return listener !== pair;
+			});
+		}.bind(this);
+	},
+	emit: function emit(event, data) {
+		this.listeners.forEach(function (listener) {
+			if (listener.event === event) {
+				listener.callback(data);
+			}
+		});
+	},
+	getInitList: function getInitList(name) {
+		getInitList(name).then(function (result) {
+			this.emit('getInitList', result);
+		}.bind(this));
+	},
+	getInitStatus: function getInitStatus(name) {
+		getInitStatus(name).then(function (result) {
+			this.emit('getInitStatus', result);
+		}.bind(this));
+	},
+	getGateways: function getGateways(name) {
+		getGateways(name).then(function (result) {
+			this.emit('getGateways', result);
+		}.bind(this));
+	},
+	getPlatformSupport: function getPlatformSupport(name) {
+		getPlatformSupport(name).then(function (result) {
+			this.emit('getPlatformSupport', result);
+		}.bind(this));
+	},
+	getInterfaces: function getInterfaces(name) {
+		getInterfaces(name).then(function (result) {
+			this.emit('getInterfaces', result);
+		}.bind(this));
+	},
+	setInitAction: function setInitAction(name, action) {
+		_setInitAction(name, action).then(function (result) {
+			this.emit('setInitAction', result);
+		}.bind(this));
+	},
+}
+
+var status = baseclass.extend({
+	render: function () {
+		return Promise.all([
+			L.resolveDefault(getInitStatus(), {}),
+//			L.resolveDefault(getGateways(), {}),
+		]).then(function (data) {
+//			var replyStatus = data[0];
+//			var replyGateways = data[1];
+			var reply = data[0][pkg.Name];
+			var text;
+			var header = E('h2', {}, _("Policy Based Routing - Status"));
+			var statusTitle = E('label', { class: 'cbi-value-title' }, _("Service Status"));
+			if (reply.version) {
+				if (reply.running) {
+					if (reply.running_iptables) {
+						text = _("Running (version: %s using iptables)").format(reply.version);
+					}
+					else if (reply.running_nft) {
+						text = _("Running (version: %s using nft)").format(reply.version);
+					}
+					else {
+						text = _("Running (version: %s)").format(reply.version);
+					}
+				}
+				else {
+					if (reply.enabled) {
+						text = _("Stopped (version: %s)").format(reply.version);
+					}
+					else {
+						text = _("Stopped (Disabled)");
+					}
+				}
+			}
+			else {
+				text = _("Not installed or not found");
+			}
+			var statusText = E('div', {}, text);
+			var statusField = E('div', { class: 'cbi-value-field' }, statusText);
+			var statusDiv = E('div', { class: 'cbi-value' }, [statusTitle, statusField]);
+
+			var gatewaysDiv = [];
+			if (reply.gateways) {
+				var gatewaysTitle = E('label', { class: 'cbi-value-title' }, _("Service Gateways"));
+				text = _("The %s indicates default gateway. See the %sREADME%s for details.").format("<strong>✓</strong>",
+					"<a href=\"" + pkg.URL + "#a-word-about-default-routing \" target=\"_blank\">", "</a>")
+				var gatewaysDescr = E('div', { class: 'cbi-value-description' }, text);
+				var gatewaysText = E('div', {}, reply.gateways);
+				var gatewaysField = E('div', { class: 'cbi-value-field' }, [gatewaysText, gatewaysDescr]);
+				gatewaysDiv = E('div', { class: 'cbi-value' }, [gatewaysTitle, gatewaysField]);
+			}
+
+			var warningsDiv = [];
+			if (reply.warnings && reply.warnings.length) {
+				var textLabelsTable = {
+					warningResolverNotSupported: _("Resolver set (%s) is not supported on this system.").format(uci.get(pkg.Name, 'config', 'resolver_set')),
+					warningAGHVersionTooLow: _("Installed AdGuardHome (%s) doesn't support 'ipset_file' option."),
+					warningPolicyProcess: _("%s")
+				};
+				var warningsTitle = E('label', { class: 'cbi-value-title' }, _("Service Warnings"));
+				var text = "";
+				(reply.warnings).forEach(element => {
+					text += (textLabelsTable[element.id]).format(element.extra || ' ') + "<br />";
+				});
+				var warningsText = E('div', {}, text);
+				var warningsField = E('div', { class: 'cbi-value-field' }, warningsText);
+				warningsDiv = E('div', { class: 'cbi-value' }, [warningsTitle, warningsField]);
+			}
+
+			var errorsDiv = [];
+			if (reply.errors && reply.errors.length) {
+				var textLabelsTable = {
+					errorConfigValidation: _("Config (%s) validation failure!").format('/etc/config/' + pkg.Name),
+					errorNoIpFull: _("ip-full binary cannot be found!"),
+					errorNoIpset: _("Resolver set support (%s) requires ipset, but ipset binary cannot be found!").format(uci.get(pkg.Name, 'config', 'resolver_set')),
+					errorNoNft: _("Resolver set support (%s) requires nftables, but nft binary cannot be found!").format(uci.get(pkg.Name, 'config', 'resolver_set')),
+					errorResolverNotSupported: _("Resolver set (%s) is not supported on this system!").format(uci.get(pkg.Name, 'config', 'resolver_set')),
+					errorServiceDisabled: _("The %s service is currently disabled!").format(pkg.Name),
+					errorNoWanGateway: _("The %s service failed to discover WAN gateway!").format(pkg.Name),
+					errorIpsetNameTooLong: _("The ipset name '%s' is longer than allowed 31 characters!"),
+					errorNftsetNameTooLong: _("The nft set name '%s' is longer than allowed 31 characters!"),
+					errorUnexpectedExit: _("Unexpected exit or service termination: '%s'!"),
+					errorPolicyNoSrcDest: _("Policy '%s' has no source/destination parameters!"),
+					errorPolicyNoInterface: _("Policy '%s' has no assigned interface!"),
+					errorPolicyUnknownInterface: _("Policy '%s' has an unknown interface!"),
+					errorPolicyProcess: _("%s"),
+					errorFailedSetup: _("Failed to set up '%s'!"),
+					errorFailedReload: _("Failed to reload '%s'!"),
+					errorUserFileNotFound: _("Custom user file '%s' not found or empty!"),
+					ererrorUserFileSyntax: _("Syntax error in custom user file '%s'!"),
+					errorUserFileRunning: _("Error running custom user file '%s'!"),
+					errorUserFileNoCurl: _("Use of 'curl' is detected in custom user file '%s', but 'curl' isn't installed!"),
+					errorNoGateways: _("Failed to set up any gateway!")
+				};
+				var errorsTitle = E('label', { class: 'cbi-value-title' }, _("Service Errors"));
+				var text = "";
+				(reply.errors).forEach(element => {
+					text += (textLabelsTable[element.id]).format(element.extra || ' ') + "<br />";
+				});
+				var errorsText = E('div', {}, text);
+				var errorsField = E('div', { class: 'cbi-value-field' }, errorsText);
+				errorsDiv = E('div', { class: 'cbi-value' }, [errorsTitle, errorsField]);
+			}
+
+			var btn_gap = E('span', {}, '&#160;&#160;');
+			var btn_gap_long = E('span', {}, '&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;');
+
+			var btn_start = E('button', {
+				'class': 'btn cbi-button cbi-button-apply',
+				disabled: true,
+				click: function (ev) {
+					ui.showModal(null, [
+						E('p', { 'class': 'spinning' }, _('Starting %s service').format(pkg.Name))
+					]);
+					return RPC.setInitAction(pkg.Name, 'start');
+				}
+			}, _('Start'));
+
+			var btn_action = E('button', {
+				'class': 'btn cbi-button cbi-button-apply',
+				disabled: true,
+				click: function (ev) {
+					ui.showModal(null, [
+						E('p', { 'class': 'spinning' }, _('Restarting %s service').format(pkg.Name))
+					]);
+					return RPC.setInitAction(pkg.Name, 'restart');
+				}
+			}, _('Restart'));
+
+			var btn_stop = E('button', {
+				'class': 'btn cbi-button cbi-button-reset',
+				disabled: true,
+				click: function (ev) {
+					ui.showModal(null, [
+						E('p', { 'class': 'spinning' }, _('Stopping %s service').format(pkg.Name))
+					]);
+					return RPC.setInitAction(pkg.Name, 'stop');
+				}
+			}, _('Stop'));
+
+			var btn_enable = E('button', {
+				'class': 'btn cbi-button cbi-button-apply',
+				disabled: true,
+				click: function (ev) {
+					ui.showModal(null, [
+						E('p', { 'class': 'spinning' }, _('Enabling %s service').format(pkg.Name))
+					]);
+					return RPC.setInitAction(pkg.Name, 'enable');
+				}
+			}, _('Enable'));
+
+			var btn_disable = E('button', {
+				'class': 'btn cbi-button cbi-button-reset',
+				disabled: true,
+				click: function (ev) {
+					ui.showModal(null, [
+						E('p', { 'class': 'spinning' }, _('Disabling %s service').format(pkg.Name))
+					]);
+					return RPC.setInitAction(pkg.Name, 'disable');
+				}
+			}, _('Disable'));
+
+			if (reply.enabled) {
+				btn_enable.disabled = true;
+				btn_disable.disabled = false;
+				if (reply.running) {
+					btn_start.disabled = true;
+					btn_action.disabled = false;
+					btn_stop.disabled = false;
+				}
+				else {
+					btn_start.disabled = false;
+					btn_action.disabled = true;
+					btn_stop.disabled = true;
+				}
+			}
+			else {
+				btn_start.disabled = true;
+				btn_action.disabled = true;
+				btn_stop.disabled = true;
+				btn_enable.disabled = false;
+				btn_disable.disabled = true;
+			}
+
+			var buttonsTitle = E('label', { class: 'cbi-value-title' }, _("Service Control"))
+			var buttonsText = E('div', {}, [btn_start, btn_gap, btn_action, btn_gap, btn_stop, btn_gap_long, btn_enable, btn_gap, btn_disable]);
+			var buttonsField = E('div', { class: 'cbi-value-field' }, buttonsText);
+			if (reply.version) {
+				var buttonsDiv = E('div', { class: 'cbi-value' }, [buttonsTitle, buttonsField]);
+			}
+			else {
+				var buttonsDiv = [];
+			}
+
+			return E('div', {}, [header, statusDiv, gatewaysDiv, warningsDiv, errorsDiv, buttonsDiv]);
+		});
+	},
+});
+
+RPC.on('setInitAction', function (reply) {
+	ui.hideModal();
+	location.reload();
+});
+
+return L.Class.extend({
+	status: status,
+	getInterfaces: getInterfaces,
+	getPlatformSupport: getPlatformSupport
+});

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
@@ -1,0 +1,246 @@
+// Copyright 2022 Stan Grishin <stangri@melmac.ca>
+// This code wouldn't have been possible without help from [@vsviridov](https://github.com/vsviridov)
+
+'use strict';
+'require form';
+'require rpc';
+'require uci';
+'require view';
+'require pbr.status as pbr';
+
+var pkg = {
+	get Name() { return 'pbr'; },
+	get URL() { return 'https://docs.openwrt.melmac.net/' + pkg.Name + '/'; }
+};
+
+return view.extend({
+	load: function () {
+		return Promise.all([
+			uci.load(pkg.Name)
+		]);
+	},
+
+	render: function () {
+		return Promise.all([
+			L.resolveDefault(pbr.getInterfaces(), {}),
+			L.resolveDefault(pbr.getPlatformSupport(), {}),
+		]).then(function (data) {
+			var arrInterfaces = data[0][pkg.Name].interfaces;
+			var replyPlatform = data[1][pkg.Name];
+			var status, m, s, o;
+
+			status = new pbr.status();
+			m = new form.Map(pkg.Name, _("Policy Based Routing - Configuration"));
+
+			s = m.section(form.NamedSection, 'config', pkg.Name);
+			s.tab("tab_basic", _("Basic Configuration"));
+			s.tab("tab_advanced", _("Advanced Configuration"),
+				_("%sWARNING:%s Please make sure to check the %sREADME%s before changing anything in this section! " +
+					"Change any of the settings below with extreme caution!%s").format(
+						"<br/>&#160;&#160;&#160;&#160;<b>", "</b>",
+						"<a href=\"" + pkg.URL + "#service-configuration-settings \" target=\"_blank\">", "</a>", "<br/><br/>"));
+			s.tab("tab_webui", _("Web UI Configuration"))
+
+			o = s.taboption("tab_basic", form.ListValue, "verbosity", _("Output verbosity"),
+				_("Controls both system log and console output verbosity."));
+			o.value("0", _("Suppress/No output"));
+			o.value("1", _("Condensed output"));
+			o.value("2", _("Verbose output"));
+			o.default = "2";
+
+			o = s.taboption("tab_basic", form.ListValue, "strict_enforcement", _("Strict enforcement"),
+				_("See the %sREADME%s for details.").format(
+					"<a href=\"" + pkg.URL + "#strict-enforcement\" target=\"_blank\">", "</a>"));
+			o.value("0", _("Do not enforce policies when their gateway is down"));
+			o.value("1", _("Strictly enforce policies when their gateway is down"));
+			o.default = "1";
+
+			var text = "";
+			if (!(replyPlatform.adguardhome_ipset_support)) {
+				text += _("Please note that %s is not supported on this system.").format("<i>adguardhome.ipset</i>") + "<br />"
+			}
+			if (!(replyPlatform.dnsmasq_ipset_support)) {
+				text += _("Please note that %s is not supported on this system.").format("<i>dnsmasq.ipset</i>") + "<br />"
+			}
+			if (!(replyPlatform.dnsmasq_nftset_support)) {
+				text += _("Please note that %s is not supported on this system.").format("<i>dnsmasq.nftset</i>") + "<br />"
+			}
+			text += _("Please check the %sREADME%s before changing this option.").format(
+				"<a href=\"" + pkg.URL + "#use-resolvers-set-support\" target=\"_blank\">", "</a>");
+			o = s.taboption("tab_basic", form.ListValue, "resolver_set", _("Use resolver set support for domains"), text);
+			o.value("none", _("Disabled"));
+			if (replyPlatform.adguardhome_ipset_support) {
+				o.value("adguardhome.ipset", _("AdGuardHome ipset"));
+				o.default = ("adguardhome.ipset", _("AdGuardHome ipset"));
+			}
+			if (replyPlatform.dnsmasq_ipset_support) {
+				o.value("dnsmasq.ipset", _("Dnsmasq ipset"));
+				o.default = ("dnsmasq.ipset", _("Dnsmasq ipset"));
+			}
+			if (replyPlatform.dnsmasq_nftset_support) {
+				o.value("dnsmasq.nftset", _("Dnsmasq nft set"));
+				o.default = ("dnsmasq.nftset", _("Dnsmasq nft set"));
+			}
+
+			o = s.taboption("tab_basic", form.ListValue, "ipv6_enabled", _("IPv6 Support"));
+			o.value("0", _("Disabled"));
+			o.value("1", _("Enabled"));
+
+			o = s.taboption("tab_advanced", form.DynamicList, "supported_interface", _("Supported Interfaces"),
+				_("Allows to specify the list of interface names (in lower case) to be explicitly supported by the service. " +
+					"Can be useful if your OpenVPN tunnels have dev option other than tun* or tap*."));
+			o.optional = false;
+
+			o = s.taboption("tab_advanced", form.DynamicList, "ignored_interface", _("Ignored Interfaces"),
+				_("Allows to specify the list of interface names (in lower case) to be ignored by the service. " +
+					"Can be useful if running both VPN server and VPN client on the router."));
+			o.optional = false;
+
+			o = s.taboption("tab_advanced", form.ListValue, "rule_create_option", _("Rule Create option"),
+				_("Select Add for -A/add and Insert for -I/Insert."));
+			o.value("add", _("Add"));
+			o.value("insert", _("Insert"));
+			o.default = "add";
+
+			o = s.taboption("tab_advanced", form.ListValue, "icmp_interface", _("Default ICMP Interface"),
+				_("Force the ICMP protocol interface."));
+			o.value("", _("No Change"));
+			arrInterfaces.forEach(element => {
+				if (element.toLowerCase() !== "ignore") {
+					o.value(element);
+				}
+			});
+			o.rmempty = true;
+
+			o = s.taboption("tab_advanced", form.Value, "wan_tid", _("WAN Table ID"),
+				_("Starting (WAN) Table ID number for tables created by the service."));
+			o.rmempty = true;
+			o.placeholder = "201";
+			o.datatype = "and(uinteger, min(201))";
+
+			o = s.taboption("tab_advanced", form.Value, "wan_mark", _("WAN Table FW Mark"),
+				_("Starting (WAN) FW Mark for marks used by the service. High starting mark is " +
+					"used to avoid conflict with SQM/QoS. Change with caution together with") +
+				" " + _("Service FW Mask") + ".");
+			o.rmempty = true;
+			o.placeholder = "010000";
+			o.datatype = "hexstring";
+
+			o = s.taboption("tab_advanced", form.Value, "fw_mask", _("Service FW Mask"),
+				_("FW Mask used by the service. High mask is used to avoid conflict with SQM/QoS. " +
+					"Change with caution together with") + " " + _("WAN Table FW Mark") + ".");
+			o.rmempty = true;
+			o.placeholder = "ff0000";
+			o.datatype = "hexstring";
+
+			o = s.taboption("tab_webui", form.ListValue, "webui_show_ignore_target", _("Add Ignore Target"),
+				_("Adds 'ignore' to the list of interfaces for policies. See the %sREADME%s for details.").format(
+					"<a href=\"" + pkg.URL + "#ignore-target\" target=\"_blank\">", "</a>"));
+			o.value("0", _("Disabled"))
+			o.value("1", _("Enabled"))
+			o.default = "0";
+			o.optional = false;
+
+			o = s.taboption("tab_webui", form.DynamicList, "webui_supported_protocol", _("Supported Protocols"),
+				_("Display these protocols in protocol column in Web UI."));
+			o.optional = false;
+
+			s = m.section(form.GridSection, 'policy', _('Policies'),
+				_("Name, interface and at least one other field are required. Multiple local and remote " +
+					"addresses/devices/domains and ports can be space separated. Placeholders below represent just " +
+					"the format/syntax and will not be used if fields are left blank."));
+			s.rowcolors = true;
+			s.sortable = true;
+			s.anonymous = true;
+			s.addremove = true;
+
+			o = s.option(form.Flag, "enabled", _("Enabled"));
+			o.default = "1";
+			o.editable = true;
+
+			o = s.option(form.Value, "name", _("Name"));
+
+			o = s.option(form.Value, "src_addr", _("Local addresses / devices"));
+			o.datatype = "list(neg(or(cidr,host,ipmask,ipaddr,macaddr,network)))";
+			o.rmempty = true;
+			o.default = "";
+
+			o = s.option(form.Value, "src_port", _("Local ports"));
+			o.datatype = "list(neg(or(portrange,port)))";
+			o.placeholder = "0-65535";
+			o.rmempty = true;
+			o.default = "";
+
+			o = s.option(form.Value, "dest_addr", _("Remote addresses / domains"));
+			o.datatype = "list(neg(or(cidr,host,ipmask,ipaddr,macaddr,network)))";
+			o.rmempty = true;
+			o.default = "";
+
+			o = s.option(form.Value, "dest_port", _("Remote ports"));
+			o.datatype = "list(neg(or(portrange,port)))";
+			o.placeholder = "0-65535";
+			o.rmempty = true;
+			o.default = "";
+
+			o = s.option(form.ListValue, "proto", _("Protocol"));
+			var proto = L.toArray(uci.get(pkg.Name, "config", "webui_supported_protocol"));
+			if (!proto.length) {
+				proto = ["all", "tcp", "udp", "tcp udp", "icmp"]
+			}
+			proto.forEach(element => {
+				if (element === "all") {
+					o.value("", _("all"));
+					o.default = ("", _("all"));
+				}
+				else {
+					o.value(element.toLowerCase());
+				}
+			});
+			o.rmempty = true;
+
+			o = s.option(form.ListValue, "chain", _("Chain"));
+			o.value("", "prerouting");
+			o.value("forward", "forward");
+			o.value("input", "input");
+			o.value("output", "output");
+			o.value("postrouting", "postrouting");
+			o.default = ("", "prerouting");
+			o.rmempty = true;
+
+			o = s.option(form.ListValue, "interface", _("Interface"));
+			arrInterfaces.forEach(element => {
+				o.value(element);
+			});
+			o.datatype = "network";
+			o.rmempty = false;
+
+			s = m.section(form.NamedSection, 'config', pkg.Name, _("DSCP Tagging"),
+				_("Set DSCP tags (in range between 1 and 63) for specific interfaces. See the %sREADME%s for details.").format(
+					"<a href=\"" + pkg.URL + "#dscp-tag-based-policies" + "\" target=\"_blank\">", "</a>"));
+			arrInterfaces.forEach(element => {
+				if (element.toLowerCase() !== "ignore") {
+					o = s.option(form.Value, element + "_dscp", element.toUpperCase() + " " + _("DSCP Tag"));
+					o.datatype = "and(uinteger, min(1), max(63))";
+				}
+			});
+
+			s = m.section(form.GridSection, 'include', _("Custom User File Includes"),
+				_("Run the following user files after setting up but before restarting DNSMASQ. " +
+					"See the %sREADME%s for details.").format(
+						"<a href=\"" + pkg.URL + "#custom-user-files\" target=\"_blank\">", "</a>"));
+			s.sortable = true;
+			s.anonymous = true;
+			s.addremove = true;
+
+			o = s.option(form.Flag, "enabled", _("Enabled"));
+			o.optional = false;
+			o.editable = true;
+
+			o = s.option(form.Value, "path", _("Path"));
+			o.optional = false;
+			o.editable = true;
+
+			return Promise.all([status.render(), m.render()]);
+		})
+	}
+});

--- a/applications/luci-app-pbr/po/templates/pbr.pot
+++ b/applications/luci-app-pbr/po/templates/pbr.pot
@@ -1,0 +1,479 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:162
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:190
+msgid "%s"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:38
+msgid ""
+"%sWARNING:%s Please make sure to check the %sREADME%s before changing "
+"anything in this section! Change any of the settings below with extreme "
+"caution!%s"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:73
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:74
+msgid "AdGuardHome ipset"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:101
+msgid "Add"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:136
+msgid "Add Ignore Target"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:137
+msgid ""
+"Adds 'ignore' to the list of interfaces for policies. See the %sREADME%s for "
+"details."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:37
+msgid "Advanced Configuration"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:90
+msgid ""
+"Allows to specify the list of interface names (in lower case) to be "
+"explicitly supported by the service. Can be useful if your OpenVPN tunnels "
+"have dev option other than tun* or tap*."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:95
+msgid ""
+"Allows to specify the list of interface names (in lower case) to be ignored "
+"by the service. Can be useful if running both VPN server and VPN client on "
+"the router."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:36
+msgid "Basic Configuration"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:201
+msgid "Chain"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:47
+msgid "Condensed output"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:177
+msgid "Config (%s) validation failure!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:45
+msgid "Controls both system log and console output verbosity."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:227
+msgid "Custom User File Includes"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:193
+msgid "Custom user file '%s' not found or empty!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:222
+msgid "DSCP Tag"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:217
+msgid "DSCP Tagging"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:105
+msgid "Default ICMP Interface"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:265
+msgid "Disable"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:71
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:86
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:139
+msgid "Disabled"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:261
+msgid "Disabling %s service"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:145
+msgid "Display these protocols in protocol column in Web UI."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:77
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:78
+msgid "Dnsmasq ipset"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:81
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:82
+msgid "Dnsmasq nft set"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:54
+msgid "Do not enforce policies when their gateway is down"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:254
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:87
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:140
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:157
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:235
+msgid "Enabled"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:250
+msgid "Enabling %s service"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:195
+msgid "Error running custom user file '%s'!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:130
+msgid ""
+"FW Mask used by the service. High mask is used to avoid conflict with SQM/"
+"QoS. Change with caution together with"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:192
+msgid "Failed to reload '%s'!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:191
+msgid "Failed to set up '%s'!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:197
+msgid "Failed to set up any gateway!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:106
+msgid "Force the ICMP protocol interface."
+msgstr ""
+
+#: applications/luci-app-pbr/root/usr/share/rpcd/acl.d/luci-app-pbr.json:3
+msgid "Grant UCI and file access for luci-app-pbr"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:85
+msgid "IPv6 Support"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:94
+msgid "Ignored Interfaces"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:102
+msgid "Insert"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:161
+msgid "Installed AdGuardHome (%s) doesn't support 'ipset_file' option."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:210
+msgid "Interface"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:163
+msgid "Local addresses / devices"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:168
+msgid "Local ports"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:161
+msgid "Name"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:149
+msgid ""
+"Name, interface and at least one other field are required. Multiple local "
+"and remote addresses/devices/domains and ports can be space separated. "
+"Placeholders below represent just the format/syntax and will not be used if "
+"fields are left blank."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:107
+msgid "No Change"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:140
+msgid "Not installed or not found"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:44
+msgid "Output verbosity"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:239
+msgid "Path"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:68
+msgid "Please check the %sREADME%s before changing this option."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:60
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:63
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:66
+msgid "Please note that %s is not supported on this system."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:148
+msgid "Policies"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:189
+msgid "Policy '%s' has an unknown interface!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:188
+msgid "Policy '%s' has no assigned interface!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:187
+msgid "Policy '%s' has no source/destination parameters!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:33
+msgid "Policy Based Routing - Configuration"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:116
+msgid "Policy Based Routing - Status"
+msgstr ""
+
+#: applications/luci-app-pbr/root/usr/share/luci/menu.d/luci-app-pbr.json:3
+msgid "Policy Routing"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:185
+msgid "Protocol"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:174
+msgid "Remote addresses / domains"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:179
+msgid "Remote ports"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:181
+msgid "Resolver set (%s) is not supported on this system!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:160
+msgid "Resolver set (%s) is not supported on this system."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:179
+msgid ""
+"Resolver set support (%s) requires ipset, but ipset binary cannot be found!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:180
+msgid ""
+"Resolver set support (%s) requires nftables, but nft binary cannot be found!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:232
+msgid "Restart"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:228
+msgid "Restarting %s service"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:99
+msgid "Rule Create option"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:228
+msgid ""
+"Run the following user files after setting up but before restarting DNSMASQ. "
+"See the %sREADME%s for details."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:121
+msgid "Running (version: %s using iptables)"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:124
+msgid "Running (version: %s using nft)"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:127
+msgid "Running (version: %s)"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:52
+msgid "See the %sREADME%s for details."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:100
+msgid "Select Add for -A/add and Insert for -I/Insert."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:289
+msgid "Service Control"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:199
+msgid "Service Errors"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:124
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:129
+msgid "Service FW Mask"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:148
+msgid "Service Gateways"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:117
+msgid "Service Status"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:164
+msgid "Service Warnings"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:218
+msgid ""
+"Set DSCP tags (in range between 1 and 63) for specific interfaces. See the "
+"%sREADME%s for details."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:221
+msgid "Start"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:217
+msgid "Starting %s service"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:122
+msgid ""
+"Starting (WAN) FW Mark for marks used by the service. High starting mark is "
+"used to avoid conflict with SQM/QoS. Change with caution together with"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:116
+msgid "Starting (WAN) Table ID number for tables created by the service."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:243
+msgid "Stop"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:135
+msgid "Stopped (Disabled)"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:132
+msgid "Stopped (version: %s)"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:239
+msgid "Stopping %s service"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:51
+msgid "Strict enforcement"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:55
+msgid "Strictly enforce policies when their gateway is down"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:89
+msgid "Supported Interfaces"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:144
+msgid "Supported Protocols"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:46
+msgid "Suppress/No output"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:194
+msgid "Syntax error in custom user file '%s'!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:149
+msgid "The %s indicates default gateway. See the %sREADME%s for details."
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:183
+msgid "The %s service failed to discover WAN gateway!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:182
+msgid "The %s service is currently disabled!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:184
+msgid "The ipset name '%s' is longer than allowed 31 characters!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:185
+msgid "The nft set name '%s' is longer than allowed 31 characters!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:186
+msgid "Unexpected exit or service termination: '%s'!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:196
+msgid ""
+"Use of 'curl' is detected in custom user file '%s', but 'curl' isn't "
+"installed!"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:70
+msgid "Use resolver set support for domains"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:48
+msgid "Verbose output"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:121
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:131
+msgid "WAN Table FW Mark"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:115
+msgid "WAN Table ID"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:42
+msgid "Web UI Configuration"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:192
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:193
+msgid "all"
+msgstr ""
+
+#: applications/luci-app-pbr/htdocs/luci-static/resources/pbr/status.js:178
+msgid "ip-full binary cannot be found!"
+msgstr ""

--- a/applications/luci-app-pbr/root/etc/uci-defaults/40_luci-pbr
+++ b/applications/luci-app-pbr/root/etc/uci-defaults/40_luci-pbr
@@ -1,0 +1,4 @@
+#!/bin/sh
+rm -rf /var/luci-modulecache/; rm -f /var/luci-indexcache;
+[ -x /etc/init.d/rpcd ] && /etc/init.d/rpcd reload;
+exit 0

--- a/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
+++ b/applications/luci-app-pbr/root/usr/libexec/rpcd/luci.pbr
@@ -1,0 +1,373 @@
+#!/bin/sh
+# Copyright 2022 Stan Grishin (stangri@melmac.ca)
+# shellcheck disable=SC1091,SC2018,SC2019,SC2039,SC3043,SC3057,SC3060
+
+# TechRef: https://openwrt.org/docs/techref/rpcd
+# TESTS
+# ubus -v list luci.pbr
+# ubus -S call luci.pbr getInitList '{"name": "pbr" }'
+# ubus -S call luci.pbr getInitStatus '{"name": "pbr" }'
+# ubus -S call luci.pbr getPlatformSupport '{"name": "pbr" }'
+# ubus -S call luci.pbr getGateways '{"name": "pbr" }'
+# ubus -S call luci.pbr getInterfaces '{"name": "pbr" }'
+
+. /lib/functions.sh
+. /lib/functions/network.sh
+. /usr/share/libubox/jshn.sh
+
+readonly packageName="pbr"
+# shellcheck disable=SC2155
+readonly ipset="$(command -v ipset)"
+# shellcheck disable=SC2155
+readonly agh="$(command -v AdGuardHome)"
+readonly aghConfigFile='/etc/adguardhome.yaml'
+# shellcheck disable=SC2155
+readonly nft="$(command -v nft)"
+
+is_enabled() { uci -q get "${1}.config.enabled"; }
+is_running_iptables() { iptables -t mangle -L | grep -q PBR_PREROUTING >/dev/null 2>&1; }
+is_running_nft() { "$nft" list table inet fw4 | grep chain | grep -q pbr_mark_ >/dev/null 2>&1; }
+is_running() { is_running_iptables || is_running_nft; }
+get_version() { grep -m1 -A2 -w "^Package: $1$" /usr/lib/opkg/status | sed -n 's/Version: //p'; }
+print_json_bool() { json_init; json_add_boolean "$1" "$2"; json_dump; json_cleanup; }
+print_json_string() { json_init; json_add_string "$1" "$2"; json_dump; json_cleanup; }
+logger() { /usr/bin/logger -t "$packageName" "$@"; }
+ubus_get_status() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances.main.data.status.${1}"; }
+ubus_get_gateway() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances.main.data.gateways[@.name='${1}']${2:+.$2}"; }
+is_greater_or_equal() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" = "$2"; }
+
+get_init_list() {
+	local name
+	name="$(basename "$1")"
+	name="${name:-$packageName}" 
+	json_init
+	json_add_object "$name"
+	json_add_boolean 'enabled' "$(is_enabled "$name")"
+	if is_running "$name"; then
+		json_add_boolean 'running' '1'
+	else
+		json_add_boolean 'running' '0'
+	fi
+	json_close_object
+	json_dump
+	json_cleanup
+}
+
+set_init_action() {
+	local name action="$2" cmd
+	name="$(basename "$1")"
+	name="${name:-$packageName}" 
+	if [ ! -f "/etc/init.d/$name" ]; then
+		print_json_string 'error' 'Init script not found!'
+		return
+	fi
+	case $action in
+		enable)
+			cmd="uci -q set ${name}.config.enabled=1 && uci commit $name";;
+		disable)
+			cmd="uci -q set ${name}.config.enabled=0 && uci commit $name";;
+		start|stop|reload|restart)
+			cmd="/etc/init.d/${name} ${action}";;
+	esac
+	if [ -n "$cmd" ] && eval "${cmd}" 1>/dev/null 2>&1; then
+		print_json_bool "result" '1'
+	else
+		print_json_bool "result" '0'
+	fi
+}
+
+get_init_status() {
+	local name
+	name="$(basename "$1")"
+	name="${name:-$packageName}" 
+	local version gateways warnings errors
+	[ -z "$version" ] && version="$(get_version "$name")"
+	[ -z "$version" ] && version="$(get_version "${name}-iptables")"
+	[ -z "$version" ] && version="$(get_version "${name}-netifd")"
+	gateways="$(ubus_get_status gateways | sed "s|\\\n|<br />|g;s|\(\\\033[^<]*\)|✓|g;")"
+	warnings="$(ubus_get_status warnings)"
+	errors="$(ubus_get_status errors)"
+	json_init
+	json_add_object  "$name"
+	json_add_boolean 'enabled' "$(is_enabled "$name")"
+	if is_running "$name"; then
+		json_add_boolean 'running' '1'
+	else
+		json_add_boolean 'running' '0'
+	fi
+	if is_running_iptables "$name"; then
+		json_add_boolean 'running_iptables' '1'
+	else
+		json_add_boolean 'running_iptables' '0'
+	fi
+	if is_running_nft "$name"; then
+		json_add_boolean 'running_nft' '1'
+	else
+		json_add_boolean 'running_nft' '0'
+	fi
+	json_add_string 'version' "$version"
+	json_add_string 'gateways' "$gateways"
+	json_add_array 'errors'
+	if [ -n "$errors" ]; then
+		while read -r line; do
+			if str_contains "$line" ' '; then
+				error_id="${line% *}"
+				error_extra="${line#* }"
+			else
+				error_id="$line"
+				unset error_extra
+			fi
+			json_add_object
+			json_add_string 'id' "$error_id"
+			json_add_string 'extra' "$error_extra"
+			json_close_object
+		done <<EOF
+$(echo "$errors" | tr \# \\n)
+EOF
+	fi
+	json_close_array
+	json_add_array 'warnings'
+	if [ -n "$warnings" ]; then
+		while read -r line; do
+			if str_contains "$line" ' '; then
+				error_id="${line% *}"
+				error_extra="${line#* }"
+			else
+				error_id="$line"
+				unset error_extra
+			fi
+			json_add_object
+			json_add_string 'id' "$error_id"
+			json_add_string 'extra' "$error_extra"
+			json_close_object
+		done <<EOF
+$(echo "$warnings" | tr \# \\n)
+EOF
+	fi
+	json_close_array
+	json_close_object
+	json_dump
+	json_cleanup
+}
+
+check_ipset() { { [ -n "$ipset" ] && "$ipset" help hash:net; } >/dev/null 2>&1; }
+check_nft() { [ -n "$nft" ]; }
+check_agh() { [ -n "$agh" ] && [ -s "$aghConfigFile" ]; }
+check_dnsmasq() { command -v dnsmasq >/dev/null 2>&1; }
+check_unbound() { command -v unbound >/dev/null 2>&1; }
+check_agh_ipset() {
+	check_ipset || return 1
+	check_agh || return 1
+	is_greater_or_equal "$($agh --version | sed 's|AdGuard Home, version v\(.*\)|\1|')" '0.107.13'
+}
+check_dnsmasq_ipset() {
+	local o;
+	check_ipset || return 1
+	check_dnsmasq || return 1
+	o="$(dnsmasq -v 2>/dev/null)"
+	! echo "$o" | grep -q 'no-ipset' && echo "$o" | grep -q 'ipset'
+}
+check_dnsmasq_nftset() {
+	local o;
+	check_nft || return 1
+	check_dnsmasq || return 1
+	o="$(dnsmasq -v 2>/dev/null)"
+	! echo "$o" | grep -q 'no-nftset' && echo "$o" | grep -q 'nftset'
+}
+
+get_platform_support() {
+	local name
+	name="$(basename "$1")"
+	name="${name:-$packageName}" 
+	json_init
+	json_add_object "$name"
+	if check_ipset; then
+		json_add_boolean 'ipset_installed' '1'
+	else
+		json_add_boolean 'ipset_installed' '0'
+	fi
+	if check_nft; then
+		json_add_boolean 'nft_installed' '1'
+	else
+		json_add_boolean 'nft_installed' '0'
+	fi
+	if check_agh; then
+		json_add_boolean 'adguardhome_installed' '1'
+	else
+		json_add_boolean 'adguardhome_installed' '0'
+	fi
+	if check_dnsmasq; then
+		json_add_boolean 'dnsmasq_installed' '1'
+	else
+		json_add_boolean 'dnsmasq_installed' '0'
+	fi
+	if check_unbound; then
+		json_add_boolean 'unbound_installed' '1'
+	else
+		json_add_boolean 'unbound_installed' '0'
+	fi
+	if check_agh_ipset; then
+		json_add_boolean 'adguardhome_ipset_support' '1'
+	else
+		json_add_boolean 'adguardhome_ipset_support' '0'
+	fi
+	if check_dnsmasq_ipset; then
+		json_add_boolean 'dnsmasq_ipset_support' '1'
+	else
+		json_add_boolean 'dnsmasq_ipset_support' '0'
+	fi
+	if check_dnsmasq_nftset; then
+		json_add_boolean 'dnsmasq_nftset_support' '1'
+	else
+		json_add_boolean 'dnsmasq_nftset_support' '0'
+	fi
+	json_close_object
+	json_dump
+	json_cleanup
+}
+
+# shellcheck disable=SC3037
+get_gateways() {
+	local name="${1:-$packageName}"
+	echo -en "{\"$name\":{\"gateways\":"
+	ubus call service list "{ 'name': '$name' }" | jsonfilter -e "@.${name}.instances.main.data.gateways"
+	echo -en "}}"
+}
+
+str_contains() { [ -n "$1" ] &&[ -n "$2" ] && [ "${1//$2}" != "$1" ]; }
+str_contains_word() { echo "$1" | grep -q -w "$2"; }
+str_to_lower() { echo "$1" | tr 'A-Z' 'a-z'; }
+str_to_upper() { echo "$1" | tr 'a-z' 'A-Z'; }
+is_ignore_target() { [ "$(str_to_lower "$1")" = 'ignore' ]; }
+is_dslite() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:6}" = "dslite" ]; }
+is_l2tp() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:4}" = "l2tp" ]; }
+is_oc() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:11}" = "openconnect" ]; }
+is_ovpn() { local dev; network_get_device dev "$1"; [ "${dev:0:3}" = "tun" ] || [ "${dev:0:3}" = "tap" ] || [ -f "/sys/devices/virtual/net/${dev}/tun_flags" ]; }
+is_pptp() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:4}" = "pptp" ]; }
+is_softether() { local dev; network_get_device dev "$1"; [ "${dev:0:4}" = "vpn_" ]; }
+is_tor() { [ "$(str_to_lower "$1")" = "tor" ]; }
+is_wg() { local proto; proto=$(uci -q get network."$1".proto); [ "${proto:0:9}" = "wireguard" ]; }
+is_tunnel() { is_dslite "$1" || is_l2tp "$1" || is_oc "$1" || is_ovpn "$1" || is_pptp "$1" || is_softether "$1" || is_tor "$1" || is_wg "$1"; }
+is_wan() { [ "$1" = "$wanIface4" ] || { [ "${1##wan}" != "$1" ] && [ "${1##wan6}" = "$1" ]; } || [ "${1%%wan}" != "$1" ]; }
+is_wan6() { [ -n "$wanIface6" ] && [ "$1" = "$wanIface6" ] || [ "${1/#wan6}" != "$1" ] || [ "${1/%wan6}" != "$1" ]; }
+is_ignored_interface() { str_contains_word "$ignored_interface" "$1"; }
+is_supported_interface() { str_contains_word "$supported_interface" "$1" || { ! is_ignored_interface "$1" && { is_wan "$1" || is_wan6 "$1" || is_tunnel "$1"; }; } || is_ignore_target "$1"; }
+pbr_find_iface() {
+	local iface i param="$2"
+	[ "$param" = 'wan6' ] || param='wan'
+	"network_find_${param}" iface
+	is_tunnel "$iface" && unset iface
+	if [ -z "$iface" ]; then
+		for i in $ifacesAll; do
+			if "is_${param}" "$i"; then break; else unset i; fi
+		done
+	fi
+	eval "$1"='${iface:-$i}'
+}
+_build_ifaces_all() { ifacesAll="${ifacesAll}${1} "; }
+_build_ifaces_supported() { is_supported_interface "$1" && ifacesSupported="${ifacesSupported}${1} "; }
+get_supported_interfaces() {
+	local name i
+	name="$(basename "$1")"
+	name="${name:-$packageName}" 
+	local ifacesAll ifacesSupported
+	local webui_show_ignore_target
+	local ignored_interface supported_interface
+	local wanIface4 wanIface6
+	config_load "$name"
+	config_get_bool webui_show_ignore_target 'config' 'webui_show_ignore_target' '0'
+	config_get ignored_interface             'config' 'ignored_interface'
+	config_get supported_interface           'config' 'supported_interface'
+	config_load 'network'
+	config_foreach _build_ifaces_all 'interface'
+	pbr_find_iface wanIface4 'wan'
+	pbr_find_iface wanIface6 'wan6'
+	config_foreach _build_ifaces_supported 'interface'
+	if [ "$webui_show_ignore_target" -eq "1" ]; then
+		ifacesSupported="$ifacesSupported ignore"
+	fi
+	json_init
+	json_add_object "$name"
+	json_add_array 'interfaces'
+	for i in $ifacesSupported; do
+		json_add_string '' "$i"
+	done
+	json_close_array
+	json_close_object
+	json_dump
+	json_cleanup
+}
+
+case "$1" in
+	list)
+		json_init
+		json_add_object "getGateways"
+			json_add_string 'name' 'name'
+		json_close_object
+		json_add_object "getInitList"
+			json_add_string 'name' 'name'
+		json_close_object
+		json_add_object "getInitStatus"
+			json_add_string 'name' 'name'
+		json_close_object
+		json_add_object "getInterfaces"
+			json_add_string 'name' 'name'
+		json_close_object
+		json_add_object "getPlatformSupport"
+			json_add_string 'name' 'name'
+		json_close_object
+		json_add_object "setInitAction"
+			json_add_string 'name' 'name'
+			json_add_string 'action' 'action'
+		json_close_object
+		json_dump
+		json_cleanup
+		;;
+	call)
+		case "$2" in
+			getGateways)
+				read -r input
+				json_load "$input"
+				json_get_var name 'name'
+				json_cleanup
+				get_gateways "$name"
+				;;
+			getInitList)
+				read -r input
+				json_load "$input"
+				json_get_var name 'name'
+				json_cleanup
+				get_init_list "$name"
+				;;
+			getInitStatus)
+				read -r input
+				json_load "$input"
+				json_get_var name 'name'
+				json_cleanup
+				get_init_status "$name"
+				;;
+			getInterfaces)
+				read -r input
+				json_load "$input"
+				json_get_var name 'name'
+				json_cleanup
+				get_supported_interfaces "$name"
+				;;
+			getPlatformSupport)
+				read -r input
+				json_load "$input"
+				json_get_var name 'name'
+				json_cleanup
+				get_platform_support "$name"
+				;;
+			setInitAction)
+				read -r input
+				json_load "$input"
+				json_get_var name 'name'
+				json_get_var action 'action'
+				json_cleanup
+				set_init_action "$name" "$action"
+				;;
+		esac
+	;;
+esac

--- a/applications/luci-app-pbr/root/usr/share/luci/menu.d/luci-app-pbr.json
+++ b/applications/luci-app-pbr/root/usr/share/luci/menu.d/luci-app-pbr.json
@@ -1,0 +1,15 @@
+{
+	"admin/services/pbr": {
+		"title": "Policy Routing",
+		"order": 90,
+		"action": {
+			"type": "view",
+			"path": "pbr/overview"
+		},
+		"depends": {
+			"acl": [
+				"luci-app-pbr"
+			]
+		}
+	}
+}

--- a/applications/luci-app-pbr/root/usr/share/rpcd/acl.d/luci-app-pbr.json
+++ b/applications/luci-app-pbr/root/usr/share/rpcd/acl.d/luci-app-pbr.json
@@ -1,0 +1,29 @@
+{
+	"luci-app-pbr": {
+		"description": "Grant UCI and file access for luci-app-pbr",
+		"read": {
+			"ubus": {
+				"luci.pbr": [
+					"getGateways",
+					"getInitList",
+					"getInitStatus",
+					"getInterfaces",
+					"getPlatformSupport"
+				]
+			},
+			"uci": [
+				"pbr"
+			]
+		},
+		"write": {
+			"uci": [
+				"pbr"
+			],
+			"ubus": {
+				"luci.pbr": [
+					"setInitAction"
+				]
+			}
+		}
+	}
+}

--- a/applications/luci-app-privoxy/po/da/privoxy.po
+++ b/applications/luci-app-privoxy/po/da/privoxy.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2021-11-16 17:38+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsprivoxy/da/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:236
 msgid ""
@@ -126,7 +126,7 @@ msgstr ""
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:134
 msgid "Enabled"
-msgstr ""
+msgstr "Aktiveret"
 
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:602
 msgid ""
@@ -269,7 +269,7 @@ msgstr ""
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:97
 #: applications/luci-app-privoxy/luasrc/model/cbi/privoxy.lua:100
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Diverse"
 
 #: applications/luci-app-privoxy/luasrc/controller/privoxy.lua:51
 msgid "NOT installed"

--- a/applications/luci-app-radicale/po/da/radicale.po
+++ b/applications/luci-app-radicale/po/da/radicale.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-05-20 17:41+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsradicale/da/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-radicale/luasrc/model/cbi/radicale.lua:268
 msgid ""
@@ -161,7 +161,7 @@ msgstr ""
 #: applications/luci-app-radicale/luasrc/model/cbi/radicale.lua:573
 #: applications/luci-app-radicale/luasrc/model/cbi/radicale.lua:595
 msgid "Error"
-msgstr ""
+msgstr "Fejl"
 
 #: applications/luci-app-radicale/luasrc/model/cbi/radicale.lua:120
 msgid "File '%s' not found !"

--- a/applications/luci-app-radicale2/po/da/radicale2.po
+++ b/applications/luci-app-radicale2/po/da/radicale2.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: luci-app-radicale 2\n"
-"PO-Revision-Date: 2022-03-20 21:24+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsradicale2/da/>\n"
@@ -10,7 +10,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.12-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-radicale2/luasrc/model/cbi/radicale2/auth.lua:8
 #: applications/luci-app-radicale2/luasrc/model/cbi/radicale2/logging.lua:4
@@ -122,7 +122,7 @@ msgstr ""
 
 #: applications/luci-app-radicale2/luasrc/model/cbi/radicale2/auth.lua:29
 msgid "Encryption"
-msgstr ""
+msgstr "Kryptering"
 
 #: applications/luci-app-radicale2/luasrc/model/cbi/radicale2/auth.lua:23
 msgid "Filename"

--- a/applications/luci-app-shadowsocks-libev/po/da/shadowsocks-libev.po
+++ b/applications/luci-app-shadowsocks-libev/po/da/shadowsocks-libev.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-05-20 17:41+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsshadowsocks-libev/da/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.13-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/instances.js:45
 msgid "-- instance type --"
@@ -114,7 +114,7 @@ msgstr ""
 
 #: applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/instances.js:142
 msgid "Enabled"
-msgstr ""
+msgstr "Aktiveret"
 
 #: applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/rules.js:69
 msgid ""

--- a/applications/luci-app-simple-adblock/po/pt_BR/simple-adblock.po
+++ b/applications/luci-app-simple-adblock/po/pt_BR/simple-adblock.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2022-10-28 15:05+0000\n"
+"PO-Revision-Date: 2022-11-23 11:36+0000\n"
 "Last-Translator: Wellington Terumi Uemura <wellingtonuemura@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationssimple-adblock/pt_BR/>\n"
@@ -11,7 +11,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.14.2-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:90
 msgid "%s is not installed or not found"
@@ -19,7 +19,7 @@ msgstr "%s não está instalado ou não foi encontrado"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:99
 msgid "Active"
-msgstr ""
+msgstr "Ativo"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:105
 msgid "Add IPv6 entries"
@@ -77,11 +77,11 @@ msgstr "Bloqueando %s domínios (com %s)."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:129
 msgid "Cache file found."
-msgstr ""
+msgstr "Arquivo de cache foi encontrado."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:111
 msgid "Compressed cache file created."
-msgstr ""
+msgstr "Foi criado um arquivo de cache compactado."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:132
 msgid "Compressed cache file found."
@@ -98,7 +98,7 @@ msgstr "Repetir o Download do Curl"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:116
 msgid "Curl maximum file size (in bytes)"
-msgstr ""
+msgstr "Tamanho máximo do arquivo Curl (em bytes)"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:85
 msgid "DNS Service"
@@ -107,6 +107,7 @@ msgstr "Serviço de DNS"
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:64
 msgid "DNS resolution option, see the %sREADME%s for details."
 msgstr ""
+"Opção da resolução do DNS, consulte %sREADME%s para obter mais detalhes."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:251
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:37
@@ -121,11 +122,11 @@ msgstr "Desabilitar Depuração"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:247
 msgid "Disabling %s service"
-msgstr ""
+msgstr "Desativando o serviço %s"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:147
 msgid "Dnsmasq Config File URL"
-msgstr ""
+msgstr "URL do arquivo de configuração do Dnsmasq"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:104
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:108
@@ -165,7 +166,7 @@ msgstr "Ativa a saída de depuração para o arquivo /tmp/simple-adblock.log."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:236
 msgid "Enabling %s service"
-msgstr ""
+msgstr "Ativando o serviço %s"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:96
 msgid "Error"
@@ -177,7 +178,7 @@ msgstr "Falha"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:114
 msgid "Force DNS ports:"
-msgstr ""
+msgstr "Imponha o uso das portas DNS:"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:218
 msgid "Force Re-Download"
@@ -198,7 +199,7 @@ msgstr "Impõem o servidor de DNS do roteador para todos os dispositivos locais"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:214
 msgid "Force re-downloading %s block lists"
-msgstr ""
+msgstr "Impor um novo download das listas de bloqueio %s"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:49
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
@@ -219,6 +220,8 @@ msgid ""
 "If curl is installed and detected, it would not download files bigger than "
 "this."
 msgstr ""
+"Se o curl estiver instalado e for detectado, ele não baixará arquivos "
+"maiores que isso."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:123
 msgid ""
@@ -256,7 +259,7 @@ msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:146
 msgid "Not installed or not found"
-msgstr ""
+msgstr "Não instalado ou não encontrado"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:41
 msgid "Output Verbosity Setting"
@@ -293,7 +296,7 @@ msgstr "Controle do Serviço"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:185
 msgid "Service Errors"
-msgstr ""
+msgstr "Erros do serviço"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:103
 msgid "Service Status"
@@ -301,7 +304,7 @@ msgstr "Condição do Serviço"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:154
 msgid "Service Warnings"
-msgstr ""
+msgstr "Avisos do serviço"
 
 #: applications/luci-app-simple-adblock/root/usr/share/luci/menu.d/luci-app-simple-adblock.json:3
 msgid "Simple AdBlock"
@@ -309,11 +312,11 @@ msgstr "AdBlock Simples"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:30
 msgid "Simple AdBlock - Configuration"
-msgstr ""
+msgstr "AdBlock Simples - Configuração"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:102
 msgid "Simple AdBlock - Status"
-msgstr ""
+msgstr "AdBlock Simples - Condição"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:127
 msgid "Simultaneous processing"
@@ -333,7 +336,7 @@ msgstr "Iniciando"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:203
 msgid "Starting %s service"
-msgstr ""
+msgstr "Iniciando o serviço %s"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:229
 msgid "Stop"
@@ -349,7 +352,7 @@ msgstr "Parado"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:225
 msgid "Stopping %s service"
-msgstr ""
+msgstr "Parando o serviço %s"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:136
 msgid "Store compressed cache"
@@ -367,6 +370,8 @@ msgstr "Suprimir"
 msgid ""
 "URL to the external dnsmasq config file, see the %sREADME%s for details."
 msgstr ""
+"A URL para o arquivo de configuração externa do dnsmasq, consulte %sREADME%s "
+"para obter mais detalhes."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:157
 msgid "URLs to lists of domains to be allowed."
@@ -392,7 +397,7 @@ msgstr "Saída detalhada"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:105
 msgid "Version: %s"
-msgstr ""
+msgstr "Versão: %s"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:97
 msgid "Warning"
@@ -400,28 +405,28 @@ msgstr "Alerta"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:126
 msgid "disabled"
-msgstr ""
+msgstr "desativado"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:87
 msgid "dnsmasq additional hosts"
-msgstr ""
+msgstr "hosts adicionais do dnsmasq"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:88
 msgid "dnsmasq config"
-msgstr ""
+msgstr "configuração do dnsmasq"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:90
 msgid "dnsmasq ipset"
-msgstr ""
+msgstr "ipset do dnsmasq"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:93
 msgid "dnsmasq nft set"
-msgstr ""
+msgstr "conjunto nft do dnsmasq"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:95
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:100
 msgid "dnsmasq servers file"
-msgstr ""
+msgstr "arquivo dos servidores do dnsmasq"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:165
 msgid "failed to access shared memory"
@@ -513,7 +518,7 @@ msgstr "nenhum"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:98
 msgid "unbound adblock list"
-msgstr ""
+msgstr "lista de bloqueio de anúncios não vinculados"
 
 #~ msgid "%s Error: %s"
 #~ msgstr "%s: Erro: %s"

--- a/applications/luci-app-simple-adblock/po/zh_Hans/simple-adblock.po
+++ b/applications/luci-app-simple-adblock/po/zh_Hans/simple-adblock.po
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"PO-Revision-Date: 2022-10-28 15:05+0000\n"
+"PO-Revision-Date: 2022-11-23 11:36+0000\n"
 "Last-Translator: Eric <hamburger1024@mailbox.org>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationssimple-adblock/zh_Hans/>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.14.2-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:90
 msgid "%s is not installed or not found"
@@ -22,7 +22,7 @@ msgstr "%s 未安装或未找到"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:99
 msgid "Active"
-msgstr ""
+msgstr "活跃"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:105
 msgid "Add IPv6 entries"
@@ -79,11 +79,11 @@ msgstr "拦截 %s 个域名 (用 %s)。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:129
 msgid "Cache file found."
-msgstr ""
+msgstr "找到了缓存文件。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:111
 msgid "Compressed cache file created."
-msgstr ""
+msgstr "创建了压缩的缓存文件。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:132
 msgid "Compressed cache file found."
@@ -99,7 +99,7 @@ msgstr "Curl 下载重试"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:116
 msgid "Curl maximum file size (in bytes)"
-msgstr ""
+msgstr "Curl 最大文件尺寸（单位 bytes)"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:85
 msgid "DNS Service"
@@ -107,7 +107,7 @@ msgstr "DNS 服务"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:64
 msgid "DNS resolution option, see the %sREADME%s for details."
-msgstr ""
+msgstr "DNS 解析选项，详情见 %sREADME%s."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:251
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:37
@@ -122,11 +122,11 @@ msgstr "禁用调试"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:247
 msgid "Disabling %s service"
-msgstr ""
+msgstr "禁用 %s 服务"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:147
 msgid "Dnsmasq Config File URL"
-msgstr ""
+msgstr "Dnsmasq 配置文件 URL"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:104
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:108
@@ -166,7 +166,7 @@ msgstr "将调试输出到 /tmp/simple-adblock.log。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:236
 msgid "Enabling %s service"
-msgstr ""
+msgstr "启用 %s 服务"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:96
 msgid "Error"
@@ -178,7 +178,7 @@ msgstr "失败"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:114
 msgid "Force DNS ports:"
-msgstr ""
+msgstr "强制 DNS 端口："
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:218
 msgid "Force Re-Download"
@@ -199,7 +199,7 @@ msgstr "强制所有本地设备使用路由器 DNS"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:214
 msgid "Force re-downloading %s block lists"
-msgstr ""
+msgstr "强制重新下载 %s 拦截列表"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:49
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
@@ -217,7 +217,7 @@ msgstr "IPv6 支持"
 msgid ""
 "If curl is installed and detected, it would not download files bigger than "
 "this."
-msgstr ""
+msgstr "如果安装了 curl 且被检测到，它不会下载超过这个大小的文件。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:123
 msgid ""
@@ -249,7 +249,7 @@ msgstr "如果进行了设置，允许本地设备使用自己的 DNS 服务器"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:146
 msgid "Not installed or not found"
-msgstr ""
+msgstr "未安装或未找到"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:41
 msgid "Output Verbosity Setting"
@@ -283,7 +283,7 @@ msgstr "服务控制"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:185
 msgid "Service Errors"
-msgstr ""
+msgstr "服务出错"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:103
 msgid "Service Status"
@@ -291,7 +291,7 @@ msgstr "服务状态"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:154
 msgid "Service Warnings"
-msgstr ""
+msgstr "服务警告"
 
 #: applications/luci-app-simple-adblock/root/usr/share/luci/menu.d/luci-app-simple-adblock.json:3
 msgid "Simple AdBlock"
@@ -299,11 +299,11 @@ msgstr "简易 AdBlock"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:30
 msgid "Simple AdBlock - Configuration"
-msgstr ""
+msgstr "Simple AdBlock - 配置"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:102
 msgid "Simple AdBlock - Status"
-msgstr ""
+msgstr "Simple AdBlock - 状态"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:127
 msgid "Simultaneous processing"
@@ -323,7 +323,7 @@ msgstr "正在启动"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:203
 msgid "Starting %s service"
-msgstr ""
+msgstr "启动 %s 服务"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:229
 msgid "Stop"
@@ -339,7 +339,7 @@ msgstr "已停止"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:225
 msgid "Stopping %s service"
-msgstr ""
+msgstr "停止 %s 服务"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:136
 msgid "Store compressed cache"
@@ -356,7 +356,7 @@ msgstr "抑制输出"
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:148
 msgid ""
 "URL to the external dnsmasq config file, see the %sREADME%s for details."
-msgstr ""
+msgstr "外部 dnsmasq 配置文件 URL，详情见 %sREADME%s."
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:157
 msgid "URLs to lists of domains to be allowed."
@@ -382,7 +382,7 @@ msgstr "详细输出"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:105
 msgid "Version: %s"
-msgstr ""
+msgstr "版本：%s"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:97
 msgid "Warning"
@@ -390,28 +390,28 @@ msgstr "警告"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:126
 msgid "disabled"
-msgstr ""
+msgstr "已禁用"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:87
 msgid "dnsmasq additional hosts"
-msgstr ""
+msgstr "dnsmasq 附加 hosts"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:88
 msgid "dnsmasq config"
-msgstr ""
+msgstr "dnsmasq 配置"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:90
 msgid "dnsmasq ipset"
-msgstr ""
+msgstr "dnsmasq ip集"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:93
 msgid "dnsmasq nft set"
-msgstr ""
+msgstr "dnsmasq nft 集"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:95
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:100
 msgid "dnsmasq servers file"
-msgstr ""
+msgstr "dnsmasq 服务器文件"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:165
 msgid "failed to access shared memory"
@@ -503,7 +503,7 @@ msgstr "无"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:98
 msgid "unbound adblock list"
-msgstr ""
+msgstr "unbound 广告拦截列表"
 
 #~ msgid "%s Error: %s"
 #~ msgstr "%s 错误: %s"

--- a/applications/luci-app-simple-adblock/po/zh_Hant/simple-adblock.po
+++ b/applications/luci-app-simple-adblock/po/zh_Hant/simple-adblock.po
@@ -3,15 +3,15 @@
 #
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-09-06 13:27+0000\n"
-"Last-Translator: Hulen <shift0106@gmail.com>\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: James Tien <jamestien.1219@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationssimple-adblock/zh_Hant/>\n"
 "Language: zh_Hant\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.14.1-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:90
 msgid "%s is not installed or not found"
@@ -19,7 +19,7 @@ msgstr "%s 未安裝或找不到"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:99
 msgid "Active"
-msgstr ""
+msgstr "已啓用"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:105
 msgid "Add IPv6 entries"
@@ -76,11 +76,11 @@ msgstr "封鎖 %s 個網域 (用 %s)。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:129
 msgid "Cache file found."
-msgstr ""
+msgstr "已找到快取檔案。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:111
 msgid "Compressed cache file created."
-msgstr ""
+msgstr "已建立快取壓縮檔案。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:132
 msgid "Compressed cache file found."
@@ -96,7 +96,7 @@ msgstr "Curl 下載重試"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:116
 msgid "Curl maximum file size (in bytes)"
-msgstr ""
+msgstr "Curl 最大的檔案限制（位元）"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:85
 msgid "DNS Service"
@@ -104,7 +104,7 @@ msgstr "DNS服務"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:64
 msgid "DNS resolution option, see the %sREADME%s for details."
-msgstr ""
+msgstr "DNS 解析選項，請參考%sREADME%s之詳細。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:251
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:37
@@ -119,11 +119,11 @@ msgstr "禁用除錯"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:247
 msgid "Disabling %s service"
-msgstr ""
+msgstr "正在禁用 %s 服務"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:147
 msgid "Dnsmasq Config File URL"
-msgstr ""
+msgstr "Dnsmasq 設定檔案的網址"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:104
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:108
@@ -163,7 +163,7 @@ msgstr "將除錯輸出啟用到 /tmp/simple-adblock.log。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:236
 msgid "Enabling %s service"
-msgstr ""
+msgstr "正在啓用 %s 服務"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:96
 msgid "Error"
@@ -175,7 +175,7 @@ msgstr "失敗"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:114
 msgid "Force DNS ports:"
-msgstr ""
+msgstr "強制使用DNS端口："
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:218
 msgid "Force Re-Download"
@@ -196,7 +196,7 @@ msgstr "強制所有本地裝置使用路由器 DNS"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:214
 msgid "Force re-downloading %s block lists"
-msgstr ""
+msgstr "強制重新下載 %s 區塊列表"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:49
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
@@ -214,13 +214,13 @@ msgstr "支援 IPv6"
 msgid ""
 "If curl is installed and detected, it would not download files bigger than "
 "this."
-msgstr ""
+msgstr "如果已安裝並檢測到curl，則不會下載比這個更大的檔案。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:123
 msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
-msgstr "如果安裝並檢測到curl，則會在逾時/失敗時重試多次下載。"
+msgstr "如果已安裝並檢測到curl，則會在逾時/失敗時重試多次下載。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:153
 msgid "Individual domains to be allowed."
@@ -246,7 +246,7 @@ msgstr "如果進行了設定，允許本地裝置使用自己的 DNS 伺服器"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:146
 msgid "Not installed or not found"
-msgstr ""
+msgstr "未安裝或找不到"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:41
 msgid "Output Verbosity Setting"
@@ -280,7 +280,7 @@ msgstr "服務控制"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:185
 msgid "Service Errors"
-msgstr ""
+msgstr "服務出錯"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:103
 msgid "Service Status"
@@ -288,7 +288,7 @@ msgstr "服務狀態"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:154
 msgid "Service Warnings"
-msgstr ""
+msgstr "服務警告"
 
 #: applications/luci-app-simple-adblock/root/usr/share/luci/menu.d/luci-app-simple-adblock.json:3
 msgid "Simple AdBlock"
@@ -296,11 +296,11 @@ msgstr "簡單 AdBlock"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:30
 msgid "Simple AdBlock - Configuration"
-msgstr ""
+msgstr "Simple AdBlock - 設定"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:102
 msgid "Simple AdBlock - Status"
-msgstr ""
+msgstr "Simple AdBlock - 狀態"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:127
 msgid "Simultaneous processing"
@@ -320,7 +320,7 @@ msgstr "開始中"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:203
 msgid "Starting %s service"
-msgstr ""
+msgstr "正在啓用 %s 服務"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:229
 msgid "Stop"
@@ -336,7 +336,7 @@ msgstr "已停止"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:225
 msgid "Stopping %s service"
-msgstr ""
+msgstr "正在停用 %s 服務"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:136
 msgid "Store compressed cache"
@@ -353,7 +353,7 @@ msgstr "抑制輸出"
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:148
 msgid ""
 "URL to the external dnsmasq config file, see the %sREADME%s for details."
-msgstr ""
+msgstr "指向外部 dnsmasq 設置檔案的網址，請參考 %sREADME%s 之詳細內容。"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:157
 msgid "URLs to lists of domains to be allowed."
@@ -379,7 +379,7 @@ msgstr "詳細輸出"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:105
 msgid "Version: %s"
-msgstr ""
+msgstr "版本： %s"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:97
 msgid "Warning"
@@ -387,28 +387,28 @@ msgstr "警告"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:126
 msgid "disabled"
-msgstr ""
+msgstr "已禁用"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:87
 msgid "dnsmasq additional hosts"
-msgstr ""
+msgstr "dnsmasq 的額外主機"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:88
 msgid "dnsmasq config"
-msgstr ""
+msgstr "dnsmasq 設置"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:90
 msgid "dnsmasq ipset"
-msgstr ""
+msgstr "dnsmasq ipset"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:93
 msgid "dnsmasq nft set"
-msgstr ""
+msgstr "dnsmasq nft set"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:95
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:100
 msgid "dnsmasq servers file"
-msgstr ""
+msgstr "dnsmasq 服務器檔案設置"
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:165
 msgid "failed to access shared memory"

--- a/applications/luci-app-transmission/po/da/transmission.po
+++ b/applications/luci-app-transmission/po/da/transmission.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-05-31 03:41+0200\n"
-"PO-Revision-Date: 2021-11-15 14:07+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationstransmission/da/>\n"
@@ -12,19 +12,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.9.1-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:65
 msgid "Alternative download speed"
-msgstr ""
+msgstr "Alternativ hentehastighed"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:59
 msgid "Alternative speed enabled"
-msgstr ""
+msgstr "Alternativ hastighed aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:277
 msgid "Alternative speed time begin"
-msgstr ""
+msgstr "Alternativ hastighed starttidspunkt"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:283
 msgid "Alternative speed time day"
@@ -40,7 +40,7 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:62
 msgid "Alternative upload speed"
-msgstr ""
+msgstr "Alternativ afsendelseshastighed"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:113
 msgid "Automatically start added torrents"
@@ -52,23 +52,23 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:174
 msgid "Binding address IPv4"
-msgstr ""
+msgstr "Knyt adresse IPv4"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:176
 msgid "Binding address IPv6"
-msgstr ""
+msgstr "Knyt adresse IPv6"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:86
 msgid "Block list enabled"
-msgstr ""
+msgstr "Blokeringsliste aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:89
 msgid "Blocklist URL"
-msgstr ""
+msgstr "Blokeringsliste URL"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:83
 msgid "Blocklists"
-msgstr ""
+msgstr "Blokeringslister"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:131
 msgid "Cache size in MB"
@@ -76,15 +76,15 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:50
 msgid "Config file directory"
-msgstr ""
+msgstr "Konfigurationsfil mappe"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:53
 msgid "Custom Web UI directory"
-msgstr ""
+msgstr "Brugerdefineret web brugerflade mappe"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:133
 msgid "DHT enabled"
-msgstr ""
+msgstr "DHT aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:151
 msgid "Debug"
@@ -108,27 +108,27 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:47
 msgid "Enabled"
-msgstr ""
+msgstr "Aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:136
 msgid "Encryption"
-msgstr ""
+msgstr "Kryptering"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:149
 msgid "Error"
-msgstr ""
+msgstr "Fejl"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:107
 msgid "Fast"
-msgstr ""
+msgstr "Hurtig"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:94
 msgid "Files and Locations"
-msgstr ""
+msgstr "Filer og lokationer"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:108
 msgid "Full"
-msgstr ""
+msgstr "Fyldt"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:183
 msgid "Global peer limit"
@@ -136,7 +136,7 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:44
 msgid "Global settings"
-msgstr ""
+msgstr "Globale indstillinger"
 
 #: applications/luci-app-transmission/root/usr/share/rpcd/acl.d/luci-app-transmission.json:3
 msgid "Grant UCI access for luci-app-transmission"
@@ -160,23 +160,23 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:150
 msgid "Info"
-msgstr ""
+msgstr "Info"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:144
 msgid "LPD enabled"
-msgstr ""
+msgstr "LPD aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:141
 msgid "Lazy bitfield enabled"
-msgstr ""
+msgstr "Doven bitfelt aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:147
 msgid "Message level"
-msgstr ""
+msgstr "Besked niveau"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:128
 msgid "Miscellaneous"
-msgstr ""
+msgstr "Diverse"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:148
 msgid "None"
@@ -199,15 +199,15 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:153
 msgid "PEX enabled"
-msgstr ""
+msgstr "PEX aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:190
 msgid "Peer Port settings"
-msgstr ""
+msgstr "Peer port indstillinger"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:178
 msgid "Peer congestion algorithm"
-msgstr ""
+msgstr "Peer overbelastnings algoritme"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:185
 msgid "Peer limit per torrent"
@@ -215,7 +215,7 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:193
 msgid "Peer port"
-msgstr ""
+msgstr "Peer port"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:198
 msgid "Peer port random high"
@@ -231,7 +231,7 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:171
 msgid "Peer settings"
-msgstr ""
+msgstr "Peer indstillinger"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:187
 msgid "Peer socket <abbr title=\"Type of Service\">TOS</abbr>"
@@ -239,7 +239,7 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:204
 msgid "Port forwarding enabled"
-msgstr ""
+msgstr "Peer videresendelse aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:105
 msgid "Preallocation"
@@ -255,7 +255,7 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:156
 msgid "Prefetch enabled"
-msgstr ""
+msgstr "Forhåndshentning aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:214
 msgid "Queue stalled enabled"
@@ -271,19 +271,19 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:242
 msgid "RPC URL"
-msgstr ""
+msgstr "RPC URL"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:259
 msgid "RPC authentication required"
-msgstr ""
+msgstr "RPC godkendelse påkrævet"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:236
 msgid "RPC bind address"
-msgstr ""
+msgstr "RPC tilknytnings adresse"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:233
 msgid "RPC enabled"
-msgstr ""
+msgstr "RPC aktiveret"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:249
 msgid "RPC host whitelist"
@@ -295,19 +295,19 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:266
 msgid "RPC password"
-msgstr ""
+msgstr "RPC kodeord"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:239
 msgid "RPC port"
-msgstr ""
+msgstr "RPC port"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:230
 msgid "RPC settings"
-msgstr ""
+msgstr "RPC indstillinger"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:263
 msgid "RPC username"
-msgstr ""
+msgstr "RPC brugernavn"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:256
 msgid "RPC whitelist"
@@ -327,7 +327,7 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:181
 msgid "Recycle peer id after"
-msgstr ""
+msgstr "Genbrug peer id efter"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:110
 msgid "Rename partial files"
@@ -335,7 +335,7 @@ msgstr ""
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:139
 msgid "Require encrypted"
-msgstr ""
+msgstr "Kræv kryptering"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:52
 msgid "Run daemon as group"
@@ -391,10 +391,13 @@ msgid ""
 "tcp-congestion-control.html\" target=\"_blank\" rel=\"noreferrer noopener"
 "\">tcp-congestion-control</a>."
 msgstr ""
+"Dette er dokumenteret under <a href=\"https://www.irif.fr/~jch/software/"
+"bittorrent/tcp-congestion-control.html\" target=\"_blank\" rel=\"noreferrer "
+"noopener\">tcp-congestion-control</a>."
 
 #: applications/luci-app-transmission/root/usr/share/luci/menu.d/luci-app-transmission.json:3
 msgid "Transmission"
-msgstr ""
+msgstr "Transmission"
 
 #: applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js:42
 msgid ""

--- a/applications/luci-app-vpn-policy-routing/po/da/vpn-policy-routing.po
+++ b/applications/luci-app-vpn-policy-routing/po/da/vpn-policy-routing.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-08-24 00:04+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
 "luciapplicationsvpn-policy-routing/da/>\n"
@@ -8,7 +8,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 4.14-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:61
 msgid "%s (disabled)"
@@ -156,7 +156,7 @@ msgstr "Aktiver"
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:279
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:371
 msgid "Enabled"
-msgstr ""
+msgstr "Aktiveret"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:238
 msgid ""

--- a/applications/luci-app-vpn-policy-routing/po/pt_BR/vpn-policy-routing.po
+++ b/applications/luci-app-vpn-policy-routing/po/pt_BR/vpn-policy-routing.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-10-14 04:08+0000\n"
+"PO-Revision-Date: 2022-11-23 11:36+0000\n"
 "Last-Translator: Wellington Terumi Uemura <wellingtonuemura@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationsvpn-policy-routing/pt_BR/>\n"
@@ -286,7 +286,7 @@ msgstr "Controle do Serviço"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:144
 msgid "Service Errors"
-msgstr "Erros de Serviço"
+msgstr "Erros do serviço"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:233
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:238
@@ -307,7 +307,7 @@ msgstr "Condição Geral do Serviço [%s %s]"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:149
 msgid "Service Warnings"
-msgstr "Serviço de Avisos"
+msgstr "Avisos do serviço"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:353
 msgid ""

--- a/applications/luci-app-vpn-policy-routing/po/zh_Hant/vpn-policy-routing.po
+++ b/applications/luci-app-vpn-policy-routing/po/zh_Hant/vpn-policy-routing.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-10-17 00:00+0000\n"
-"Last-Translator: Hulen <shift0106@gmail.com>\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: James Tien <jamestien.1219@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationsvpn-policy-routing/zh_Hant/>\n"
 "Language: zh_Hant\n"
@@ -278,7 +278,7 @@ msgstr "服務控制"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:144
 msgid "Service Errors"
-msgstr "服務錯誤"
+msgstr "服務出錯"
 
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:233
 #: applications/luci-app-vpn-policy-routing/luasrc/model/cbi/vpn-policy-routing.lua:238

--- a/applications/luci-app-vpnbypass/po/pt_BR/vpnbypass.po
+++ b/applications/luci-app-vpnbypass/po/pt_BR/vpnbypass.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2022-10-14 04:08+0000\n"
+"PO-Revision-Date: 2022-11-23 11:36+0000\n"
 "Last-Translator: Wellington Terumi Uemura <wellingtonuemura@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationsvpnbypass/pt_BR/>\n"
@@ -61,7 +61,7 @@ msgstr "Portas locais que farão o disparo do Bypass VPN."
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:84
 msgid "Not installed or not found"
-msgstr "Não está instalado ou não foi encontrado"
+msgstr "Não instalado ou não encontrado"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:68
 msgid "Quering"

--- a/applications/luci-app-vpnbypass/po/zh_Hant/vpnbypass.po
+++ b/applications/luci-app-vpnbypass/po/zh_Hant/vpnbypass.po
@@ -3,15 +3,15 @@
 #
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-04-17 15:06+0000\n"
-"Last-Translator: 王攀 <41330784@qq.com>\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: James Tien <jamestien.1219@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
 "openwrt/luciapplicationsvpnbypass/zh_Hant/>\n"
 "Language: zh_Hant\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.12-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:150
 msgid "Disable"
@@ -19,7 +19,7 @@ msgstr "停用"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:146
 msgid "Disabling %s service"
-msgstr "正在停用 %s 服務"
+msgstr "正在禁用 %s 服務"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/view/vpnbypass/overview.js:58
 msgid "Domains to Bypass"
@@ -35,7 +35,7 @@ msgstr "啟用"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:135
 msgid "Enabling %s service"
-msgstr "正在啟用 %s 服務"
+msgstr "正在啓用 %s 服務"
 
 #: applications/luci-app-vpnbypass/root/usr/share/rpcd/acl.d/luci-app-vpnbypass.json:3
 msgid "Grant UCI and file access for luci-app-vpnbypass"
@@ -59,7 +59,7 @@ msgstr "觸發 VPN Bypass 的本地連接埠。"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:84
 msgid "Not installed or not found"
-msgstr "未安裝或未找到"
+msgstr "未安裝或找不到"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:68
 msgid "Quering"
@@ -107,7 +107,7 @@ msgstr "啟動"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:102
 msgid "Starting %s service"
-msgstr "正在啟動 %s 服務"
+msgstr "正在啓用 %s 服務"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:128
 msgid "Stop"
@@ -123,7 +123,7 @@ msgstr "已停止 (版本：%s)"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/vpnbypass/widgets.js:124
 msgid "Stopping %s service"
-msgstr "正在停止 %s 服務"
+msgstr "正在停用 %s 服務"
 
 #: applications/luci-app-vpnbypass/htdocs/luci-static/resources/view/vpnbypass/overview.js:27
 #: applications/luci-app-vpnbypass/root/usr/share/luci/menu.d/vpnbypass.json:3

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -1,9 +1,9 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-11-09 19:39+0000\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
 "Last-Translator: drax red <drax@outlook.dk>\n"
-"Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/luci/da/"
-">\n"
+"Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/luci/da/>"
+"\n"
 "Language: da\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1388,6 +1388,8 @@ msgstr "Opkald mislykkedes"
 msgid ""
 "Can be useful if ISP has IPv6 nameservers but does not provide IPv6 routing."
 msgstr ""
+"Kan være nyttigt, hvis ISP har IPv6 navneservere, men ikke leverer IPv6 "
+"routing."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2933
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4162
@@ -3144,11 +3146,11 @@ msgstr "Filsystem"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:466
 msgid "Filter IPv4 A records"
-msgstr ""
+msgstr "Filter IPv4 A Akter"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:460
 msgid "Filter IPv6 AAAA records"
-msgstr ""
+msgstr "Filtrere IPv6 AAAA Akter"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:450
 msgid "Filter private"
@@ -3819,6 +3821,9 @@ msgid ""
 "tunnelled packets with source IP addresses matching this list and route back "
 "packets with matching destination IP."
 msgstr ""
+"IP-adresser, der er tilladt inde i tunnelen. Peeren accepterer tunnelerede "
+"pakker med kilde-IP-adresser, der matcher denne liste, og ruter pakker "
+"tilbage med matchende destinations-IP."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:36
 msgctxt "nft ip protocol"
@@ -4344,15 +4349,13 @@ msgid "Instance"
 msgstr "Instans"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:162
-#, fuzzy
 msgctxt "WireGuard instance heading"
 msgid "Instance \"%h\""
-msgstr "Instans"
+msgstr "Instans \"%h\""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:71
-#, fuzzy
 msgid "Instance Details"
-msgstr "Instans"
+msgstr "Oplysninger om instans"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2046
 msgid ""
@@ -4566,7 +4569,7 @@ msgstr "Bevar indstillingerne og den aktuelle konfiguration"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:97
 msgid "Keep-Alive"
-msgstr ""
+msgstr "Keep-Alive"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:20
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
@@ -5634,7 +5637,6 @@ msgid "Never"
 msgstr "Aldrig"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:16
-#, fuzzy
 msgctxt "No WireGuard peer handshake yet"
 msgid "Never"
 msgstr "Aldrig"
@@ -5791,9 +5793,8 @@ msgid "No password set!"
 msgstr "Ingen adgangskode angivet!"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:121
-#, fuzzy
 msgid "No peers connected"
-msgstr "Ikke tilsluttet"
+msgstr "Ingen peers tilsluttet"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:512
 msgid "No peers defined yet."
@@ -6571,13 +6572,12 @@ msgid "Peak:"
 msgstr "Spids:"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:111
-#, fuzzy
 msgid "Peer"
-msgstr "Peers"
+msgstr "Peer"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:88
 msgid "Peer Details"
-msgstr ""
+msgstr "Peer Detaljer"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:89
 msgid "Peer IP address to assign"
@@ -6685,10 +6685,9 @@ msgid "Port"
 msgstr "Port"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:174
-#, fuzzy
 msgctxt "WireGuard listen port"
 msgid "Port %d"
-msgstr "Port"
+msgstr "Port %d"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:702
 msgid "Port isolation"
@@ -7041,9 +7040,8 @@ msgid "Receive"
 msgstr "Modtag"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:94
-#, fuzzy
 msgid "Received Data"
-msgstr "Modtag"
+msgstr "Modtaget data"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:181
 msgid "Recommended. IP addresses of the WireGuard interface."
@@ -7120,11 +7118,9 @@ msgid "Relay Bridge"
 msgstr "Relæbroen"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:352
-#, fuzzy
 msgid "Relay DHCP requests elsewhere. OK: v4↔v4, v6↔v6. Not OK: v4↔v6, v6↔v4."
 msgstr ""
-"Videresender DHCP-anmodninger andre steder. OK: v4<->v4, v6<->v6. Ikke OK: "
-"v4<->v6, v6<->v4."
+"Relay DHCP anmoder andre steder. OK: v4↔v4, v6↔v6. Not OK: v4↔v6, v6↔v4."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:385
 msgid "Relay To address"
@@ -7167,11 +7163,11 @@ msgstr "Fjern"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:467
 msgid "Remove IPv4 addresses from the results and only return IPv6 addresses."
-msgstr ""
+msgstr "Fjern IPv4 adresser fra resultaterne og returner kun IPv6 adresser."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:461
 msgid "Remove IPv6 addresses from the results and only return IPv4 addresses."
-msgstr ""
+msgstr "Fjern IPv6 adresser fra resultaterne og returner kun IPv4 adresser."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1318
 msgid "Remove related device settings from the configuration"
@@ -9408,9 +9404,8 @@ msgid "Transmit Hash Policy"
 msgstr "Politik for overførsel af hash"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:95
-#, fuzzy
 msgid "Transmitted Data"
-msgstr "Data Overført"
+msgstr "Overførte data"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:79
 msgctxt "nft @th,off,len"
@@ -10496,7 +10491,7 @@ msgstr "f.eks.: dump"
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:97
 msgctxt "WireGuard keep alive interval"
 msgid "every %ds"
-msgstr ""
+msgstr "hver %ds"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:871
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:901

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-06-10 03:40+0200\n"
-"PO-Revision-Date: 2022-10-29 20:58+0000\n"
+"PO-Revision-Date: 2022-11-23 11:35+0000\n"
 "Last-Translator: INAGAKI Hiroshi <musashino.open@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/openwrt/luci/ja/"
 ">\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.14.2-dev\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:643
 msgctxt "Yet unknown nftables table family (\"family\" table \"name\")"
@@ -4193,7 +4193,8 @@ msgstr "受信:"
 msgid ""
 "Include in backup a list of current installed packages at /etc/backup/"
 "installed_packages.txt"
-msgstr ""
+msgstr "現在インストールされているパッケージのリスト /etc/backup/"
+"installed_packages.txt をバックアップに含める"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:100
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:105
@@ -7771,7 +7772,7 @@ msgstr "スキップ"
 
 #: modules/luci-mod-system/htdocs/luci-static/resources/view/system/flash.js:257
 msgid "Skip from backup files that are equal to those in /rom"
-msgstr ""
+msgstr "/rom 内のデフォルトから未変更のファイルはバックアップをスキップ"
 
 #: themes/luci-theme-openwrt-2020/ucode/template/themes/openwrt2020/header.ut:35
 #: themes/luci-theme-openwrt/luasrc/view/themes/openwrt.org/header.htm:46

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2009-06-10 03:41+0200\n"
-"PO-Revision-Date: 2022-11-08 01:55+0000\n"
+"PO-Revision-Date: 2022-11-23 11:36+0000\n"
 "Last-Translator: Wellington Terumi Uemura <wellingtonuemura@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
 "openwrt/luci/pt_BR/>\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 4.14.2\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:643
 msgctxt "Yet unknown nftables table family (\"family\" table \"name\")"
@@ -1426,6 +1426,8 @@ msgstr "A chamada falhou"
 msgid ""
 "Can be useful if ISP has IPv6 nameservers but does not provide IPv6 routing."
 msgstr ""
+"Pode ser útil caso o provedor tenha servidores de nomes IPv6, mas não "
+"forneça o roteamento IPv6."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2933
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4162
@@ -2921,7 +2923,7 @@ msgstr "Criptografia"
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:92
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:112
 msgid "Endpoint"
-msgstr "Endpoint"
+msgstr "Extremidade"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:664
 msgid "Endpoint Host"
@@ -3206,11 +3208,11 @@ msgstr "Sistema de arquivo"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:466
 msgid "Filter IPv4 A records"
-msgstr ""
+msgstr "Filtrar os registros IPv4 A"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:460
 msgid "Filter IPv6 AAAA records"
-msgstr ""
+msgstr "Filtrar os registros IPv6 AAAA"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:450
 msgid "Filter private"
@@ -3891,6 +3893,9 @@ msgid ""
 "tunnelled packets with source IP addresses matching this list and route back "
 "packets with matching destination IP."
 msgstr ""
+"Endereços IP permitidos dentro do túnel. O par aceitará pacotes no túnel com "
+"endereços IP de origem correspondentes a esta lista e roteará de volta os "
+"pacotes com IP de destino correspondente."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:36
 msgctxt "nft ip protocol"
@@ -4419,15 +4424,13 @@ msgid "Instance"
 msgstr "Instância"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:162
-#, fuzzy
 msgctxt "WireGuard instance heading"
 msgid "Instance \"%h\""
-msgstr "Instância"
+msgstr "Instância \"%h\""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:71
-#, fuzzy
 msgid "Instance Details"
-msgstr "Instância"
+msgstr "Detalhes da instância"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2046
 msgid ""
@@ -4646,7 +4649,7 @@ msgstr "Mantenha as configurações e preserve a configuração atual"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:97
 msgid "Keep-Alive"
-msgstr ""
+msgstr "Manter vivo"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:20
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
@@ -5725,7 +5728,6 @@ msgid "Never"
 msgstr "Nunca"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:16
-#, fuzzy
 msgctxt "No WireGuard peer handshake yet"
 msgid "Never"
 msgstr "Nunca"
@@ -5883,9 +5885,8 @@ msgid "No password set!"
 msgstr "Nenhuma senha definida!"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:121
-#, fuzzy
 msgid "No peers connected"
-msgstr "Não conectado"
+msgstr "Nenhum par conectado"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:512
 msgid "No peers defined yet."
@@ -6681,7 +6682,7 @@ msgstr "Parceiro"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:88
 msgid "Peer Details"
-msgstr ""
+msgstr "Detalhes do par"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:89
 msgid "Peer IP address to assign"
@@ -6789,10 +6790,9 @@ msgid "Port"
 msgstr "Porta"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:174
-#, fuzzy
 msgctxt "WireGuard listen port"
 msgid "Port %d"
-msgstr "Porta %s"
+msgstr "Porta %d"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:702
 msgid "Port isolation"
@@ -7147,9 +7147,8 @@ msgid "Receive"
 msgstr "Receber"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:94
-#, fuzzy
 msgid "Received Data"
-msgstr "Receber"
+msgstr "Dados recebidos"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:181
 msgid "Recommended. IP addresses of the WireGuard interface."
@@ -7226,11 +7225,10 @@ msgid "Relay Bridge"
 msgstr "Ponte por Retransmissão"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:352
-#, fuzzy
 msgid "Relay DHCP requests elsewhere. OK: v4↔v4, v6↔v6. Not OK: v4↔v6, v6↔v4."
 msgstr ""
-"Redistribuir as solicitações do DHCP em outro lugar. OK: v4<->v4, v6<->v6. "
-"Não está ok: v4<->v6, v6<->v4."
+"Retransmita as solicitações DHCP em outro lugar. OK: v4 v4↔, v6 v6↔. Não "
+"está OK: v4 v6, v6↔v4↔."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:385
 msgid "Relay To address"
@@ -7274,10 +7272,12 @@ msgstr "Remover"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:467
 msgid "Remove IPv4 addresses from the results and only return IPv6 addresses."
 msgstr ""
+"Remova os endereços IPv4 dos resultados e retorne apenas endereços IPv6."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:461
 msgid "Remove IPv6 addresses from the results and only return IPv4 addresses."
 msgstr ""
+"Remova os endereços IPv6 dos resultados e retorne apenas endereços IPv4."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1318
 msgid "Remove related device settings from the configuration"
@@ -9545,9 +9545,8 @@ msgid "Transmit Hash Policy"
 msgstr "Política de transmissão do hash"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:95
-#, fuzzy
 msgid "Transmitted Data"
-msgstr "Antena de Transmissão"
+msgstr "Dados transmitidos"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:79
 msgctxt "nft @th,off,len"
@@ -10629,7 +10628,7 @@ msgstr "desativar"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:91
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:25
 msgid "disabled"
-msgstr "desabilitado"
+msgstr "desativado"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:577
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:611
@@ -10647,7 +10646,7 @@ msgstr "por exemplo: despejo"
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:97
 msgctxt "WireGuard keep alive interval"
 msgid "every %ds"
-msgstr ""
+msgstr "a cada %ds"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:871
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:901

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -2,24 +2,24 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LuCI: base\n"
 "POT-Creation-Date: 2010-05-09 01:01+0300\n"
-"PO-Revision-Date: 2022-11-08 16:02+0000\n"
-"Last-Translator: Anton Kikin <a.a.kikin@gmail.com>\n"
-"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/luci/ru/"
-">\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: AHOHNMYC <lqwh2h2cwa@protonmail.com>\n"
+"Language-Team: Russian <https://hosted.weblate.org/projects/openwrt/luci/ru/>"
+"\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
-"X-Generator: Weblate 4.14.2\n"
+"X-Generator: Weblate 4.15-dev\n"
 "Project-Info: Это технический перевод, не дословный. Главное-удобный русский "
 "интерфейс, все проверялось в графическом режиме, совместим с другими apps\n"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:643
 msgctxt "Yet unknown nftables table family (\"family\" table \"name\")"
 msgid "\"%h\" table \"%h\""
-msgstr "«%h» таблица «%h»"
+msgstr "\"%h\" таблица \"%h\""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1539
 msgid "%.1f dB"
@@ -47,7 +47,7 @@ msgstr "%d сек. назад"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/switch.js:35
 msgid "%s is untagged in multiple VLANs!"
-msgstr "%s не тегирован в множестве VLAN!"
+msgstr "%s не тегирован в нескольких VLAN-ах!"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/bandwidth.js:296
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js:405
@@ -1411,6 +1411,8 @@ msgstr "Ошибка вызова"
 msgid ""
 "Can be useful if ISP has IPv6 nameservers but does not provide IPv6 routing."
 msgstr ""
+"Может быть полезно, когда провайдер имеет IPv6 серверы имён, но не "
+"предоставляет IPv6 маршрутизацию."
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2933
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4162
@@ -3176,11 +3178,11 @@ msgstr "Файловая система"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:466
 msgid "Filter IPv4 A records"
-msgstr ""
+msgstr "Фильтровать IPv4 A записи"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:460
 msgid "Filter IPv6 AAAA records"
-msgstr ""
+msgstr "Фильтровать IPv6 AAAA записи"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:450
 msgid "Filter private"
@@ -3850,6 +3852,9 @@ msgid ""
 "tunnelled packets with source IP addresses matching this list and route back "
 "packets with matching destination IP."
 msgstr ""
+"IP-адреса, которые разрешены внутри туннеля. Пир будет принимать туннельные "
+"пакеты с IP-адресами источника, соответствующими этому списку, и направлять "
+"обратно пакеты с соответствующими IP-адресами назначения."
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:36
 msgctxt "nft ip protocol"
@@ -4373,15 +4378,13 @@ msgid "Instance"
 msgstr "Экземпляр"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:162
-#, fuzzy
 msgctxt "WireGuard instance heading"
 msgid "Instance \"%h\""
-msgstr "Экземпляр"
+msgstr "Экземпляр «%h»"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:71
-#, fuzzy
 msgid "Instance Details"
-msgstr "Экземпляр"
+msgstr "Сведения об экземпляре"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2046
 msgid ""
@@ -4600,7 +4603,7 @@ msgstr "Сохранить настройки и оставить текущую
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:97
 msgid "Keep-Alive"
-msgstr ""
+msgstr "Keep-Alive"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:20
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
@@ -5678,7 +5681,6 @@ msgid "Never"
 msgstr "Никогда"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:16
-#, fuzzy
 msgctxt "No WireGuard peer handshake yet"
 msgid "Never"
 msgstr "Никогда"
@@ -5837,9 +5839,8 @@ msgid "No password set!"
 msgstr "Пароль не установлен!"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:121
-#, fuzzy
 msgid "No peers connected"
-msgstr "Не подключен"
+msgstr "Нет подключенных узлов"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:512
 msgid "No peers defined yet."
@@ -6626,7 +6627,7 @@ msgstr "Узел"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:88
 msgid "Peer Details"
-msgstr ""
+msgstr "Сведения об узле"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:89
 msgid "Peer IP address to assign"
@@ -6734,10 +6735,9 @@ msgid "Port"
 msgstr "Порт"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:174
-#, fuzzy
 msgctxt "WireGuard listen port"
 msgid "Port %d"
-msgstr "Порт %s"
+msgstr "Порт %d"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:702
 msgid "Port isolation"
@@ -7094,9 +7094,8 @@ msgid "Receive"
 msgstr "Приём"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:94
-#, fuzzy
 msgid "Received Data"
-msgstr "Приём"
+msgstr "Принятые данные"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:181
 msgid "Recommended. IP addresses of the WireGuard interface."
@@ -7173,11 +7172,9 @@ msgid "Relay Bridge"
 msgstr "Мост-Ретранслятор"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:352
-#, fuzzy
 msgid "Relay DHCP requests elsewhere. OK: v4↔v4, v6↔v6. Not OK: v4↔v6, v6↔v4."
 msgstr ""
-"Передача запросов DHCP в другие места. OK: v4<->v4, v6<->v6. Не OK: v4<->v6, "
-"v6<->v4."
+"Передача запросов DHCP в другие места. OK: v4↔v4, v6↔v6. Не OK: v4↔v6, v6↔v4."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:385
 msgid "Relay To address"
@@ -7220,11 +7217,11 @@ msgstr "Удалить"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:467
 msgid "Remove IPv4 addresses from the results and only return IPv6 addresses."
-msgstr ""
+msgstr "Удалить адреса IPv4 из результатов и возвращать только адреса IPv6."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:461
 msgid "Remove IPv6 addresses from the results and only return IPv4 addresses."
-msgstr ""
+msgstr "Удалить адреса IPv6 из результатов и возвращать только адреса IPv4."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1318
 msgid "Remove related device settings from the configuration"
@@ -9471,7 +9468,6 @@ msgid "Transmit Hash Policy"
 msgstr "Хэш политика передачи пакетов"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:95
-#, fuzzy
 msgid "Transmitted Data"
 msgstr "Переданные данные"
 
@@ -10572,7 +10568,7 @@ msgstr "например: dump"
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:97
 msgctxt "WireGuard keep alive interval"
 msgid "every %ds"
-msgstr ""
+msgstr "каждые %dс"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:871
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:901

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-11-08 00:12+0000\n"
+"PO-Revision-Date: 2022-11-23 11:36+0000\n"
 "Last-Translator: Eric <hamburger1024@mailbox.org>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
 "openwrt/luci/zh_Hans/>\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.14.2\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:643
 msgctxt "Yet unknown nftables table family (\"family\" table \"name\")"
@@ -1353,7 +1353,7 @@ msgstr "调用失败"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:462
 msgid ""
 "Can be useful if ISP has IPv6 nameservers but does not provide IPv6 routing."
-msgstr ""
+msgstr "如果你的 ISP 有 IPv6 名称服务器但不提供 IPv6 路由，本选项可能会有用。"
 
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:2933
 #: modules/luci-base/htdocs/luci-static/resources/ui.js:4162
@@ -3048,11 +3048,11 @@ msgstr "文件系统"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:466
 msgid "Filter IPv4 A records"
-msgstr ""
+msgstr "过滤 IPv4 A 记录"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:460
 msgid "Filter IPv6 AAAA records"
-msgstr ""
+msgstr "过滤 IPv6 AAAA 记录"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:450
 msgid "Filter private"
@@ -3712,7 +3712,8 @@ msgid ""
 "IP addresses that are allowed inside the tunnel. The peer will accept "
 "tunnelled packets with source IP addresses matching this list and route back "
 "packets with matching destination IP."
-msgstr ""
+msgstr "隧道内允许的 IP 地址。对端接受源 IP 地址匹配此列表的隧道报文，并将目的地 IP "
+"匹配该列表的数据包路由回去。"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:36
 msgctxt "nft ip protocol"
@@ -4221,15 +4222,13 @@ msgid "Instance"
 msgstr "实例"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:162
-#, fuzzy
 msgctxt "WireGuard instance heading"
 msgid "Instance \"%h\""
-msgstr "实例"
+msgstr "实例 \"%h\""
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:71
-#, fuzzy
 msgid "Instance Details"
-msgstr "实例"
+msgstr "实例详情"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:2046
 msgid ""
@@ -4436,7 +4435,7 @@ msgstr "保留当前配置"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:97
 msgid "Keep-Alive"
-msgstr ""
+msgstr "保活"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js:20
 #: modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json:84
@@ -5489,7 +5488,6 @@ msgid "Never"
 msgstr "永不"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:16
-#, fuzzy
 msgctxt "No WireGuard peer handshake yet"
 msgid "Never"
 msgstr "永不"
@@ -5642,9 +5640,8 @@ msgid "No password set!"
 msgstr "未设置密码！"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:121
-#, fuzzy
 msgid "No peers connected"
-msgstr "未连接"
+msgstr "未连接对端"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:512
 msgid "No peers defined yet."
@@ -6404,7 +6401,7 @@ msgstr "对端"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:88
 msgid "Peer Details"
-msgstr ""
+msgstr "对端详情"
 
 #: protocols/luci-proto-pppossh/htdocs/luci-static/resources/protocol/pppossh.js:89
 msgid "Peer IP address to assign"
@@ -6512,10 +6509,9 @@ msgid "Port"
 msgstr "端口"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:174
-#, fuzzy
 msgctxt "WireGuard listen port"
 msgid "Port %d"
-msgstr "端口 %s"
+msgstr "端口 %d"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/tools/network.js:702
 msgid "Port isolation"
@@ -6856,9 +6852,8 @@ msgid "Receive"
 msgstr "接收"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:94
-#, fuzzy
 msgid "Received Data"
-msgstr "接收"
+msgstr "已接收的数据"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js:181
 msgid "Recommended. IP addresses of the WireGuard interface."
@@ -6933,9 +6928,8 @@ msgid "Relay Bridge"
 msgstr "中继桥"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:352
-#, fuzzy
 msgid "Relay DHCP requests elsewhere. OK: v4↔v4, v6↔v6. Not OK: v4↔v6, v6↔v4."
-msgstr "在别处中继 DHCP 请求。OK: v4<->v4, v6<->v6. Not OK: v4<->v6, v6<->v4。"
+msgstr "在别处中继 DHCP 请求。OK: v4↔v4, v6↔v6. Not OK: v4↔v6, v6↔v4。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:385
 msgid "Relay To address"
@@ -6978,11 +6972,11 @@ msgstr "移除"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:467
 msgid "Remove IPv4 addresses from the results and only return IPv6 addresses."
-msgstr ""
+msgstr "从结果中删除 IPv4 地址，只返回 IPv6 地址。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:461
 msgid "Remove IPv6 addresses from the results and only return IPv4 addresses."
-msgstr ""
+msgstr "从结果中删除 IPv6 地址，只返回 IPv4 地址。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1318
 msgid "Remove related device settings from the configuration"
@@ -9059,9 +9053,8 @@ msgid "Transmit Hash Policy"
 msgstr "传输散列策略"
 
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:95
-#, fuzzy
 msgid "Transmitted Data"
-msgstr "传送天线"
+msgstr "已传输的数据"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js:79
 msgctxt "nft @th,off,len"
@@ -10111,7 +10104,7 @@ msgstr "比如： dump"
 #: protocols/luci-proto-wireguard/htdocs/luci-static/resources/view/wireguard/status.js:97
 msgctxt "WireGuard keep alive interval"
 msgid "every %ds"
-msgstr ""
+msgstr "每 %d 秒"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:871
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:901

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"PO-Revision-Date: 2022-10-18 16:08+0000\n"
-"Last-Translator: Hulen <shift0106@gmail.com>\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: James Tien <jamestien.1219@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
 "openwrt/luci/zh_Hant/>\n"
 "Language: zh_Hant\n"
@@ -465,7 +465,7 @@ msgstr "動作"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js:14
 msgid "Active"
-msgstr "活躍"
+msgstr "已啓用"
 
 #: modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js:81
 msgid "Active Connections"
@@ -10099,7 +10099,7 @@ msgstr "關閉"
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:91
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:25
 msgid "disabled"
-msgstr "已停用"
+msgstr "已禁用"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:577
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:611

--- a/modules/luci-mod-dashboard/po/zh_Hant/dashboard.po
+++ b/modules/luci-mod-dashboard/po/zh_Hant/dashboard.po
@@ -1,18 +1,18 @@
 msgid ""
 msgstr ""
-"PO-Revision-Date: 2022-05-07 19:19+0000\n"
-"Last-Translator: 王攀 <41330784@qq.com>\n"
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: James Tien <jamestien.1219@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
 "openwrt/lucimodulesluci-mod-dashboard/zh_Hant/>\n"
 "Language: zh_Hant\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-"X-Generator: Weblate 4.12.1\n"
+"X-Generator: Weblate 4.15-dev\n"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js:163
 msgid "Active"
-msgstr "活躍"
+msgstr "已啓用"
 
 #: modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js:308
 msgid "Architecture"

--- a/modules/luci-mod-dsl/po/da/dsl.po
+++ b/modules/luci-mod-dsl/po/da/dsl.po
@@ -1,0 +1,76 @@
+msgid ""
+msgstr ""
+"PO-Revision-Date: 2022-11-25 14:34+0000\n"
+"Last-Translator: drax red <drax@outlook.dk>\n"
+"Language-Team: Danish <https://hosted.weblate.org/projects/openwrt/"
+"luci_modules_luci-mod-dsl/da/>\n"
+"Language: da\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 4.15-dev\n"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:24
+#: modules/luci-mod-dsl/root/usr/share/luci/menu.d/luci-mod-dsl.json:3
+msgid "DSL line spectrum"
+msgstr "DSL linje spektrum"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:212
+msgid "Downstream HLOG"
+msgstr "Downstream HLOG"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:182
+msgid "Downstream QLN"
+msgstr "Downstream QLN"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:152
+msgid "Downstream SNR"
+msgstr "Downstream SNR"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:122
+msgid "Downstream bits allocation"
+msgstr "Downstream bittildeling"
+
+#: modules/luci-mod-dsl/root/usr/share/rpcd/acl.d/luci-mod-dsl.json:3
+msgid "Grant access to luci-mod-dsl spectrum"
+msgstr "Giv adgang til luci-mod-dsl-spektrum"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:25
+msgid ""
+"Graphs below show Signal-to-noise ratio, Bit allocation, Quiet line noise "
+"and Channel characteristics function (HLOG) per sub-carrier."
+msgstr ""
+"Nedenstående grafer viser signal-til-støj-forhold, bitallokering, stille "
+"linjestøj og kanalkarakteristikfunktion (HLOG) pr. sub-carrier."
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:106
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:136
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:166
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:196
+msgid "Sub-carrier"
+msgstr "Sub-carrier"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:207
+msgid "Upstream HLOG"
+msgstr "Upstream HLOG"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:177
+msgid "Upstream QLN"
+msgstr "Upstream QLN"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:147
+msgid "Upstream SNR"
+msgstr "Upstream SNR"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:111
+msgid "bits"
+msgstr "bits"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:141
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:201
+msgid "dB"
+msgstr "dB"
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:171
+msgid "dBm/Hz"
+msgstr "dBm/Hz"


### PR DESCRIPTION
* Depends on https://github.com/openwrt/packages/pull/19763
* This removes luci apps for vpn-policy-routing and vpnbypass as their principal packages are obsoleted by `pbr`
* As this is a first substantial converstion to javascript, I need help to finish this up. I'll link specific parts of code in comments below.

Signed-off-by: Stan Grishin <stangri@melmac.ca>