### PR TITLE
luci-mod-status: extend DSL metrics

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
@@ -33,23 +33,35 @@ function renderbox(dsl) {
 				_('Line State'), dsl.state || '-',
 				_('Line Mode'), dsl.mode || '-',
 				_('Line Uptime'), '%t'.format(dsl.uptime),
-				_('Annex'), dsl.annex || '-',
+				_('Annex'), dsl.annex || '-'
+			]),
+			L.itemlist(E('span'), [
 				_('Data Rate'), format_values('%1000.3mb/s', dsl.downstream.data_rate, dsl.upstream.data_rate),
 				_('Max. Attainable Data Rate (ATTNDR)'), format_values('%1000.3mb/s', dsl.downstream.attndr, dsl.upstream.attndr),
-				_('Latency'), format_values_func(format_latency, dsl.downstream.interleave_delay, dsl.upstream.interleave_delay),
+				_('Latency'), format_values_func(format_latency, dsl.downstream.interleave_delay, dsl.upstream.interleave_delay)
+			]),
+			L.itemlist(E('span'), [
 				_('Line Attenuation (LATN)'), format_values('%.1f dB', dsl.downstream.latn, dsl.upstream.latn),
 				_('Signal Attenuation (SATN)'), format_values('%.1f dB', dsl.downstream.satn, dsl.upstream.satn),
 				_('Noise Margin (SNR)'), format_values('%.1f dB', dsl.downstream.snr, dsl.upstream.snr),
-				_('Aggregate Transmit Power (ACTATP)'), format_values('%.1f dB', dsl.downstream.actatp, dsl.upstream.actatp),
+				_('Aggregate Transmit Power (ACTATP)'), format_values('%.1f dB', dsl.downstream.actatp, dsl.upstream.actatp)
+			]),
+			L.itemlist(E('span'), [
 				_('Forward Error Correction Seconds (FECS)'), format_values('%d', dsl.errors.near.fecs, dsl.errors.far.fecs),
 				_('Errored seconds (ES)'), format_values('%d', dsl.errors.near.es, dsl.errors.far.es),
 				_('Severely Errored Seconds (SES)'), format_values('%d', dsl.errors.near.ses, dsl.errors.far.ses),
 				_('Loss of Signal Seconds (LOSS)'), format_values('%d', dsl.errors.near.loss, dsl.errors.far.loss),
-				_('Unavailable Seconds (UAS)'), format_values('%d', dsl.errors.near.uas, dsl.errors.far.uas),
+				_('Unavailable Seconds (UAS)'), format_values('%d', dsl.errors.near.uas, dsl.errors.far.uas)
+			]),
+			L.itemlist(E('span'), [
 				_('Header Error Code Errors (HEC)'), format_values('%d', dsl.errors.near.hec, dsl.errors.far.hec),
 				_('Non Pre-emptive CRC errors (CRC_P)'), format_values('%d', dsl.errors.near.crc_p, dsl.errors.far.crc_p),
-				_('Pre-emptive CRC errors (CRCP_P)'), format_values('%d', dsl.errors.near.crcp_p, dsl.errors.far.crcp_p),
-				_('ATU-C System Vendor ID'), dsl.atu_c.vendor || dsl.atu_c.vendor_id,
+				_('Pre-emptive CRC errors (CRCP_P)'), format_values('%d', dsl.errors.near.crcp_p, dsl.errors.far.crcp_p)
+			]),
+			L.itemlist(E('span'), [
+				_('ATU-C System Vendor ID'), dsl.atu_c.vendor || dsl.atu_c.vendor_id
+			]),
+			L.itemlist(E('span'), [
 				_('Power Management Mode'), dsl.power_state
 			])
 		])

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
@@ -43,23 +43,23 @@ function renderbox(dsl) {
 			L.itemlist(E('span'), [
 				_('Line Attenuation (LATN)'), format_values('%.1f dB', dsl.downstream.latn, dsl.upstream.latn),
 				_('Signal Attenuation (SATN)'), format_values('%.1f dB', dsl.downstream.satn, dsl.upstream.satn),
-				_('Noise Margin (SNR)'), format_values('%.1f dB', dsl.downstream.snr, dsl.upstream.snr),
+				_('Noise Margin (SNRM)'), format_values('%.1f dB', dsl.downstream.snr, dsl.upstream.snr),
 				_('Aggregate Transmit Power (ACTATP)'), format_values('%.1f dB', dsl.downstream.actatp, dsl.upstream.actatp)
 			]),
 			L.itemlist(E('span'), [
 				_('Forward Error Correction Seconds (FECS)'), format_values('%d', dsl.errors.near.fecs, dsl.errors.far.fecs),
-				_('Errored seconds (ES)'), format_values('%d', dsl.errors.near.es, dsl.errors.far.es),
+				_('Errored Seconds (ES)'), format_values('%d', dsl.errors.near.es, dsl.errors.far.es),
 				_('Severely Errored Seconds (SES)'), format_values('%d', dsl.errors.near.ses, dsl.errors.far.ses),
 				_('Loss of Signal Seconds (LOSS)'), format_values('%d', dsl.errors.near.loss, dsl.errors.far.loss),
 				_('Unavailable Seconds (UAS)'), format_values('%d', dsl.errors.near.uas, dsl.errors.far.uas)
 			]),
 			L.itemlist(E('span'), [
-				_('Header Error Code Errors (HEC)'), format_values('%d', dsl.errors.near.hec, dsl.errors.far.hec),
-				_('Non Pre-emptive CRC errors (CRC_P)'), format_values('%d', dsl.errors.near.crc_p, dsl.errors.far.crc_p),
-				_('Pre-emptive CRC errors (CRCP_P)'), format_values('%d', dsl.errors.near.crcp_p, dsl.errors.far.crcp_p)
+				_('ATM Header Error Code Errors (HEC)'), format_values('%d', dsl.errors.near.hec, dsl.errors.far.hec),
+				_('PTM Non Pre-emptive CRC Errors (CRC-P)'), format_values('%d', dsl.errors.near.crc_p, dsl.errors.far.crc_p),
+				_('PTM Pre-emptive CRC Errors (CRCP-P)'), format_values('%d', dsl.errors.near.crcp_p, dsl.errors.far.crcp_p)
 			]),
 			L.itemlist(E('span'), [
-				_('ATU-C System Vendor ID'), dsl.atu_c.vendor || dsl.atu_c.vendor_id
+				_('xTU-C Vendor ID'), dsl.atu_c.vendor || dsl.atu_c.vendor_id
 			]),
 			L.itemlist(E('span'), [
 				_('Power Management Mode'), dsl.power_state

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
@@ -9,6 +9,21 @@ var callDSLMetrics = rpc.declare({
 	expect: { '': {} }
 });
 
+function format_latency(val) {
+	return '%.2f ms'.format(val / 1000);
+}
+
+function format_values(format, val1, val2) {
+	var val1Str = (val1 != null) ? format.format(val1) : '-';
+	var val2Str = (val2 != null) ? format.format(val2) : '-';
+	return val1Str + ' / ' + val2Str;
+}
+function format_values_func(func, val1, val2) {
+	var val1Str = (val1 != null) ? func(val1) : '-';
+	var val2Str = (val2 != null) ? func(val2) : '-';
+	return val1Str + ' / ' + val2Str;
+}
+
 function renderbox(dsl) {
 	return E('div', { class: 'ifacebox' }, [
 		E('div', { class: 'ifacebox-head center ' + (dsl.up ? 'active' : '') },
@@ -19,21 +34,21 @@ function renderbox(dsl) {
 				_('Line Mode'), dsl.mode || '-',
 				_('Line Uptime'), '%t'.format(dsl.uptime),
 				_('Annex'), dsl.annex || '-',
-				_('Data Rate'), '%1000.3mb/s / %1000.3mb/s'.format(dsl.downstream.data_rate, dsl.upstream.data_rate),
-				_('Max. Attainable Data Rate (ATTNDR)'), '%1000.3mb/s / %1000.3mb/s'.format(dsl.downstream.attndr, dsl.upstream.attndr),
-				_('Latency'), '%.2f ms / %.2f ms'.format(dsl.downstream.interleave_delay / 1000, dsl.upstream.interleave_delay / 1000),
-				_('Line Attenuation (LATN)'), '%.1f dB / %.1f dB'.format(dsl.downstream.latn, dsl.upstream.latn),
-				_('Signal Attenuation (SATN)'), '%.1f dB / %.1f dB'.format(dsl.downstream.satn, dsl.upstream.satn),
-				_('Noise Margin (SNR)'), '%.1f dB / %.1f dB'.format(dsl.downstream.snr, dsl.upstream.snr),
-				_('Aggregate Transmit Power (ACTATP)'), '%.1f dB / %.1f dB'.format(dsl.downstream.actatp, dsl.upstream.actatp),
-				_('Forward Error Correction Seconds (FECS)'), '%d / %d'.format(dsl.errors.near.fecs, dsl.errors.far.fecs),
-				_('Errored seconds (ES)'), '%d / %d'.format(dsl.errors.near.es, dsl.errors.far.es),
-				_('Severely Errored Seconds (SES)'), '%d / %d'.format(dsl.errors.near.ses, dsl.errors.far.ses),
-				_('Loss of Signal Seconds (LOSS)'), '%d / %d'.format(dsl.errors.near.loss, dsl.errors.far.loss),
-				_('Unavailable Seconds (UAS)'), '%d / %d'.format(dsl.errors.near.uas, dsl.errors.far.uas),
-				_('Header Error Code Errors (HEC)'), '%d / %d'.format(dsl.errors.near.hec, dsl.errors.far.hec),
-				_('Non Pre-emptive CRC errors (CRC_P)'), '%d / %d'.format(dsl.errors.near.crc_p, dsl.errors.far.crc_p),
-				_('Pre-emptive CRC errors (CRCP_P)'), '%d / %d'.format(dsl.errors.near.crcp_p, dsl.errors.far.crcp_p),
+				_('Data Rate'), format_values('%1000.3mb/s', dsl.downstream.data_rate, dsl.upstream.data_rate),
+				_('Max. Attainable Data Rate (ATTNDR)'), format_values('%1000.3mb/s', dsl.downstream.attndr, dsl.upstream.attndr),
+				_('Latency'), format_values_func(format_latency, dsl.downstream.interleave_delay, dsl.upstream.interleave_delay),
+				_('Line Attenuation (LATN)'), format_values('%.1f dB', dsl.downstream.latn, dsl.upstream.latn),
+				_('Signal Attenuation (SATN)'), format_values('%.1f dB', dsl.downstream.satn, dsl.upstream.satn),
+				_('Noise Margin (SNR)'), format_values('%.1f dB', dsl.downstream.snr, dsl.upstream.snr),
+				_('Aggregate Transmit Power (ACTATP)'), format_values('%.1f dB', dsl.downstream.actatp, dsl.upstream.actatp),
+				_('Forward Error Correction Seconds (FECS)'), format_values('%d', dsl.errors.near.fecs, dsl.errors.far.fecs),
+				_('Errored seconds (ES)'), format_values('%d', dsl.errors.near.es, dsl.errors.far.es),
+				_('Severely Errored Seconds (SES)'), format_values('%d', dsl.errors.near.ses, dsl.errors.far.ses),
+				_('Loss of Signal Seconds (LOSS)'), format_values('%d', dsl.errors.near.loss, dsl.errors.far.loss),
+				_('Unavailable Seconds (UAS)'), format_values('%d', dsl.errors.near.uas, dsl.errors.far.uas),
+				_('Header Error Code Errors (HEC)'), format_values('%d', dsl.errors.near.hec, dsl.errors.far.hec),
+				_('Non Pre-emptive CRC errors (CRC_P)'), format_values('%d', dsl.errors.near.crc_p, dsl.errors.far.crc_p),
+				_('Pre-emptive CRC errors (CRCP_P)'), format_values('%d', dsl.errors.near.crcp_p, dsl.errors.far.crcp_p),
 				_('ATU-C System Vendor ID'), dsl.atu_c.vendor || dsl.atu_c.vendor_id,
 				_('Power Management Mode'), dsl.power_state
 			])

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
@@ -9,6 +9,10 @@ var callDSLMetrics = rpc.declare({
 	expect: { '': {} }
 });
 
+function format_on_off(val) {
+	return val ? _('on') : _('off');
+}
+
 function format_latency(val) {
 	return '%.2f ms'.format(val / 1000);
 }
@@ -38,7 +42,16 @@ function renderbox(dsl) {
 			L.itemlist(E('span'), [
 				_('Data Rate'), format_values('%1000.3mb/s', dsl.downstream.data_rate, dsl.upstream.data_rate),
 				_('Max. Attainable Data Rate (ATTNDR)'), format_values('%1000.3mb/s', dsl.downstream.attndr, dsl.upstream.attndr),
-				_('Latency'), format_values_func(format_latency, dsl.downstream.interleave_delay, dsl.upstream.interleave_delay)
+				_('Min. Error-Free Throughput (MINEFTR)'), format_values('%1000.3mb/s', dsl.downstream.mineftr, dsl.upstream.mineftr)
+			]),
+			L.itemlist(E('span'), [
+				_('Bitswap'), format_values_func(format_on_off, dsl.downstream.bitswap, dsl.upstream.bitswap),
+				_('Rate Adaptation Mode'), format_values('%s', dsl.downstream.ra_mode, dsl.upstream.ra_mode)
+			]),
+			L.itemlist(E('span'), [
+				_('Latency'), format_values_func(format_latency, dsl.downstream.interleave_delay, dsl.upstream.interleave_delay),
+				_('Impulse Noise Protection (INP)'), format_values('%.1f symbols', dsl.downstream.inp, dsl.upstream.inp),
+				_('Retransmission (G.INP)'), format_values_func(format_on_off, dsl.downstream.retx, dsl.upstream.retx)
 			]),
 			L.itemlist(E('span'), [
 				_('Line Attenuation (LATN)'), format_values('%.1f dB', dsl.downstream.latn, dsl.upstream.latn),
@@ -51,7 +64,12 @@ function renderbox(dsl) {
 				_('Errored Seconds (ES)'), format_values('%d', dsl.errors.near.es, dsl.errors.far.es),
 				_('Severely Errored Seconds (SES)'), format_values('%d', dsl.errors.near.ses, dsl.errors.far.ses),
 				_('Loss of Signal Seconds (LOSS)'), format_values('%d', dsl.errors.near.loss, dsl.errors.far.loss),
-				_('Unavailable Seconds (UAS)'), format_values('%d', dsl.errors.near.uas, dsl.errors.far.uas)
+				_('Unavailable Seconds (UAS)'), format_values('%d', dsl.errors.near.uas, dsl.errors.far.uas),
+				_('Seconds with Low Error-Free Throughput (LEFTRS)'), format_values('%d', dsl.errors.near.leftrs, dsl.errors.far.leftrs)
+			]),
+			L.itemlist(E('span'), [
+				_('Channel CRC Errors (CV-C)'), format_values('%d', dsl.errors.near.cv_c, dsl.errors.far.cv_c),
+				_('Channel Errors Corrected by FEC (FEC-C)'), format_values('%d', dsl.errors.near.fec_c, dsl.errors.far.fec_c)
 			]),
 			L.itemlist(E('span'), [
 				_('ATM Header Error Code Errors (HEC)'), format_values('%d', dsl.errors.near.hec, dsl.errors.far.hec),
@@ -59,6 +77,13 @@ function renderbox(dsl) {
 				_('PTM Pre-emptive CRC Errors (CRCP-P)'), format_values('%d', dsl.errors.near.crcp_p, dsl.errors.far.crcp_p)
 			]),
 			L.itemlist(E('span'), [
+				_('Retransmitted DTUs (rtx-tx)'), format_values('%d', dsl.errors.far.tx_retransmitted, dsl.errors.near.tx_retransmitted),
+				_('Corrected DTUs (rtx-c)'), format_values('%d', dsl.errors.near.rx_corrected, dsl.errors.far.rx_corrected),
+				_('Uncorrected DTUs (rtx-uc)'), format_values('%d', dsl.errors.near.rx_uncorrected_protected, dsl.errors.far.rx_uncorrected_protected)
+			]),
+			L.itemlist(E('span'), [
+				_('Modem Chipset'), dsl.chipset || '-',
+				_('Modem Firmware'), dsl.firmware_version || '-',
 				_('xTU-C Vendor ID'), dsl.atu_c.vendor || dsl.atu_c.vendor_id
 			]),
 			L.itemlist(E('span'), [


### PR DESCRIPTION
This restructures the DSL metrics to make them easier to read, and adds several additional metrics, making use of https://github.com/openwrt/openwrt/commit/b91d7d9d78ea12097de4c518c8cd2215ff286f7a.