### PR TITLE
luci-app-frps：add enable options

### DIFF
--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -16,6 +16,7 @@ var startupConf = [
 ];
 
 var commonConf = [
+	[form.Flag, 'enabled', _('Enable')],
 	[form.Value, 'bind_addr', _('Bind address'), _('BindAddr specifies the address that the server binds to.<br />By default, this value is "0.0.0.0".'), {datatype: 'ipaddr'}],
 	[form.Value, 'bind_port', _('Bind port'), _('BindPort specifies the port that the server listens on.<br />By default, this value is 7000.'), {datatype: 'port'}],
 	[form.Value, 'bind_udp_port', _('UDP bind port'), _('BindUdpPort specifies the UDP port that the server listens on. If this value is 0, the server will not listen for UDP connections.<br />By default, this value is 0'), {datatype: 'port'}],
@@ -137,12 +138,10 @@ return view.extend({
 				});
 			});
 
-			return E('div', { class: 'cbi-map' },
-				E('fieldset', { class: 'cbi-section'}, [
-					E('p', { id: 'service_status' },
-						_('Collecting data ...'))
-				])
-			);
+			return E('div', { class: 'cbi-section' }, [
+				E('div', { id: 'service_status' },
+					_('Collecting data ...'))
+			]);
 		}
 
 		s = m.section(form.NamedSection, 'common', 'conf');

--- a/applications/luci-app-frps/po/zh_Hans/frps.po
+++ b/applications/luci-app-frps/po/zh_Hans/frps.po
@@ -10,19 +10,23 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.7.2-dev\n"
 
+#: applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js:19
+msgid "Enable"
+msgstr "启用"
+
 #: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:15
 msgid "Additional configs"
 msgstr "额外配置"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
 msgid "Additional settings"
 msgstr "其他设置"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
 msgid "Allow ports"
 msgstr "允许的端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
 msgid ""
 "AllowPorts specifies a set of ports that clients are able to proxy to. If "
 "the length of this value is 0, all ports are allowed.<br />By default, this "
@@ -31,11 +35,11 @@ msgstr ""
 "AllowPorts 指定客户端能够代理的一组端口。如果此值的长度为 0，则允许所有端口。"
 "<br />默认情况下，此集合为空。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
 msgid "Assets dir"
 msgstr "资源目录"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
 msgid ""
 "AssetsDir specifies the local directory that the dashboard will load "
 "resources from. If this value is \"\", assets will be loaded from the "
@@ -44,21 +48,21 @@ msgstr ""
 "AssetsDir指定仪表板从哪个本地目录加载资源。如果此值为\"\"，将用statik从打包的"
 "可执行文件加载资源。<br />默认值为\"\"。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
 msgid "Bind address"
 msgstr "绑定地址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
 msgid "Bind port"
 msgstr "绑定端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:19
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
 msgid ""
 "BindAddr specifies the address that the server binds to.<br />By default, this "
 "value is \"0.0.0.0\"."
 msgstr "BindAddr 指定服务器绑定到的地址。<br />默认值为 \"0.0.0.0\"。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
 msgid ""
 "BindKcpPort specifies the KCP port that the server listens on. If this value "
 "is 0, the server will not listen for KCP connections.<br />By default, this "
@@ -67,13 +71,13 @@ msgstr ""
 "BindKcpPort 指定服务器侦听的 KCP 端口。如果此值为 0，则服务器将不会侦听 KCP "
 "连接。<br />默认值为 0。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:20
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
 msgid ""
 "BindPort specifies the port that the server listens on.<br />By default, this "
 "value is 7000."
 msgstr "BindPort 指定服务器侦听的端口。<br />默认值为 7000。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
 msgid ""
 "BindUdpPort specifies the UDP port that the server listens on. If this value "
 "is 0, the server will not listen for UDP connections.<br />By default, this "
@@ -86,7 +90,7 @@ msgstr ""
 msgid "Collecting data ..."
 msgstr "收集数据中 ..."
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:151
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:150
 msgid "Common settings"
 msgstr "常规设置"
 
@@ -94,11 +98,11 @@ msgstr "常规设置"
 msgid "Config files include in temporary config file"
 msgstr "配置文件包含在临时配置文件中"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
 msgid "Custom 404 page"
 msgstr "自定义 404 页面"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:40
 msgid ""
 "Custom404Page specifies a path to a custom 404 page to display. If this "
 "value is \"\", a default page will be displayed.<br />By default, this value "
