### PR TITLE
Fix crash issue when viewing hearing map

### DIFF
--- a/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
+++ b/applications/luci-app-dawn/luasrc/model/cbi/dawn/dawn_hearing_map.lua
@@ -38,6 +38,7 @@ function s.render(self, sid)
 							local mac2, data2
 							local count_loop = 0
 							for mac2, data2 in pairs(data) do
+								if data2.freq ~= 0 then --prevent empty entry crashes
 					%>
 						<tr class="tr">
 							<td class="td"><%= (count_loop == 0) and mac or "" %></td>
@@ -53,7 +54,8 @@ function s.render(self, sid)
 							<td class="td"><%= "%d" % data2.score %></td>
 						</tr>
 					<%
-								count_loop = count_loop + 1
+									count_loop = count_loop + 1
+								end
 							end
 						end
 					%>


### PR DESCRIPTION
When viewing the hearing map, sometimes a crash will happen when one of the routers suddenly cannot view a client (see screenshot). This PR simply checks that the radio frequency in data2 is not 0, and skips the entry if it is a 0.

I've verified this works on my installation of OpenWRT 22.03.2 on the Archer C7 and Belkin RT3200 running the latest version of DAWN. Unless there is a use for having a radio frequency of 0 in the hearing map, this should be fairly safe to commit.

![image](https://user-images.githubusercontent.com/5245718/211455811-75e6594e-1d84-40a6-ad8b-a59cda111f10.png)
