### PR TITLE
luci-mod-network: add basic bonding features

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/icons/bonding.png
+++ b/modules/luci-base/htdocs/luci-static/resources/icons/bonding.png
@@ -1,0 +1,1 @@
+bridge.png

--- a/modules/luci-base/htdocs/luci-static/resources/icons/bonding_disabled.png
+++ b/modules/luci-base/htdocs/luci-static/resources/icons/bonding_disabled.png
@@ -1,0 +1,1 @@
+bridge_disabled.png

--- a/modules/luci-base/htdocs/luci-static/resources/network.js
+++ b/modules/luci-base/htdocs/luci-static/resources/network.js
@@ -2921,6 +2921,7 @@ Device = baseclass.extend(/** @lends LuCI.network.Device.prototype */ {
 	 *  - `tunnel` if it is a tun or tap device (e.g. `tun0`)
 	 *  - `vlan` if it is a vlan device (e.g. `eth0.1`)
 	 *  - `switch` if it is a switch device (e.g.`eth1` connected to switch0)
+	 *  - `bonding` if it is a bond device (e.g. `bond0`)
 	 *  - `ethernet` for all other device types
 	 */
 	getType: function() {
@@ -2940,6 +2941,8 @@ Device = baseclass.extend(/** @lends LuCI.network.Device.prototype */ {
 			return 'vlan';
 		else if (this.config.type == 'bridge')
 			return 'bridge';
+		else if (this.dev.devtype == 'bond' || this.config.type == 'bonding')
+			return 'bonding';
 		else
 			return 'ethernet';
 	},
@@ -3003,6 +3006,9 @@ Device = baseclass.extend(/** @lends LuCI.network.Device.prototype */ {
 
 		case 'tunnel':
 			return _('Tunnel Interface');
+
+		case 'bonding':
+			return _('Link Aggregation');
 
 		default:
 			return _('Ethernet Adapter');

--- a/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
+++ b/modules/luci-base/htdocs/luci-static/resources/tools/widgets.js
@@ -483,6 +483,9 @@ var CBIDeviceSelect = form.ListValue.extend({
 			if (this.nobridges && type == 'bridge')
 				continue;
 
+			if (this.nobondings && type == 'bonding')
+				continue;
+
 			if (this.noinactive && device.isUp() == false)
 				continue;
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -1399,6 +1399,9 @@ return view.extend({
 			case 'veth':
 				return 'veth';
 
+			case 'bond':
+				return 'bonding';
+
 			case 'wifi':
 			case 'alias':
 			case 'switch':
@@ -1430,6 +1433,9 @@ return view.extend({
 
 			case 'veth':
 				return _('Virtual Ethernet');
+
+			case 'bond':
+				return _('LAG device');
 
 			default:
 				return _('Network device');


### PR DESCRIPTION
Since netifd commit 5ba9744aac6d42da1e56357aca951b52f86cfacb bonding is supported out of the box. Format for /etc/config/network is fixed. This change provides basic luci bonding support on the device page. To work properly we need some basic changes:

- use device type bonding for getNetworkDevices() too
- enhance all the other type functions for bonding
- Add bonding as new UI device type
- Provide basic UI fields to change bonding type

Currently only a subset of all bonding features is supported. This can be enhanced in future commits.

Fixes for PR #5858

Signed-off-by: Markus Stockhausen <markus.stockhausen@gmx.de>
Signed-off-by: Paul Dee <itsascambutmailmeanyway@gmail.com>