### PR TITLE
luci-mod-system: use new "rc" ubus object for init.d scripts

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/startup.js
@@ -7,29 +7,28 @@
 var isReadonlyView = !L.hasViewPermission() || null;
 
 return view.extend({
-	callInitList: rpc.declare({
-		object: 'luci',
-		method: 'getInitList',
+	callRcList: rpc.declare({
+		object: 'rc',
+		method: 'list',
 		expect: { '': {} }
 	}),
 
-	callInitAction: rpc.declare({
-		object: 'luci',
-		method: 'setInitAction',
+	callRcInit: rpc.declare({
+		object: 'rc',
+		method: 'init',
 		params: [ 'name', 'action' ],
-		expect: { result: false }
 	}),
 
 	load: function() {
 		return Promise.all([
 			L.resolveDefault(fs.read('/etc/rc.local'), ''),
-			this.callInitList()
+			this.callRcList()
 		]);
 	},
 
 	handleAction: function(name, action, ev) {
-		return this.callInitAction(name, action).then(function(success) {
-			if (success != true)
+		return this.callRcInit(name, action).then(function(ret) {
+			if (ret)
 				throw _('Command failed');
 
 			return true;
@@ -80,19 +79,19 @@ return view.extend({
 		]);
 
 		for (var init in initList)
-			if (initList[init].index < 100)
+			if (initList[init].start < 100)
 				list.push(Object.assign({ name: init }, initList[init]));
 
 		list.sort(function(a, b) {
-			if (a.index != b.index)
-				return a.index - b.index
+			if (a.start != b.start)
+				return a.start - b.start
 
 			return a.name > b.name;
 		});
 
 		for (var i = 0; i < list.length; i++) {
 			rows.push([
-				'%02d'.format(list[i].index),
+				'%02d'.format(list[i].start),
 				list[i].name,
 				E('div', [
 					this.renderEnableDisable(list[i]),

--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/system.js
@@ -7,12 +7,12 @@
 'require form';
 'require tools.widgets as widgets';
 
-var callInitList, callInitAction, callTimezone,
+var callRcList, callRcInit, callTimezone,
     callGetLocaltime, callSetLocaltime, CBILocalTime;
 
-callInitList = rpc.declare({
-	object: 'luci',
-	method: 'getInitList',
+callRcList = rpc.declare({
+	object: 'rc',
+	method: 'list',
 	params: [ 'name' ],
 	expect: { '': {} },
 	filter: function(res) {
@@ -22,9 +22,9 @@ callInitList = rpc.declare({
 	}
 });
 
-callInitAction = rpc.declare({
-	object: 'luci',
-	method: 'setInitAction',
+callRcInit = rpc.declare({
+	object: 'rc',
+	method: 'init',
 	params: [ 'name', 'action' ],
 	expect: { result: false }
 });
@@ -83,7 +83,7 @@ CBILocalTime = form.DummyValue.extend({
 				this.ntpd_support ? E('button', {
 					'class': 'cbi-button cbi-button-apply',
 					'click': ui.createHandlerFn(this, function() {
-						return callInitAction('sysntpd', 'restart');
+						return callRcInit('sysntpd', 'restart');
 					}),
 					'disabled': (this.readonly != null) ? this.readonly : this.map.readonly
 				}, _('Sync with NTP-Server')) : ''
@@ -95,7 +95,7 @@ CBILocalTime = form.DummyValue.extend({
 return view.extend({
 	load: function() {
 		return Promise.all([
-			callInitList('sysntpd'),
+			callRcList('sysntpd'),
 			callTimezone(),
 			callGetLocaltime(),
 			uci.load('luci'),
@@ -271,7 +271,7 @@ return view.extend({
 				else
 					uci.unset('system', 'ntp', 'enabled');
 
-				return callInitAction('sysntpd', 'enable');
+				return callRcInit('sysntpd', 'enable');
 			};
 			o.load = function(section_id) {
 				return (ntpd_enabled == 1 &&

--- a/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
@@ -35,7 +35,7 @@
 			},
 			"ubus": {
 				"file": [ "write" ],
-				"luci": [ "setInitAction", "setLocaltime" ]
+				"luci": [ "setLocaltime" ]
 			},
 			"uci": [ "dropbear" ]
 		}
@@ -47,9 +47,6 @@
 			"uci": [ "uhttpd" ]
 		},
 		"write": {
-			"ubus": {
-				"luci": [ "setInitAction" ]
-			},
 			"uci": [ "uhttpd" ]
 		}
 	},

--- a/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
+++ b/modules/luci-mod-system/root/usr/share/rpcd/acl.d/luci-mod-system.json
@@ -3,14 +3,16 @@
 		"description": "Grant access to system configuration",
 		"read": {
 			"ubus": {
-				"luci": [ "getInitList", "getLEDs", "getTimezones", "getUSBDevices" ],
+				"luci": [ "getLEDs", "getTimezones", "getUSBDevices" ],
+				"rc": [ "list" ],
 				"system": [ "info" ]
 			},
 			"uci": [ "luci", "system" ]
 		},
 		"write": {
 			"ubus": {
-				"luci": [ "setInitAction", "setLocaltime", "setPassword" ]
+				"luci": [ "setLocaltime", "setPassword" ],
+				"rc": [ "init" ],
 			},
 			"uci": [ "luci", "system" ]
 		}
@@ -61,7 +63,7 @@
 			},
 			"ubus": {
 				"file": [ "read" ],
-				"luci": [ "getInitList" ]
+				"rc": [ "list" ]
 			}
 		},
 		"write": {
@@ -70,7 +72,7 @@
 			},
 			"ubus": {
 				"file": [ "write" ],
-				"luci": [ "setInitAction" ]
+				"rc": [ "init" ]
 			}
 		}
 	},


### PR DESCRIPTION
Convert startup.js and system.js to use the generic ubus rc method to
handle /etc/init.d/ scripts for enable/disable/start/restart/reload/stop
operation.

Signed-off-by: Rafał Miłecki <rafal@milecki.pl>
[ reword commit description, convert system.js ]
Signed-off-by: Christian Marangi <ansuelsmth@gmail.com>

---

This comes from an old patch here [1]. I just tested and looks to now work. Also I modified to add some missing part and a cleanup in the acl.d file.

@jow- I'm not really sure why we had the extra permission for uhttpd and ssh... I guess a leftover from old js pages?
I think I will add a change to rc to add support to optionally pass a name so we can return info of just one specific service... This is currently the only difference from the luci implementation... 

Also I notice that for some reason rc list is 1 second slower and lack info about the stop index... I will also investigate why it's slow... (probably the running check?) No idea if we need the stop index?

[1] https://patchwork.ozlabs.org/project/openwrt/patch/20200911112645.20101-1-zajec5@gmail.com/