### PR TITLE
luci-app-frpc：add enable options

### DIFF
--- a/applications/luci-app-frpc/po/zh_Hans/frpc.po
+++ b/applications/luci-app-frpc/po/zh_Hans/frpc.po
@@ -10,7 +10,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.13.1-dev\n"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:214
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+msgid "Enable"
+msgstr "启用"
+
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:213
 msgid "Add new proxy..."
 msgstr "添加新代理…"
 
@@ -18,33 +22,33 @@ msgstr "添加新代理…"
 msgid "Additional configs"
 msgstr "额外配置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid "Additional settings"
 msgstr "其他设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
 msgid "Admin address"
 msgstr "管理地址"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
 msgid "Admin password"
 msgstr "管理密码"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
 msgid "Admin port"
 msgstr "管理端口"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
 msgid "Admin user"
 msgstr "管理用户"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
 msgid ""
 "AdminAddr specifies the address that the admin server binds to.<br />By "
 "default, this value is \"127.0.0.1\"."
 msgstr "AdminAddr 特指用于绑定管理服务器的地址。<br />默认是\"127.0.0.1\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:29
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
 msgid ""
 "AdminPort specifies the port for the admin server to listen on. If this "
 "value is 0, the admin server will not be started.<br />By default, this "
@@ -53,25 +57,25 @@ msgstr ""
 "AdminPort 用于指定管理服务器要侦听的端口。如果此值为0，则不会启动管理服务器。"
 "<br />默认情况下，此值为0。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
 msgid ""
 "AdminPwd specifies the password that the admin server will use for login."
 "<br />By default, this value is \"admin\"."
 msgstr ""
 "AdminPwd 指定管理服务器用于登录的密码。<br />默认情况下，此值为\"admin\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:30
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:31
 msgid ""
 "AdminUser specifies the username that the admin server will use for login."
 "<br />By default, this value is \"admin\"."
 msgstr ""
 "AdminUser 指定管理服务器用于登录的用户名。<br />默认情况下，此值为\"admin\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
 msgid "Assets dir"
 msgstr "资源目录"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:32
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
 msgid ""
 "AssetsDir specifies the local directory that the admin server will load "
 "resources from. If this value is \"\", assets will be loaded from the "
@@ -84,11 +88,11 @@ msgstr ""
 msgid "Collecting data ..."
 msgstr "收集数据中 ..."
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:197
 msgid "Common Settings"
 msgstr "通用设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
 msgid "Compression"
 msgstr "压缩"
 
@@ -96,21 +100,21 @@ msgstr "压缩"
 msgid "Config files include in temporary config file"
 msgstr "配置文件包含在临时配置文件中"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:57
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
 msgid "Custom domains"
 msgstr "自定义域名"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
 msgid "Disable log color"
 msgstr "禁用日志的颜色"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
 msgid ""
 "DisableLogColor disables log colors when LogWay == \"console\" when set to "
 "true."
 msgstr "当DisableLogColor设置为true且LogWay==\"console\"时禁用日志颜色。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
 msgid "Encryption"
 msgstr "加密"
 
@@ -118,11 +122,11 @@ msgstr "加密"
 msgid "Environment variable"
 msgstr "环境变量"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
 msgid "Exit when login fail"
 msgstr "当登录失败时退出"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:217
 msgid "General Settings"
 msgstr "常规设置"
 
@@ -130,25 +134,25 @@ msgstr "常规设置"
 msgid "Grant access to LuCI app frpc"
 msgstr "授予访问 LuCI 应用 frpc 的权限"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:218
 msgid "HTTP Settings"
 msgstr "HTTP 设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
 msgid "HTTP password"
 msgstr "HTTP 密码"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
 msgid "HTTP proxy"
 msgstr "HTTP 代理"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:77
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:64
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:78
 msgid "HTTP user"
 msgstr "HTTP 用户"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
 msgid ""
 "HeartBeatInterval specifies at what interval heartbeats are sent to the "
 "server, in seconds. It is not recommended to change this value.<br />By "
@@ -157,7 +161,7 @@ msgstr ""
 "HeartBeatInterval 用于指定向服务器发送心跳包的间隔（以秒为单位）。不建议更改"
 "此值。<br />默认情况下，此值为 30。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
 msgid ""
 "HeartBeatTimeout specifies the maximum allowed heartbeat response delay "
 "before the connection is terminated, in seconds. It is not recommended to "
@@ -166,19 +170,19 @@ msgstr ""
 "HeartBeatTimeout 用于指定多久未收到心跳包后断开连接（以秒为单位）。不建议更改"
 "此值。<br />默认情况下，此值为 90。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
 msgid "Heartbeat interval"
 msgstr "心跳包间隔时间"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:39
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
 msgid "Heartbeat timeout"
 msgstr "心跳包超时"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:65
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:66
 msgid "Host header rewrite"
 msgstr "主机头重写"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
 msgid ""
 "HttpProxy specifies a proxy address to connect to the server through. If "
 "this value is \"\", the server will be connected to directly.<br />By "
