### PR TITLE
luci-app-frpc：add enable options

### DIFF
--- a/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
+++ b/applications/luci-app-frpc/htdocs/luci-static/resources/view/frpc.js
@@ -17,6 +17,7 @@ var startupConf = [
 ];
 
 var commonConf = [
+	[form.Flag, 'enabled', _('Enable')],
 	[form.Value, 'server_addr', _('Server address'), _('ServerAddr specifies the address of the server to connect to.<br />By default, this value is "0.0.0.0".'), {datatype: 'host'}],
 	[form.Value, 'server_port', _('Server port'), _('ServerPort specifies the port to connect to the server on.<br />By default, this value is 7000.'), {datatype: 'port'}],
 	[form.Value, 'http_proxy', _('HTTP proxy'), _('HttpProxy specifies a proxy address to connect to the server through. If this value is "", the server will be connected to directly.<br />By default, this value is read from the "http_proxy" environment variable.')],
@@ -184,12 +185,10 @@ return view.extend({
 				});
 			});
 
-			return E('div', { class: 'cbi-map' },
-				E('fieldset', { class: 'cbi-section'}, [
-					E('p', { id: 'service_status' },
-						_('Collecting data ...'))
-				])
-			);
+			return E('div', { class: 'cbi-section' }, [
+				E('div', { id: 'service_status' },
+					_('Collecting data ...'))
+			]);
 		}
 
 		s = m.section(form.NamedSection, 'common', 'conf');


### PR DESCRIPTION
without the enable option, there is no control over running or stopping the plug-in. After the enable option is added, you can control whether the plug-in is enabled or not. adaptation frpc.