@@ -107,29 +111,29 @@ msgstr ""
 "Custom404Page 指定要显示的自定义 404 页面的路径。如果此值为\"\"，将显示默认页"
 "面。<br />默认值为\"\"。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
 msgid "Dashboard address"
 msgstr "仪表板地址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
 msgid "Dashboard password"
 msgstr "仪表板密码"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
 msgid "Dashboard port"
 msgstr "仪表板端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
 msgid "Dashboard user"
 msgstr "仪表板用户"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
 msgid ""
 "DashboardAddr specifies the address that the dashboard binds to.<br />By "
 "default, this value is \"0.0.0.0\"."
 msgstr "DashboardAddr 指定仪表板绑定到的地址。<br />默认值为“0.0.0.0”。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:28
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
 msgid ""
 "DashboardPort specifies the port that the dashboard listens on. If this "
 "value is 0, the dashboard will not be started.<br />By default, this value is "
@@ -138,23 +142,23 @@ msgstr ""
 "DashboardPort 指定仪表板侦听的端口。如果此值为 0，则不会启动仪表板。<br />默认"
 "值为 0。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:31
 msgid ""
 "DashboardPwd specifies the password that the dashboard will use for login."
 "<br />By default, this value is \"admin\"."
 msgstr "DashboardPwd 指定仪表板将用于登录的密码。<br />默认值为“admin”。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:29
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:30
 msgid ""
 "DashboardUser specifies the username that the dashboard will use for login."
 "<br />By default, this value is \"admin\"."
 msgstr "DashboardUser 指定登录仪表板所用的用户名。<br />默认值为“admin”。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
 msgid "Disable log color"
 msgstr "禁用日志的颜色"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
 msgid ""
 "DisableLogColor disables log colors when LogWay == \"console\" when set to "
 "true.<br />By default, this value is false."
@@ -170,7 +174,7 @@ msgstr "环境变量"
 msgid "Grant access to LuCI app frps"
 msgstr "授予访问 LuCI 应用 frps 的权限"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
 msgid ""
 "HeartBeatTimeout specifies the maximum time to wait for a heartbeat before "
 "terminating the connection. It is not recommended to change this value."
@@ -179,23 +183,23 @@ msgstr ""
 "HeartBeatTimeout 指定在终止连接前等待检测心跳包的最长时间。不建议更改此值。"
 "<br />默认值为 90。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
 msgid "Heartbeat timeout"
 msgstr "心跳包超时"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
 msgid "KCP bind port"
 msgstr "KCP 绑定端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
 msgid "Log file"
 msgstr "日志文件"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
 msgid "Log level"
 msgstr "日志记录等级"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid "Log max days"
 msgstr "日志最大天数"
 
@@ -207,7 +211,7 @@ msgstr "错误日志"
 msgid "Log stdout"
 msgstr "普通日志"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:32
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
 msgid ""
 "LogFile specifies a file where logs will be written to. This value will only "
 "be used if LogWay is set appropriately.<br />By default, this value is "
@@ -216,7 +220,7 @@ msgstr ""
 "LogFile 指定写入日志的文件。仅当正确设置 LogWay 时，才会使用此值。<br />默认值"
 "为“console”。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:33
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
 msgid ""
 "LogLevel specifies the minimum log level. Valid values are \"trace\", \"debug"
 "\", \"info\", \"warn\", and \"error\".<br />By default, this value is \"info\"."
@@ -224,7 +228,7 @@ msgstr ""
 "LogLevel 指定最小的日志级别。有效值为\"trace\", \"debug\", \"info\", \"warn"
 "\"和\"error\"。<br />默认情况下，此值为\"info\"。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:34
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:35
 msgid ""
 "LogMaxDays specifies the maximum number of days to store log information "
 "before deletion. This is only used if LogWay == \"file\".<br />By default, "
@@ -233,11 +237,11 @@ msgstr ""
 "LogMaxDays 指定删除前存储日志信息的最长天数。仅当 LogWay == \"file\" 时才使"
 "用。<br />默认值为 0。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
 msgid "Max ports per client"
 msgstr "每客户端的最大端口数"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:41
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:42
 msgid ""
 "MaxPortsPerClient specifies the maximum number of ports a single client may "
 "proxy to. If this value is 0, no limit will be applied.<br />By default, this "
@@ -246,7 +250,7 @@ msgstr ""
 "MaxPortsPerClient 指定单个客户端可以代理的最大端口数。如果此值为 0，则不作任"
 "何限制。<br />默认值为 0。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:119
 msgid "NOT RUNNING"
 msgstr "未在运行"
 