@@ -187,41 +191,41 @@ msgstr ""
 "HttpProxy 指定连接到服务器所用的代理地址。如果此值空，则直接连接服务器。<br /"
 ">默认情况下，从\"http_proxy\"环境变量中读取此值。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
 msgid "If remote_port is 0, frps will assign a random port for you"
 msgstr "如果remote_port为 0，frps 将为您随机分配一个端口"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
 msgid "Local IP"
 msgstr "本地 IP"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:50
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:224
 msgid "Local port"
 msgstr "本地端口"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
 msgid "LocalIp specifies the IP address or host name to proxy to."
 msgstr "本地 IP 指定要被代理的 IP 地址或主机名。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:49
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:50
 msgid "LocalPort specifies the port to proxy to."
 msgstr "本地端口指定要被代理的端口。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:62
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:63
 msgid "Locations"
 msgstr "位置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid "Log file"
 msgstr "日志文件"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid "Log level"
 msgstr "日志记录等级"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
 msgid "Log max days"
 msgstr "日志最大天数"
 
@@ -233,7 +237,7 @@ msgstr "错误日志"
 msgid "Log stdout"
 msgstr "普通日志"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:23
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
 msgid ""
 "LogFile specifies a file where logs will be written to. This value will only "
 "be used if LogWay is set appropriately.<br />By default, this value is "
@@ -242,7 +246,7 @@ msgstr ""
 "LogFile 指定写入日志的文件。仅当正确设置 LogWay 时，才会使用此值。<br />默认"
 "值为“console”。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:24
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
 msgid ""
 "LogLevel specifies the minimum log level. Valid values are \"trace\", "
 "\"debug\", \"info\", \"warn\", and \"error\".<br />By default, this value is "
@@ -251,7 +255,7 @@ msgstr ""
 "LogLevel 指定最小的日志级别。有效值为\"trace\", \"debug\", \"info\", "
 "\"warn\"和\"error\"。<br />默认情况下，此值为\"info\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:25
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:26
 msgid ""
 "LogMaxDays specifies the maximum number of days to store log information "
 "before deletion. This is only used if LogWay == \"file\".<br />By default, "
@@ -260,7 +264,7 @@ msgstr ""
 "LogMaxDays 指定删除前存储日志信息的最长天数。仅当 LogWay == \"file\" 时才使"
 "用。<br />默认值为 0。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
 msgid ""
 "LoginFailExit controls whether or not the client should exit after a failed "
 "login attempt. If false, the client will retry until a login attempt "
@@ -269,7 +273,7 @@ msgstr ""
 "LoginFailExit 控制客户端在尝试登录失败后是否应退出。如果为 false，客户端将重"
 "试，直到登录成功。<br />默认情况下，此值为 true。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
 msgid "NOT RUNNING"
 msgstr "未在运行"
 
@@ -281,19 +285,19 @@ msgstr ""
 "操作系统环境传递给 frp。配置模板请参阅 <a href=\"https://github.com/fatedier/"
 "frp#configuration-file-template\">frp文档</a>"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:76
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:77
 msgid "Plugin"
 msgstr "插件"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:220
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:219
 msgid "Plugin Settings"
 msgstr "插件设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
 msgid "Protocol"
 msgstr "协议"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:36
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
 msgid ""
 "Protocol specifies the protocol to use when interacting with the server. "
 "Valid values are \"tcp\", \"kcp\", and \"websocket\".<br />By default, this "
@@ -302,21 +306,21 @@ msgstr ""
 "Protocol 指定在与服务器交互时要使用的协议。有效值为\"tcp\"、\"kcp\"和"
 "\"websocket\"。<br />默认情况下，此值为\"tcp\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:210
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:209
 msgid "Proxy Settings"
 msgstr "代理设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:44
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:221
 msgid "Proxy name"
 msgstr "代理名称"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:223
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:222
 msgid "Proxy type"
 msgstr "代理类型"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:45
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
 msgid ""
 "ProxyType specifies the type of this proxy. Valid values include \"tcp\", "
 "\"udp\", \"http\", \"https\", \"stcp\", and \"xtcp\".<br />By default, this "
@@ -326,12 +330,12 @@ msgstr ""
 "\"tcp\"、\"udp\"、\"http\"、\"https\"、\"stcp\"和\"xtcp\"。<br />默认情况下，"
 "此值为\"tcp\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:164
 msgid "RUNNING"
 msgstr "运行中"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:53
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:226
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:54
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:225
 msgid "Remote port"
 msgstr "远程端口"
 
@@ -339,7 +343,7 @@ msgstr "远程端口"
 msgid "Respawn when crashed"
 msgstr "崩溃时重启"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:70
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
 msgid "Role"
 msgstr "角色"
 
