### PR TITLE
[22.03] luci-app-simple-adblock: update to 1.9.3-1

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.9.2-5
+PKG_VERSION:=1.9.3-1
 
 LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.

--- a/applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js
+++ b/applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js
@@ -110,8 +110,14 @@ return view.extend({
 
 			o = s.taboption("tab_advanced", form.Value, "download_timeout", _("Download time-out (in seconds)"),
 				_("Stop the download if it is stalled for set number of seconds."));
-			o.default = "10";
+			o.default = "20";
 			o.datatype = "range(1,60)";
+
+			o = s.taboption("tab_advanced", form.Value, "curl_max_file_size", _("Curl maximum file size (in bytes)"),
+				_("If curl is installed and detected, it would not download files bigger than this."));
+			o.default = "";
+			o.datatype = "uinteger";
+			o.rmempty = true;
 
 			o = s.taboption("tab_advanced", form.Value, "curl_retry", _("Curl download retry"),
 				_("If curl is installed and detected, it would retry download this many times on timeout/fail."));
@@ -138,21 +144,31 @@ return view.extend({
 
 			s = m.section(form.NamedSection, "config", "simple-adblock", 
 				_("Allowed and Blocked Lists Management"));
+			o = s.option(form.Value, "dnsmasq_config_file_url", _("Dnsmasq Config File URL"),
+				_("URL to the external dnsmasq config file, see the %sREADME%s for details.")
+					.format("<a href=\"" + pkg.URL + "#dnsmasq_config_file_url\" target=\"_blank\">", "</a>"));
+			o.addremove = true;
+			o.rmempty = true;
 			o = s.option(form.DynamicList, "allowed_domain", _("Allowed Domains"),
 				_("Individual domains to be allowed."));
-			o.addremove = false;
+			o.depends('dnsmasq_config_file_url', '');
+			o.addremove = true;
 			o = s.option(form.DynamicList, "allowed_domains_url", _("Allowed Domain URLs"),
 				_("URLs to lists of domains to be allowed."));
-			o.addremove = false;
+			o.depends('dnsmasq_config_file_url', '');
+			o.addremove = true;
 			o = s.option(form.DynamicList, "blocked_domain", _("Blocked Domains"),
 				_("Individual domains to be blocked."));
-			o.addremove = false;
+			o.depends('dnsmasq_config_file_url', '');
+			o.addremove = true;
 			o = s.option(form.DynamicList, "blocked_domains_url", _("Blocked Domain URLs"),
 				_("URLs to lists of domains to be blocked."));
-			o.addremove = false;
+			o.depends('dnsmasq_config_file_url', '');
+			o.addremove = true;
 			o = s.option(form.DynamicList, "blocked_hosts_url", _("Blocked Hosts URLs"),
 				_("URLs to lists of hosts to be blocked."));
-			o.addremove = false;
+			o.depends('dnsmasq_config_file_url', '');
+			o.addremove = true;
 
 			return Promise.all([status.render(), m.render()]);
 		})

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -21,19 +21,19 @@ msgstr ""
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:144
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:156
 msgid "Allowed Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:141
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:152
 msgid "Allowed Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:140
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:146
 msgid "Allowed and Blocked Lists Management"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:128
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:134
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
 msgstr ""
@@ -46,15 +46,15 @@ msgstr ""
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:150
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:164
 msgid "Blocked Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:147
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:160
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:153
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:168
 msgid "Blocked Hosts URLs"
 msgstr ""
 
@@ -78,8 +78,12 @@ msgstr ""
 msgid "Controls system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:116
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:122
 msgid "Curl download retry"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:116
+msgid "Curl maximum file size (in bytes)"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:85
@@ -96,8 +100,8 @@ msgstr ""
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:135
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:137
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:141
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:143
 msgid "Disable Debugging"
 msgstr ""
 
@@ -105,17 +109,21 @@ msgstr ""
 msgid "Disabling %s service"
 msgstr ""
 
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:147
+msgid "Dnsmasq Config File URL"
+msgstr ""
+
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:104
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:108
 msgid "Do not add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:129
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:131
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:135
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:137
 msgid "Do not store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:123
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:129
 msgid "Do not use simultaneous processing"
 msgstr ""
 
@@ -132,12 +140,12 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:133
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:136
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:139
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:142
 msgid "Enable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:134
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:140
 msgid "Enables debug output to /tmp/simple-adblock.log."
 msgstr ""
 
@@ -192,15 +200,21 @@ msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:117
 msgid ""
+"If curl is installed and detected, it would not download files bigger than "
+"this."
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:123
+msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:142
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:153
 msgid "Individual domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:148
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:161
 msgid "Individual domains to be blocked."
 msgstr ""
 
@@ -208,7 +222,7 @@ msgstr ""
 msgid "LED to indicate status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:122
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:128
 msgid ""
 "Launch all lists downloads and processing simultaneously, reducing service "
 "start time."
@@ -276,7 +290,7 @@ msgstr ""
 msgid "Simple AdBlock - Status"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:121
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:127
 msgid "Simultaneous processing"
 msgstr ""
 
@@ -312,11 +326,11 @@ msgstr ""
 msgid "Stopping %s service"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:130
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:136
 msgid "Store compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:127
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:133
 msgid "Store compressed cache file on router"
 msgstr ""
 
@@ -324,20 +338,25 @@ msgstr ""
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:145
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:148
+msgid ""
+"URL to the external dnsmasq config file, see the %sREADME%s for details."
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:157
 msgid "URLs to lists of domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:151
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:165
 msgid "URLs to lists of domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:154
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:169
 msgid "URLs to lists of hosts to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:124
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:125
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:130
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:131
 msgid "Use simultaneous processing"
 msgstr ""
 

--- a/applications/luci-app-simple-adblock/root/usr/libexec/rpcd/luci.simple-adblock
+++ b/applications/luci-app-simple-adblock/root/usr/libexec/rpcd/luci.simple-adblock
@@ -109,11 +109,16 @@ get_init_status() {
 	local name
 	name="$(basename "$1")"
 	name="${name:-$packageName}" 
-	local errors ports dns outputFile outputCache outputGzip
+	local errors warnings ports dns outputFile outputCache outputGzip
 	local i
 	errors="$(ubus_get_status errors)"
+	warnings="$(ubus_get_status warnings)"
 	ports="$(ubus_get_ports)"
-	dns="$(uci -q get $packageName.config.dns)"
+	if [ -n "$(uci -q get $packageName.config.dnsmasq_config_file_url)" ]; then
+		dns="dnsmasq.conf"
+	else
+		dns="$(uci -q get $packageName.config.dns)"
+	fi
 	case "$dns" in
 		dnsmasq.addnhosts)
 			outputFile="$dnsmasqAddnhostsFile"
@@ -160,6 +165,7 @@ get_init_status() {
 	json_add_array 'errors'
 		for i in $errors; do json_add_string '' "$i"; done
 	json_close_array
+#	json_add_string 'warnings' "$warnings"
 	if [ -n "$ports" ]; then
 		json_add_boolean 'force_dns_active' '1'
 		json_add_array 'force_dns_ports'


### PR DESCRIPTION
Depends on https://github.com/openwrt/packages/pull/19901
Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit ec31047e357afc19806b7f3d5781389769fada81)