### PR TITLE
luci-app-natmap: add forward_port option and update stun_server description

### DIFF
--- a/applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js
+++ b/applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js
@@ -79,7 +79,7 @@ return view.extend({
 		o.datatype = 'uinteger';
 		o.modalonly = true;
 
-		o = s.option(form.Value, 'stun_server', _('STUN server'), _('For UDP mode'));
+		o = s.option(form.Value, 'stun_server', _('STUN server'));
 		o.datatype = 'host';
 		o.modalonly = true;
 		o.optional = false;
@@ -88,12 +88,10 @@ return view.extend({
 		o = s.option(form.Value, 'http_server', _('HTTP server'), _('For TCP mode'));
 		o.datatype = 'host';
 		o.modalonly = true;
-		o.optional = false;
 		o.rmempty = false;
 
-		o = s.option(form.Value, 'port', _('Port'));
+		o = s.option(form.Value, 'port', _('Bind port'));
 		o.datatype = 'port';
-		o.optional = false;
 		o.rmempty = false;
 
 		o = s.option(form.Flag, '_forward_mode', _('Forward mode'));
@@ -106,6 +104,11 @@ return view.extend({
 
 		o = s.option(form.Value, 'forward_target', _('Forward target'));
 		o.datatype = 'host';
+		o.modalonly = true;
+		o.depends('_forward_mode', '1');
+
+		o = s.option(form.Value, 'forward_port', _('Forward target port'));
+		o.datatype = 'port';
 		o.modalonly = true;
 		o.depends('_forward_mode', '1');
 

--- a/applications/luci-app-natmap/po/templates/natmap.pot
+++ b/applications/luci-app-natmap/po/templates/natmap.pot
@@ -1,83 +1,83 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:56
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:55
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:117
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:121
 msgid "External IP"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:124
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:128
 msgid "External Port"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:89
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:88
 msgid "For TCP mode"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:83
-msgid "For UDP mode"
-msgstr ""
-
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:100
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:99
 msgid "Forward mode"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:108
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:107
 msgid "Forward target"
+msgstr ""
+
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:112
+msgid "Forward target port"
 msgstr ""
 
 #: applications/luci-app-natmap/root/usr/share/rpcd/acl.d/luci-app-natmap.json:3
 msgid "Grant access to LuCI app natmap"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:89
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:88
 msgid "HTTP server"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:72
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:71
 msgid "IPv4 and IPv6"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:73
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:72
 msgid "IPv4 only"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:74
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:73
 msgid "IPv6 only"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:76
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:75
 msgid "Interface"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:79
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:78
 msgid "Keep-alive interval"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:51
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:50
 #: applications/luci-app-natmap/root/usr/share/luci/menu.d/luci-app-natmap.json:3
 msgid "NATMap"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:113
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:117
 msgid "Notify script"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:95
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:94
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:60
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:59
 msgid "Protocol"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:70
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:69
 msgid "Restrict to address family"
 msgstr ""
 
-#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:83
+#: applications/luci-app-natmap/htdocs/luci-static/resources/view/natmap.js:82
 msgid "STUN server"
 msgstr ""


### PR DESCRIPTION
The bind port (-b) can be used with forward port (-p), so expose this option in config file. Requires [this PR](https://github.com/openwrt/packages/pull/20150) to be merged.
`stun_server` option is used in both TCP and UDP mode, so remove that description.