### PR TITLE
luci-lib-httpprotoutils: add airplay mime types

### DIFF
--- a/libs/luci-lib-httpprotoutils/luasrc/http/mime.lua
+++ b/libs/luci-lib-httpprotoutils/luasrc/http/mime.lua
@@ -45,10 +45,13 @@ MIME_TYPES = {
     ["mp3"]   = "audio/mpeg";
     ["ogg"]   = "audio/x-vorbis+ogg";
     ["wav"]   = "audio/x-wav";
+    ["aac"]   = "audio/aac";
 
     ["mpg"]   = "video/mpeg";
     ["mpeg"]  = "video/mpeg";
     ["avi"]   = "video/x-msvideo";
+    ["mov"]   = "video/quicktime";
+    ["mp4"]   = "video/mp4";
 }
 
 -- "application/octet-stream" if the extension is unknown.


### PR DESCRIPTION
Airplay of a statically hosted video file from one Apple device to another fails due to unrecognized content-type. Adding Airplay supported mime types fixes the issue.

Signed-off-by: Sasha Andonov <s.andonnov@gmail.com>