### PR TITLE
luci: remove installation of attendedsysupgrade

### DIFF
--- a/collections/luci/Makefile
+++ b/collections/luci/Makefile
@@ -13,7 +13,6 @@ LUCI_TITLE:=LuCI interface with Uhttpd as Webserver (default)
 LUCI_DESCRIPTION:=Standard OpenWrt set including package management and attended sysupgrades support
 LUCI_DEPENDS:= \
 	+luci-light \
-	+luci-app-attendedsysupgrade \
 	+luci-app-opkg
 
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
The package is only useful when running an official build. The ImageBuilders used for this service can not contain any special compiler flags etc. used by custom builds.

Instead of installing the package whenever `luci` is installed, it should be installed via the buildbots itself, like it's currently done for `luci`.

@ynezz do you mind adding the `loci-app-attendedsysupgrade` package via the buildbots?

Signed-off-by: Paul Spooren <mail@aparcar.org>