### PR TITLE
luci-light: rework and reenable

### DIFF
--- a/collections/luci-light/Makefile
+++ b/collections/luci-light/Makefile
@@ -9,8 +9,19 @@ include $(TOPDIR)/rules.mk
 LUCI_TYPE:=col
 LUCI_BASENAME:=light
 
-LUCI_TITLE:=Minimum package set using only admin mini and the standard theme
-LUCI_DEPENDS:=+uhttpd +luci-mod-admin-mini +luci-theme-openwrt @BROKEN
+LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (light)
+LUCI_DESCRIPTION:=Light OpenWrt set including admin support and the default Bootstrap theme
+LUCI_DEPENDS:= \
+	+IPV6:luci-proto-ipv6 \
+	+luci-app-firewall \
+	+luci-mod-admin-full \
+	+luci-proto-ppp \
+	+luci-theme-bootstrap \
+	+rpcd-mod-rrdns \
+	+uhttpd \
+	+uhttpd-mod-ubus
+
+PKG_LICENSE:=Apache-2.0
 
 include ../../luci.mk
 

--- a/collections/luci-ssl-openssl/Makefile
+++ b/collections/luci-ssl-openssl/Makefile
@@ -14,7 +14,7 @@ LUCI_DESCRIPTION:=LuCI with OpenSSL as the SSL backend (libustream-openssl). \
  OpenSSL cmd tools (openssl-util) are used by uhttpd for SSL key generation \
  instead of the default px5g. (If px5g is installed, uhttpd will prefer that.)
 
-LUCI_DEPENDS:=+luci +libustream-openssl +openssl-util
+LUCI_DEPENDS:=+luci-light +libustream-openssl +openssl-util
 
 include ../../luci.mk
 

--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -10,7 +10,7 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
 LUCI_TITLE:=LuCI with HTTPS support (WolfSSL as SSL backend)
-LUCI_DEPENDS:=+luci +libustream-wolfssl +px5g-wolfssl
+LUCI_DEPENDS:=+luci-light +libustream-wolfssl +px5g-wolfssl
 
 PKG_LICENSE:=Apache-2.0
 

--- a/collections/luci/Makefile
+++ b/collections/luci/Makefile
@@ -10,18 +10,11 @@ LUCI_TYPE:=col
 LUCI_BASENAME:=luci
 
 LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (default)
-LUCI_DESCRIPTION:=Standard OpenWrt set including full admin with ppp support and the default Bootstrap theme
+LUCI_DESCRIPTION:=Standard OpenWrt set including package management and attended sysupgrades support
 LUCI_DEPENDS:= \
-	+IPV6:luci-proto-ipv6 \
+	+luci-light \
 	+luci-app-attendedsysupgrade \
-	+luci-app-firewall \
-	+luci-app-opkg \
-	+luci-mod-admin-full \
-	+luci-proto-ppp \
-	+luci-theme-bootstrap \
-	+rpcd-mod-rrdns \
-	+uhttpd \
-	+uhttpd-mod-ubus
+	+luci-app-opkg
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
The `luci` collection contains package management and attended sysupgrades support, which are not that useful if not even undesired for self-compiled images.

Rework the `luci-light` collection to exclude the two above mentioned features, and make `luci` instead depend on the light collection in additon to those features.

The `luci-ssl` and `luci-ssl-openssl` collections then only need to depend on `luci-light`.

We now have three variants with won't pull in `luci-app-opkg` or `luci-app-attendedsysupgrade`, making everybody happy.