### PR TITLE
luci-app-openvpn: add possibility to set param "compress" without algorithm

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -161,7 +161,7 @@ local knownParams = {
 			translate("Policy level over usage of external programs and scripts") },
 		{ ListValue,
 			"compress",
-			{ "lzo", "lz4", "stub-v2"},
+			{ "frames_only", "lzo", "lz4", "stub-v2"},
 			translate("Security recommendation: It is recommended to not enable compression and set this parameter to `stub-v2`") },
 	} },
 


### PR DESCRIPTION
@feckert This is the luci part of the PR https://github.com/openwrt/packages/pull/19756

In some situations you need to set the compress param without an algorithm. Compression will be turned off, but the packet framing for compression will still be enabled, allowing a different setting to be pushed later.

As it is not possible to have options with optional values at the moment, I've introduced a pseudo value "frames_only" which will be removed in the init script.

Signed-off-by: Martin Schiller <ms@dev.tdt.de>

