### PR TITLE
luci-app-advanced-reboot: add support for Linksys WHW03 v2

### DIFF
--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-whw03v2.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-whw03v2.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "WHW03 V2 (Velop)",
+	"boardNames": [ "linksys-whw03v2", "linksys,whw03v2" ],
+	"partition1MTD": "mtd9",
+	"partition2MTD": "mtd11",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
Add support for Linksys WHW03 V2 (Velop)
The device was [merged](https://github.com/openwrt/openwrt/commit/9e4ede8344d60d4837e047e9275c21fd2a8f130b) in openwrt a couple of days ago.

This patch was fully tested on a running device.

Signed-off-by: Vincent Tremblay <vincent@vtremblay.dev>