### PR TITLE
luci-app-advanced-reboot: Xiaomi AX9000 json file

### DIFF
--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax9000.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax9000.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Xiaomi",
+	"deviceName": "AX9000",
+	"boardNames": [ "ax9000", "xiaomi,ax9000" ],
+	"partition1MTD": "rootfs",
+	"partition2MTD": "rootfs_1",
+	"labelOffset": 32,
+	"bootEnv1": "flag_boot_rootfs",
+	"bootEnv1Partition1Value": 0,
+	"bootEnv1Partition2Value": 1,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax9000.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax9000.json
@@ -4,7 +4,7 @@
 	"boardNames": [ "ax9000", "xiaomi,ax9000" ],
 	"partition1MTD": "rootfs",
 	"partition2MTD": "rootfs_1",
-	"labelOffset": 32,
+	"labelOffset": 266432,
 	"bootEnv1": "flag_boot_rootfs",
 	"bootEnv1Partition1Value": 0,
 	"bootEnv1Partition2Value": 1,


### PR DESCRIPTION
The Xiaomi AX9000 has now experimental support on robimarko's github repo.

Wiki: https://openwrt.org/inbox/toh/xiaomi/ax9000#experimental_firmware

