### PR TITLE
luci-app-statistics: Generate graphs for humidity sensors

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/sensors.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/sensors.js
@@ -7,20 +7,44 @@ return baseclass.extend({
 	title: _('Sensors'),
 
 	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
-		return {
-			per_instance: true,
-			title: "%H: %pi - %di",
-			vlabel: "\xb0C",
-			number_format: "%4.1lf\xb0C",
-			data: {
-				types: [ "temperature" ],
-				options: {
-					temperature__value: {
-						color: "ff0000",
-						title: "Temperature"
+		var rv = [];
+		var types = graph.dataTypes(host, plugin, plugin_instance);
+
+		if (types.indexOf('temperature') > -1) {
+			rv.push({
+				per_instance: true,
+				title: "%H: %pi - %di",
+				vlabel: "\xb0C",
+				number_format: "%4.1lf\xb0C",
+				data: {
+					types: [ "temperature" ],
+					options: {
+						temperature__value: {
+							color: "ff0000",
+							title: "Temperature"
+						}
 					}
 				}
-			}
-		};
+			});
+		}
+		if (types.indexOf('humidity') > -1) {
+			rv.push({
+				per_instance: true,
+				title: "%H: %pi - %di",
+				vlabel: "%RH",
+				number_format: "%4.1lf %%RH",
+				data: {
+					types: [ "humidity" ],
+					options: {
+						humidity__value: {
+							color: "0000ff",
+							title: "Humidity"
+						}
+					}
+				}
+			});
+		}
+
+		return rv;
 	}
 });

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/sensors.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/sensors.js
@@ -8,6 +8,7 @@ var sensorTypes = [
 	/^(?:ain|in|vccp|vdd|vid|vin|volt|voltbatt|vrm)[0-9]*$/,	'voltage',
 	/^(?:cpu_temp|remote_temp|temp)[0-9]*$/,					'temperature',
 	/^(?:fan)[0-9]*$/,											'fanspeed',
+	/^(?:humidity)[0-9]*$/,										'humidity',
 	/^(?:power)[0-9]*$/,										'power'
 ];
 


### PR DESCRIPTION
This makes a humidity graph appear for the sht3x I have connected to my OpenWrt machine.

However it also shows some artifacts that I don't understand:
![image](https://user-images.githubusercontent.com/5037590/208200333-ac416e7e-d49e-4e24-a142-d0cd5ece0dd5.png)
If you spot the problem, please advise.