### PR TITLE
luci-app-frps：add enable options

### DIFF
--- a/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
+++ b/applications/luci-app-frps/htdocs/luci-static/resources/view/frps.js
@@ -16,6 +16,7 @@ var startupConf = [
 ];
 
 var commonConf = [
+	[form.Flag, 'enabled', _('Enable')],
 	[form.Value, 'bind_addr', _('Bind address'), _('BindAddr specifies the address that the server binds to.<br />By default, this value is "0.0.0.0".'), {datatype: 'ipaddr'}],
 	[form.Value, 'bind_port', _('Bind port'), _('BindPort specifies the port that the server listens on.<br />By default, this value is 7000.'), {datatype: 'port'}],
 	[form.Value, 'bind_udp_port', _('UDP bind port'), _('BindUdpPort specifies the UDP port that the server listens on. If this value is 0, the server will not listen for UDP connections.<br />By default, this value is 0'), {datatype: 'port'}],
@@ -137,12 +138,10 @@ return view.extend({
 				});
 			});
 
-			return E('div', { class: 'cbi-map' },
-				E('fieldset', { class: 'cbi-section'}, [
-					E('p', { id: 'service_status' },
-						_('Collecting data ...'))
-				])
-			);
+			return E('div', { class: 'cbi-section' }, [
+				E('div', { id: 'service_status' },
+					_('Collecting data ...'))
+			]);
 		}
 
 		s = m.section(form.NamedSection, 'common', 'conf');


### PR DESCRIPTION
without the enable option, there is no control over running or stopping the plug-in. After the enable option is added, you can control whether the plug-in is enabled or not.adaptation frps.