### PR TITLE
luci-mod-status: fix neighbour display

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/routes.js
@@ -87,7 +87,7 @@ return view.extend({
 		    res = [];
 
 		for (var i = 0; i < lines.length; i++) {
-			var m = lines[i].match(/^([0-9a-f:.]+) (.+) (\S+)$/),
+			var m = lines[i].match(/^([0-9a-f:.]+) (.+) (\S+) *$/),
 			    addr = m ? m[1] : null,
 			    flags = m ? m[2].trim().split(/\s+/) : [],
 			    state = (m ? m[3] : null) || 'FAILED';


### PR DESCRIPTION
The neighbour display parses the output of 'ip -4 neigh show' e.g.

192.168.219.95 dev eth1 lladdr 38:b4:d3:c9:b2:0c REACHABLE 192.168.219.200 dev eth1 lladdr 04:c4:61:12:f2:d2 STALE

Using regexp /^([0-9a-f:.]+) (.+) (\S+)$/  Unfortunately there's a space character that sneaks in at the end of line, so let's make this less brittle by accepting lines that may end with spaces e.g.

/^([0-9a-f:.]+) (.+) (\S+) *$/

Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>