### PR TITLE
luci-mod-network: improve description for filterwin2k option again

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -452,8 +452,8 @@ return view.extend({
 		o.default = o.enabled;
 
 		s.taboption('advanced', form.Flag, 'filterwin2k',
-			_('Filter useless'),
-			_('Avoid uselessly triggering dial-on-demand links (filters SRV/SOA records and names with underscores).') + '<br />' +
+			_('Filter SRV/SOA service discovery'),
+			_('Filters SRV/SOA service discovery, to avoid triggering dial-on-demand links.') + '<br />' +
 			_('May prevent VoIP or other services from working.'));
 
 		o = s.taboption('advanced', form.Flag, 'filter_aaaa',


### PR DESCRIPTION
@janh improved this somewhat in #5996.

This change goes one step further:

Stop using the word useless both in the name and the description and call the feature what it actually is (Filter SRV/SOA service discovery).
