### PR TITLE
luci-app-https-dns-proxy: add cn.edu.tsinghua.tuna.dns.lua provider

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.edu.tsinghua.tuna.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.edu.tsinghua.tuna.dns.lua
@@ -1,0 +1,6 @@
+return {
+	name = "dns.tuna.tsinghua.edu.cn",
+	label = _("Tsinghua University Secure DNS - CN"),
+	resolver_url = "https://dns.tuna.tsinghua.edu.cn:8443/dns-query",
+	bootstrap_dns = "208.67.222.222,208.67.220.220",
+}

--- a/applications/luci-app-https-dns-proxy/po/zh_Hans/https-dns-proxy.po
+++ b/applications/luci-app-https-dns-proxy/po/zh_Hans/https-dns-proxy.po
@@ -28,6 +28,10 @@ msgstr "%s 未安装或未找到"
 msgid "360 Secure DNS - CN"
 msgstr "360 安全 DNS - CN"
 
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.edu.tsinghua.tuna.dns.lua:3
+msgid "Tsinghua University Secure DNS - CN"
+msgstr "清华大学 安全 DNS - CN"
+
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua:3
 msgid "AdGuard (Family Protection)"
 msgstr "AdGuard（家庭保护）"


### PR DESCRIPTION
luci-app-https-dns-proxy: add cn.edu.tsinghua.tuna.dns.lua provider

Signed-off-by: Zhang Rui <rui.crater@gmail.com>