### PR TITLE
luci-mod-system: add support for led brightness

### DIFF
--- a/modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js
+++ b/modules/luci-mod-system/htdocs/luci-static/resources/view/system/leds.js
@@ -72,6 +72,11 @@ return view.extend({
 			o.value(name)
 		});
 
+		o = s.option(form.Value, 'brightness', _('Brightness'),
+		_('The brightness is based on a virtual scale of 0 to 1000.<br />The result depends on your hardware specifications.'));
+		o.default = 1000;
+		o.datatype = 'range(0,1000)';
+
 		o = s.option(form.ListValue, 'trigger', _('Trigger'));
 		for (var i = 0; i < plugins.length; i++) {
 			var plugin = plugins[i];


### PR DESCRIPTION
This PR goes in pair with another one in OpenWRT (See [here](https://github.com/openwrt/openwrt/pull/11811) - reviews are welcome). 
It adds the support to configure LEDs' brightness through uci/luci.

Signed-off-by: Vincent Tremblay <vincent@vtremblay.dev>