### PR TITLE
luci-mod-network: disambiguate DHCP IP set help text

### DIFF
--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -4745,7 +4745,7 @@ msgstr "قائمة المضيفين الذين يقدمون نتائج زائف�
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -4690,7 +4690,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -4632,7 +4632,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -4701,7 +4701,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -4747,7 +4747,7 @@ msgstr "Seznam IP adres, které se mají převádět na odpovědi NXDOMAIN."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -4867,7 +4867,7 @@ msgstr "Liste over IP-adresser, der skal konverteres til NXDOMAIN-svar."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr "Liste over IP-sæt, der skal udfyldes med de angivne domæne-IP'er."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -4924,7 +4924,7 @@ msgstr "Liste von Servern die falsche \"NX Domain\" Antworten liefern"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 "Liste von IP-Sets welche mit den aufgelösten IPs der angegebenen Domains "
 "gefüllt werden."

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -4735,7 +4735,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -4637,7 +4637,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -5254,7 +5254,7 @@ msgstr "Lista de direcciones IP para convertir en respuestas NXDOMAIN."
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:304
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:726
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 "Lista de conjuntos de IP para completar con las IP de dominio especificadas."
 

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -4764,7 +4764,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -4901,7 +4901,7 @@ msgstr "Liste des adresses IP à convertir en réponses NXDOMAIN."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 "Liste des ensembles d'adresses IP à remplir avec les adresses IP de domaine "
 "spécifiées."

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -4655,7 +4655,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -4634,7 +4634,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -4770,7 +4770,7 @@ msgstr "Gépek listája, amelyek hamis NX-tartomány eredményeket szolgáltatna
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -4762,7 +4762,7 @@ msgstr "Elenco di indirizzi IP da convertire in risposte NXDOMAIN."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -4790,8 +4790,8 @@ msgstr "NXドメインの嘘の結果を提供するホストのリスト"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
-msgstr ""
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
+msgstr "ここで指定されたFQDNのDNSルックアップ結果のIPを投入するIPsetのリストも指定する。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
 msgid ""

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -4713,7 +4713,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -4632,7 +4632,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -4654,7 +4654,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -4707,7 +4707,7 @@ msgstr "Liste over verter som returneren falske NX domene resultater"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -4645,7 +4645,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -4884,9 +4884,9 @@ msgstr "Lista adresów IP do konwersji na odpowiedzi NXDOMAIN."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
-"Lista zestawów adresów IP do wypełnienia określonymi adresami IP domeny."
+"Lista zestawów adresów IP, które mają być wypełnione adresami IP wyników DNS lookup dla FQDN określonych tutaj."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
 msgid ""

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -4907,7 +4907,7 @@ msgstr "Lista de endereços IP a serem convertidos em respostas NXDOMAIN."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 "Lista os conjuntos dos IPs para preencher os IPs com domínios especificados."
 

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -4948,7 +4948,7 @@ msgstr "Lista dos endereços IP que serão convertidos em respostas NXDOMAIN."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 "Lista os conjuntos dos IPs para preencher os IPs com domínios especificados."
 

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -4883,7 +4883,7 @@ msgstr "Lista de adrese IP care trebuie convertite în răspunsuri NXDOMAIN."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 "Listă de seturi IP care trebuie completate cu IP-urile de domeniu "
 "specificate."

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -4891,9 +4891,9 @@ msgstr "Список IP адресов, поставляющих поддель�
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
-"Список наборов IP-адресов для заполнения указанными IP-адресами доменов."
+"Список IPsetов для заполнения IP-адресами результатов DNS-поиска FQDN, также указанных здесь."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
 msgid ""

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -4667,7 +4667,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -4666,8 +4666,8 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
-msgstr ""
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
+msgstr "Lista på IP-set:er som fyllas med IP:erna av resultaten av DNS-uppslag för de FQDN:er som också anges här."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
 msgid ""

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -4623,7 +4623,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -4857,7 +4857,7 @@ msgstr "NXDOMAIN yanıtlarına dönüştürülecek IP adresleri listesi."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr "Belirtilen etki alanı IP'leriyle doldurulacak IP kümelerinin listesi."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -4893,8 +4893,8 @@ msgstr "Список доменів, які підтримують резуль�
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
-msgstr "Список IP-наборів для заповнення вказаними IP-адресами доменів."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
+msgstr "Перелік IPsetів для заповнення IP-адресами результатів DNS-пошуку FQDN, які також вказані тут."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575
 msgid ""

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -4631,7 +4631,7 @@ msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -4725,7 +4725,7 @@ msgstr "Danh sách các máy chủ cung cấp kết quả tên miền NX không 
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr ""
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -4724,7 +4724,7 @@ msgstr "要转换成 NXDOMAIN 响应的 IP 地址列表。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr "要用指定域 IP 填充的 IP 集列表。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -4734,7 +4734,7 @@ msgstr "列出供應偽裝NX網域成果的主機群."
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:306
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:728
-msgid "List of IP sets to populate with the specified domain IPs."
+msgid "List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here."
 msgstr "使用指定網域 IP 填充的 IP 集列表。"
 
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:1575

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -303,7 +303,7 @@ return view.extend({
 
 		o = s.taboption('general', form.DynamicList, 'ipset',
 			_('IP sets'),
-			_('List of IP sets to populate with the specified domain IPs.'));
+			_('List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here.'));
 		o.optional = true;
 		o.placeholder = '/example.org/ipset,ipset6';
 
@@ -725,7 +725,7 @@ return view.extend({
 		});
 
 		o = s.taboption('ipsets', form.SectionValue, '__ipsets__', form.GridSection, 'ipset', null,
-			_('List of IP sets to populate with the specified domain IPs.'));
+			_('List of IP sets to populate with the IPs of DNS lookup results of the FQDNs also specified here.'));
 
 		ss = o.subsection;
 


### PR DESCRIPTION
Despite this string existing for a while now, it rarely got translated, and where it did, it was equally obscure. A hint that the source string was unclear. 

Disambiguated. 