### PR TITLE
luci-app-firewall: Add clarification to masquerading option

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -156,7 +156,8 @@ return view.extend({
 		p[1].default = fwDefaults.getOutput();
 		p[2].default = fwDefaults.getForward();
 
-		o = s.taboption('general', form.Flag, 'masq', _('Masquerading'));
+		o = s.taboption('general', form.Flag, 'masq', _('Masquerading'),
+			_('Enable network address and port translation (NAT or NAPT) for outbound traffic on this zone. This is typically enabled on the <em>wan</em> zone.'));
 		o.editable = true;
 		o.tooltip = function(section_id) {
 			var masq_src = uci.get('firewall', section_id, 'masq_src')


### PR DESCRIPTION
I wasted a little to much time tinkering around with my configuration before realizing I just needed to set the "Masquerading" option. In an attempt to save everyone else this wasted time, I want to suggest to add a tooltip clarifying this option.

I am not sure how the gettext internationalization files are to be edited/generated; If anyone has pointers for this I will gladly make sure that this all works fine with my newly added interface string.