@@ -258,11 +262,11 @@ msgstr ""
 "操作系统环境传递给 frp。配置模板请参阅 <a href=\"https://github.com/fatedier/"
 "frp#configuration-file-template\">frp文档</a>"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
 msgid "Proxy bind address"
 msgstr "代理绑定地址"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:23
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
 msgid ""
 "ProxyBindAddr specifies the address that the proxy binds to. This value may "
 "be the same as BindAddr.<br />By default, this value is \"0.0.0.0\"."
@@ -270,7 +274,7 @@ msgstr ""
 "ProxyBindAddr 指定代理绑定到的地址。此值可能与 BindAddr 相同。<br />默认值"
 "为“0.0.0.0”。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:116
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:117
 msgid "RUNNING"
 msgstr "运行中"
 
@@ -286,12 +290,12 @@ msgstr "以此组权限运行"
 msgid "Run daemon as user"
 msgstr "以此用户权限运行"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:152
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:156
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:151
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:155
 msgid "Startup settings"
 msgstr "启动设置"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
 msgid ""
 "SubDomainHost specifies the domain that will be attached to sub-domains "
 "requested by the client when using Vhost proxying. For example, if this "
@@ -303,15 +307,15 @@ msgstr ""
 "值设置为“frps.com”，并且客户端请求子域“test”，则生成的 URL 将是“test.frps."
 "com”。<br />默认值为\"\"。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
 msgid "Subdomain host"
 msgstr "子域主机"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid "TCP mux"
 msgstr "TCP 多路复用"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:38
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:39
 msgid ""
 "TcpMux toggles TCP stream multiplexing. This allows multiple requests from a "
 "client to share a single TCP connection.<br />By default, this value is true."
@@ -319,17 +323,17 @@ msgstr ""
 "TcpMux切换TCP流复用。这允许来自一个客户端的多个请求共享一个TCP连接。<br />该值"
 "默认为true。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:43
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:44
 msgid ""
 "This list can be used to specify some additional parameters which have not "
 "been included in this LuCI."
 msgstr "此列表可用于指定此LuCI中未包括的一些其他参数。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
 msgid "Token"
 msgstr "令牌"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:36
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:37
 msgid ""
 "Token specifies the authorization token used to authenticate keys received "
 "from clients. Clients must have a matching token to be authorized to use the "
@@ -338,23 +342,23 @@ msgstr ""
 "令牌指定用于对从客户端接收的密钥进行验证的授权令牌。客户端必须有匹配的令牌才"
 "能被授权使用服务器。<br />该值默认为 \"\"。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:21
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:22
 msgid "UDP bind port"
 msgstr "UDP 绑定端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
 msgid "Vhost HTTP port"
 msgstr "Vhost HTTP端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
 msgid "Vhost HTTP timeout"
 msgstr "Vhost HTTP 超时"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
 msgid "Vhost HTTPS port"
 msgstr "Vhost HTTPS 端口"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:24
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
 msgid ""
 "VhostHttpPort specifies the port that the server listens for HTTP Vhost "
 "requests. If this value is 0, the server will not listen for HTTP requests."
@@ -363,7 +367,7 @@ msgstr ""
 "VhostHttpPort指定服务器侦听HTTP Vhost请求的端口。如果该值为0，服务器将不侦听"
 "HTTP请求。<br />该值默认为0。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:27
 msgid ""
 "VhostHttpTimeout specifies the response header timeout for the Vhost HTTP "
 "server, in seconds.<br />By default, this value is 60."
@@ -371,7 +375,7 @@ msgstr ""
 "VhostHttpTimeout指定Vhost HTTP服务器的响应头超时，单位为秒。<br />该值默认为 "
 "60。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:25
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:26
 msgid ""
 "VhostHttpsPort specifies the port that the server listens for HTTPS Vhost "
 "requests. If this value is 0, the server will not listen for HTTPS requests."
@@ -380,9 +384,9 @@ msgstr ""
 "VhostHttpsPort指定服务器侦听HTTPS Vhost请求的端口。如果该值为0，服务器将不侦"
 "听HTTPS请求。.<br />该值默认为 0。"
 
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:116
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:118
-#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:128
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:117
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:119
+#: applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js:129
 #: applications/luci-app-frps/root/usr/share/luci/menu.d/luci-app-frps.json:3
 msgid "frp Server"
 msgstr "frp 服务器"


### PR DESCRIPTION
without the enable option, there is no control over running or stopping the plug-in. After the enable option is added, you can control whether the plug-in is enabled or not.adaptation frps

Signed-off-by: zxlhhyccc <45259624+zxlhhyccc@users.noreply.github.com>