@@ -351,67 +355,67 @@ msgstr "以此组权限运行"
 msgid "Run daemon as user"
 msgstr "以此用户权限运行"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
 msgid "SOCKS5 password"
 msgstr "SOCKS5 密码"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:79
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:80
 msgid "SOCKS5 user"
 msgstr "SOCKS5 用户"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
 msgid "Server address"
 msgstr "服务器地址"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:71
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
 msgid "Server name"
 msgstr "服务器名称"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
 msgid "Server port"
 msgstr "服务器端口"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:20
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
 msgid ""
 "ServerAddr specifies the address of the server to connect to.<br />By "
 "default, this value is \"0.0.0.0\"."
 msgstr ""
 "ServerAddr 指定要连接到的服务器的地址。<br />默认情况下，此值为\"0.0.0.0\"。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:21
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:22
 msgid ""
 "ServerPort specifies the port to connect to the server on.<br />By default, "
 "this value is 7000."
 msgstr "ServerPort 指定要连接到的服务器端口。<br />默认情况下，此值为 7000。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:72
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:73
 msgid "Sk"
 msgstr "Sk"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:199
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:203
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:198
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:202
 msgid "Startup Settings"
 msgstr "启动设置"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:58
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:59
 msgid "Subdomain"
 msgstr "子域名"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
 msgid "TCP mux"
 msgstr "TCP 多路复用"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
 msgid "TLS"
 msgstr "TLS"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:37
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:38
 msgid ""
 "TLSEnable specifies whether or not TLS should be used when communicating "
 "with the server."
 msgstr "TLSEnable 指定在与服务器通信时是否应使用 TLS。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:33
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection. If this value is true, the server "
@@ -421,17 +425,17 @@ msgstr ""
 "TcpMux 切换 TCP 流多路复用。这允许来自客户端的多个请求共享单个 TCP 连接。如果"
 "此值为 true，则服务器必须启用 TCP 多路复用。<br />默认情况下，此值为 true。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:40
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:41
 msgid ""
 "This list can be used to specify some additional parameters which have not "
 "been included in this LuCI."
 msgstr "此列表可用于指定此LuCI中未包括的一些其他参数。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
 msgid "Token"
 msgstr "令牌"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:27
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:28
 msgid ""
 "Token specifies the authorization token used to create keys to be sent to "
 "the server. The server must have a matching token for authorization to "
@@ -440,18 +444,18 @@ msgstr ""
 "Token 指定用于创建要发送到服务器的密钥的授权令牌。服务器必须具有匹配的令牌才"
 "能成功进行授权。<br />默认情况下，此值为空。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:81
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:82
 msgid "Unix domain socket path"
 msgstr "Unix 域套接字路径"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:48
 msgid ""
 "UseCompression controls whether or not communication with the server will be "
 "compressed.<br />By default, this value is false."
 msgstr ""
 "UseCompression 控制是否压缩与服务器的通信。<br />默认情况下，此值为 false。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:46
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:47
 msgid ""
 "UseEncryption controls whether or not communication with the server will be "
 "encrypted. Encryption is done using the tokens supplied in the server and "
@@ -460,11 +464,11 @@ msgstr ""
 "UseEncryption 控制是否加密与服务器的通信。使用服务器和客户端配置中提供的令牌"
 "来完成加密。<br />默认情况下，此值为 false。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
 msgid "User"
 msgstr "用户"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:34
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:35
 msgid ""
 "User specifies a prefix for proxy names to distinguish them from other "
 "clients. If this value is not \"\", proxy names will automatically be "
@@ -473,9 +477,9 @@ msgstr ""
 "User 为代理名称指定前缀，以将它们与其他客户端区分开来。如果此值不为空，则代理"
 "名称将自动更改为\"{user}.{proxy_name}\"。<br />默认情况下，此值为空。"
 
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:163
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:165
-#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:175
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:164
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:166
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:176
 #: applications/luci-app-frpc/root/usr/share/luci/menu.d/luci-app-frpc.json:3
 msgid "frp Client"
 msgstr "frp 客户端"

--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -16,6 +16,7 @@ var startupConf = [
 ];
 
 var commonConf = [
+	[form.Flag, 'enabled', _('Enable')],
 	[form.Value, 'bind_addr', _('Bind address'), _('BindAddr specifies the address that the server binds to.<br />By default, this value is "0.0.0.0".'), {datatype: 'ipaddr'}],
 	[form.Value, 'bind_port', _('Bind port'), _('BindPort specifies the port that the server listens on.<br />By default, this value is 7000.'), {datatype: 'port'}],
 	[form.Value, 'bind_udp_port', _('UDP bind port'), _('BindUdpPort specifies the UDP port that the server listens on. If this value is 0, the server will not listen for UDP connections.<br />By default, this value is 0'), {datatype: 'port'}],
@@ -137,12 +138,10 @@ return view.extend({
 				});
 			});
 
-			return E('div', { class: 'cbi-map' },
-				E('fieldset', { class: 'cbi-section'}, [
-					E('p', { id: 'service_status' },
-						_('Collecting data ...'))
-				])
-			);
+			return E('div', { class: 'cbi-section' }, [
+				E('div', { id: 'service_status' },
+					_('Collecting data ...'))
+			]);
 		}
 
 		s = m.section(form.NamedSection, 'common', 'conf');


### PR DESCRIPTION
without the enable option, there is no control over running or stopping the plug-in. After the enable option is added, you can control whether the plug-in is enabled or not.adaptation frps

Signed-off-by: zxlhhyccc <45259624+zxlhhyccc@users.noreply.github.com>