### PR TITLE
luci-ssl: switch to mbedtls

### DIFF
--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
-LUCI_TITLE:=LuCI with HTTPS support (WolfSSL as SSL backend)
-LUCI_DEPENDS:=+luci-light +libustream-wolfssl +px5g-wolfssl
+LUCI_TITLE:=LuCI with HTTPS support (mbedtls as SSL backend)
+LUCI_DEPENDS:=+luci-light +libustream-mbedtls +px5g-mbedtls
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
OpenWrt has switched the default SSL library to be mbedtls instead of WolfSSL. To avoid the need of installing both SSL libraries, switch luci-ssl to use the mbedtls variant of libustream and px5g.

PR for CI testing
