### PR TITLE
luci-app-statistics: set shortest period data/graph to 2 hours

### DIFF
--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -22,7 +22,7 @@ config statistics 'collectd_rrdtool'
 	option DataDir '/tmp/rrd'
 	option RRARows '288'
 	option RRASingle '1'
-	option RRATimespans '1hour 1day 1week 1month 1year'
+	option RRATimespans '2hour 1day 1week 1month 1year'
 
 config statistics 'collectd_csv'
 	option enable '0'


### PR DESCRIPTION
Change the shortest defined statistics period from 1 hour to 2 hours.

In practice, this only changes the displayed graph for the shortest data period to show 2 hours of data instead of 1 hour.

The underlying database is not changed:
there are currently 288 data items for each period, so with the 30 seconds default step, the shortest data series contains 288 x 0.5 min = 144 min > 2 hours of data.

I authored a PR and did not immediately commit this, as I wondered about the impact:

* From data perspective, the change makes sense as the RRD database already contains that 2 hours data, so just show it.
* On the other hand, showing 2 hours may decrease the visible granularity on the "hourly" graph (as the graph is horizontally drawn more tightly).

You may easily test this by just editing the config file. The graph will reflect the settings.
Any comments?
