### PR TITLE
luci-app-firewall: remove zone name length limitiation

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -122,7 +122,7 @@ return view.extend({
 		o.placeholder = _('Unnamed zone');
 		o.modalonly = true;
 		o.rmempty = false;
-		o.datatype = 'and(uciname,maxlength(11))';
+		o.datatype = 'uciname';
 		o.write = function(section_id, formvalue) {
 			var cfgvalue = this.cfgvalue(section_id);
 

--- a/modules/luci-compat/luasrc/view/cbi/firewall_zonelist.htm
+++ b/modules/luci-compat/luasrc/view/cbi/firewall_zonelist.htm
@@ -98,7 +98,7 @@
 			<span class="zonebadge">
 				<em><%:create%>:</em>
 				<input type="password" style="display:none" />
-				<input class="create-item-input" type="text" data-type="and(uciname,maxlength(11))" data-optional="true" />
+				<input class="create-item-input" type="text" data-type="uciname" data-optional="true" />
 			</span>
 		</li>
 		<% end %>


### PR DESCRIPTION
It was already possible to exceed the 11 character limit by creating the new zone in the interface edit view. #6008 
I could not find a test case where a longer name causes functional problems, therefor this patch removes the limit in the firewall view as well, in order to allow for more descriptive zone names. 

Signed-off-by: Evelyn Alicke <dev@evl.li>
