### PR TITLE
Move DSL status to new page in luci-mod-dsl

### DIFF
--- a/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js
+++ b/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js
@@ -1,0 +1,188 @@
+'use strict';
+'require view';
+'require dom';
+'require poll';
+'require rpc';
+
+var callDSLMetrics = rpc.declare({
+	object: 'dsl',
+	method: 'metrics',
+	expect: { '': {} }
+});
+
+function format_on_off(val) {
+	return val ? _('on') : _('off');
+}
+
+function format_latency(val) {
+	return '%.2f ms'.format(val / 1000);
+}
+
+return view.extend({
+	load: function() {
+		return L.resolveDefault(callDSLMetrics(), {});
+	},
+
+	pollData: function(container) {
+		poll.add(L.bind(function() {
+			return L.resolveDefault(callDSLMetrics(), {}).then(L.bind(function(data) {
+				dom.content(container, this.renderContent(data));
+			}, this));
+		}, this));
+	},
+
+	formatHelper: function(format, val) {
+		if (val != null) {
+			if (format instanceof Function) {
+				return format(val);
+			} else if (typeof format === 'string') {
+				return format.format(val);
+			} else {
+				return val;
+			}
+		}
+		return '-';
+	},
+
+	renderSimpleTable: function(data) {
+		var table = E('table', { 'class': 'table' });
+
+		for (var [i, item] of data.entries()) {
+			var label = item[0];
+			var val = item[1];
+
+			var rowstyle = (i % 2 == 0) ? 'cbi-rowstyle-1' : 'cbi-rowstyle-2';
+
+			table.appendChild(E('tr', { 'class': 'tr ' + rowstyle }, [
+				E('td', { 'class': 'td left', 'width': '33%' }, [ label ]),
+				E('td', { 'class': 'td left' }, [ this.formatHelper(null, val) ])
+			]));
+		}
+
+		return table;
+	},
+
+	renderTable: function(data) {
+		var table = E('table', { 'class': 'table' });
+
+		for (var [i, item] of data.entries()) {
+			var label = item[0];
+			var format = item[1];
+			var val1 = item[2];
+			var val2 = item[3];
+
+			var rowstyle = (i % 2 == 0) ? 'cbi-rowstyle-1' : 'cbi-rowstyle-2';
+
+			table.appendChild(E('tr', { 'class': 'tr ' + rowstyle }, [
+				E('td', { 'class': 'td left', 'width': '33%' }, [ label ]),
+				E('td', { 'class': 'td right', 'width': '33%' }, [ this.formatHelper(format, val1) ]),
+				E('td', { 'class': 'td right', 'width': '33%' }, [ this.formatHelper(format, val2) ])
+			]));
+		}
+
+		return table;
+	},
+
+	renderContent: function(data) {
+		return E([], [
+
+			E('h3', {}, [ _('Connection State') ]),
+
+			this.renderSimpleTable([
+				[ _('Line State'), data.state ],
+				[ _('Line Mode'), data.mode ],
+				[ _('Line Uptime'), '%t'.format(data.uptime) ],
+				[ _('Annex'), data.annex ],
+				[ _('Power Management Mode'), data.power_state ]
+			]),
+
+			E('h3', {}, [ _('Inventory') ]),
+
+			this.renderSimpleTable([
+				[ _('Modem Chipset'), data.chipset ],
+				[ _('Modem Firmware'), data.firmware_version ],
+				[ _('xTU-C Vendor ID'), data.atu_c.vendor || data.atu_c.vendor_id ]
+			]),
+
+			E('h3', {}, [ _('Line Details') ]),
+
+			E('h4', {}, [ _('Data Rates') ]),
+			this.renderTable([
+				[ _('Actual Data Rate'), '%1000.3mb/s', data.downstream.data_rate, data.upstream.data_rate ],
+				[ _('Attainable Data Rate (ATTNDR)'), '%1000.3mb/s', data.downstream.attndr, data.upstream.attndr ],
+				[ _('Minimum Error-Free Throughput (MINEFTR)'), '%1000.3mb/s', data.downstream.mineftr, data.upstream.mineftr ]
+			]),
+
+			E('h4', {}, [ _('On-line Reconfiguration') ]),
+			this.renderTable([
+				[ _('Bitswap'), format_on_off, data.downstream.bitswap, data.upstream.bitswap ],
+				[ _('Rate Adaptation Mode'), '%s', data.downstream.ra_mode, data.upstream.ra_mode ]
+			]),
+
+			E('h4', {}, [ _('Noise Protection') ]),
+			this.renderTable([
+				[ _('Latency'), format_latency, data.downstream.interleave_delay, data.upstream.interleave_delay ],
+				[ _('Impulse Noise Protection (INP)'), '%.1f symbols', data.downstream.inp, data.upstream.inp ],
+				[ _('Retransmission (G.INP)'), format_on_off, data.downstream.retx, data.upstream.retx ]
+			]),
+
+			E('h4', {}, [ _('Line Parameters') ]),
+			this.renderTable([
+				[ _('Line Attenuation (LATN)'), '%.1f dB', data.downstream.latn, data.upstream.latn ],
+				[ _('Signal Attenuation (SATN)'), '%.1f dB', data.downstream.satn, data.upstream.satn ],
+				[ _('Noise Margin (SNRM)'), '%.1f dB', data.downstream.snr, data.upstream.snr ],
+				[ _('Aggregate Transmit Power (ACTATP)'), '%.1f dB', data.downstream.actatp, data.upstream.actatp ]
+			]),
+
+			E('h3', {}, [ _('Error Counters') ]),
+
+			E('h4', {}, [ _('Error Seconds') ]),
+			this.renderTable([
+				[ _('Forward Error Correction Seconds (FECS)'), '%d', data.errors.near.fecs, data.errors.far.fecs ],
+				[ _('Errored Seconds (ES)'), '%d', data.errors.near.es, data.errors.far.es ],
+				[ _('Severely Errored Seconds (SES)'), '%d', data.errors.near.ses, data.errors.far.ses ],
+				[ _('Loss of Signal Seconds (LOSS)'), '%d', data.errors.near.loss, data.errors.far.loss ],
+				[ _('Unavailable Seconds (UAS)'), '%d', data.errors.near.uas, data.errors.far.uas ],
+				[ _('Seconds with Low Error-Free Throughput (LEFTRS)'), '%d', data.errors.near.leftrs, data.errors.far.leftrs ]
+			]),
+
+			E('h4', {}, [ _('Channel Counters') ]),
+			this.renderTable([
+				[ _('CRC Errors (CV-C)'), '%d', data.errors.near.cv_c, data.errors.far.cv_c ],
+				[ _('Corrected by FEC (FEC-C)'), '%d', data.errors.near.fec_c, data.errors.far.fec_c ]
+			]),
+
+			E('h4', {}, [ _('Data Path Counters') ]),
+			this.renderTable([
+				[ _('ATM Header Error Code Errors (HEC-P)'), '%d', data.errors.near.hec, data.errors.far.hec ],
+				[ _('PTM Non Pre-emptive CRC Errors (CRC-P)'), '%d', data.errors.near.crc_p, data.errors.far.crc_p ],
+				[ _('PTM Pre-emptive CRC Errors (CRCP-P)'), '%d', data.errors.near.crcp_p, data.errors.far.crcp_p ]
+			]),
+
+			E('h4', {}, [ _('Retransmission Counters') ]),
+			this.renderTable([
+				[ _('Retransmitted DTUs (rtx-tx)'), '%d', data.errors.far.tx_retransmitted, data.errors.near.tx_retransmitted ],
+				[ _('Corrected DTUs (rtx-c)'), '%d', data.errors.near.rx_corrected, data.errors.far.rx_corrected ],
+				[ _('Uncorrected DTUs (rtx-uc)'), '%d', data.errors.near.rx_uncorrected_protected, data.errors.far.rx_uncorrected_protected ]
+			])
+
+		]);
+	},
+
+	render: function(data) {
+		var v = E([], [
+			E('h2', {}, [ _('DSL stats') ]),
+			E('div')
+		]);
+
+		var container = v.lastElementChild;
+		dom.content(container, this.renderContent(data));
+		this.pollData(container);
+
+		return v;
+	},
+
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null
+});

--- a/modules/luci-mod-dsl/po/templates/dsl.pot
+++ b/modules/luci-mod-dsl/po/templates/dsl.pot
@@ -1,29 +1,104 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:24
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:159
+msgid "ATM Header Error Code Errors (HEC-P)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:113
+msgid "Actual Data Rate"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:136
+msgid "Aggregate Transmit Power (ACTATP)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:97
+msgid "Annex"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:114
+msgid "Attainable Data Rate (ATTNDR)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:120
+msgid "Bitswap"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:153
+msgid "CRC Errors (CV-C)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:151
+msgid "Channel Counters"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:91
+msgid "Connection State"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:167
+msgid "Corrected DTUs (rtx-c)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:154
+msgid "Corrected by FEC (FEC-C)"
+msgstr ""
+
 #: modules/luci-mod-dsl/root/usr/share/luci/menu.d/luci-mod-dsl.json:3
+msgid "DSL Status"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:24
 msgid "DSL line spectrum"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:212
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:176
+msgid "DSL stats"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:157
+msgid "Data Path Counters"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:111
+msgid "Data Rates"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:219
 msgid "Downstream HLOG"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:182
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:189
 msgid "Downstream QLN"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:152
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:159
 msgid "Downstream SNR"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:122
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:123
 msgid "Downstream bits allocation"
 msgstr ""
 
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:139
+msgid "Error Counters"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:141
+msgid "Error Seconds"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:144
+msgid "Errored Seconds (ES)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:143
+msgid "Forward Error Correction Seconds (FECS)"
+msgstr ""
+
 #: modules/luci-mod-dsl/root/usr/share/rpcd/acl.d/luci-mod-dsl.json:3
-msgid "Grant access to luci-mod-dsl spectrum"
+msgid "Grant access to luci-mod-dsl"
 msgstr ""
 
 #: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js:25
@@ -32,34 +107,170 @@ msgid ""
 "and Channel characteristics function (HLOG) per sub-carrier."
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:106
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:136
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:166
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:196
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:127
+msgid "Impulse Noise Protection (INP)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:101
+msgid "Inventory"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:126
+msgid "Latency"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:133
+msgid "Line Attenuation (LATN)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:109
+msgid "Line Details"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:95
+msgid "Line Mode"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:131
+msgid "Line Parameters"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:94
+msgid "Line State"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:96
+msgid "Line Uptime"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:146
+msgid "Loss of Signal Seconds (LOSS)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:115
+msgid "Minimum Error-Free Throughput (MINEFTR)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:104
+msgid "Modem Chipset"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:105
+msgid "Modem Firmware"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:135
+msgid "Noise Margin (SNRM)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:124
+msgid "Noise Protection"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:118
+msgid "On-line Reconfiguration"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:160
+msgid "PTM Non Pre-emptive CRC Errors (CRC-P)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:161
+msgid "PTM Pre-emptive CRC Errors (CRCP-P)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:129
+msgid "Pilot tones"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:98
+msgid "Power Management Mode"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:121
+msgid "Rate Adaptation Mode"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:128
+msgid "Retransmission (G.INP)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:164
+msgid "Retransmission Counters"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:166
+msgid "Retransmitted DTUs (rtx-tx)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:148
+msgid "Seconds with Low Error-Free Throughput (LEFTRS)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:145
+msgid "Severely Errored Seconds (SES)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:134
+msgid "Signal Attenuation (SATN)"
+msgstr ""
+
+#: modules/luci-mod-dsl/root/usr/share/luci/menu.d/luci-mod-dsl.json:23
+msgid "Spectrum"
+msgstr ""
+
+#: modules/luci-mod-dsl/root/usr/share/luci/menu.d/luci-mod-dsl.json:14
+msgid "Stats"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:107
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:143
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:173
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:203
 msgid "Sub-carrier"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:207
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:147
+msgid "Unavailable Seconds (UAS)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:168
+msgid "Uncorrected DTUs (rtx-uc)"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:214
 msgid "Upstream HLOG"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:177
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:184
 msgid "Upstream QLN"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:147
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:154
 msgid "Upstream SNR"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:111
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:112
 msgid "bits"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:141
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:201
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:148
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:208
 msgid "dB"
 msgstr ""
 
-#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:171
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/graph.js:178
 msgid "dBm/Hz"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:16
+msgid "off"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:16
+msgid "on"
+msgstr ""
+
+#: modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js:106
+msgid "xTU-C Vendor ID"
 msgstr ""

--- a/modules/luci-mod-dsl/root/usr/share/luci/menu.d/luci-mod-dsl.json
+++ b/modules/luci-mod-dsl/root/usr/share/luci/menu.d/luci-mod-dsl.json
@@ -1,13 +1,30 @@
 {
 	"admin/status/dsl": {
-		"title": "DSL line spectrum",
+		"title": "DSL Status",
 		"order": 7,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-mod-dsl" ]
+		}
+	},
+
+	"admin/status/dsl/stats": {
+		"title": "Stats",
+		"order": 1,
+		"action": {
+			"type": "view",
+			"path": "status/dsl/stats"
+		}
+	},
+
+	"admin/status/dsl/spectrum": {
+		"title": "Spectrum",
+		"order": 2,
 		"action": {
 			"type": "view",
 			"path": "status/dsl/spectrum"
-		},
-		"depends": {
-			"acl": [ "luci-mod-dsl-spectrum" ]
 		}
 	}
 }

--- a/modules/luci-mod-dsl/root/usr/share/rpcd/acl.d/luci-mod-dsl.json
+++ b/modules/luci-mod-dsl/root/usr/share/rpcd/acl.d/luci-mod-dsl.json
@@ -1,9 +1,9 @@
 {
-	"luci-mod-dsl-spectrum": {
-		"description": "Grant access to luci-mod-dsl spectrum",
+	"luci-mod-dsl": {
+		"description": "Grant access to luci-mod-dsl",
 		"read": {
 			"ubus": {
-				"dsl": [ "statistics" ]
+				"dsl": [ "metrics", "statistics" ]
 			}
 		}
 	}

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/50_dsl.js
@@ -9,22 +9,9 @@ var callDSLMetrics = rpc.declare({
 	expect: { '': {} }
 });
 
-function format_on_off(val) {
-	return val ? _('on') : _('off');
-}
-
-function format_latency(val) {
-	return '%.2f ms'.format(val / 1000);
-}
-
 function format_values(format, val1, val2) {
 	var val1Str = (val1 != null) ? format.format(val1) : '-';
 	var val2Str = (val2 != null) ? format.format(val2) : '-';
-	return val1Str + ' / ' + val2Str;
-}
-function format_values_func(func, val1, val2) {
-	var val1Str = (val1 != null) ? func(val1) : '-';
-	var val2Str = (val2 != null) ? func(val2) : '-';
 	return val1Str + ' / ' + val2Str;
 }
 
@@ -37,57 +24,10 @@ function renderbox(dsl) {
 				_('Line State'), dsl.state || '-',
 				_('Line Mode'), dsl.mode || '-',
 				_('Line Uptime'), '%t'.format(dsl.uptime),
-				_('Annex'), dsl.annex || '-'
 			]),
 			L.itemlist(E('span'), [
 				_('Data Rate'), format_values('%1000.3mb/s', dsl.downstream.data_rate, dsl.upstream.data_rate),
-				_('Max. Attainable Data Rate (ATTNDR)'), format_values('%1000.3mb/s', dsl.downstream.attndr, dsl.upstream.attndr),
-				_('Min. Error-Free Throughput (MINEFTR)'), format_values('%1000.3mb/s', dsl.downstream.mineftr, dsl.upstream.mineftr)
-			]),
-			L.itemlist(E('span'), [
-				_('Bitswap'), format_values_func(format_on_off, dsl.downstream.bitswap, dsl.upstream.bitswap),
-				_('Rate Adaptation Mode'), format_values('%s', dsl.downstream.ra_mode, dsl.upstream.ra_mode)
-			]),
-			L.itemlist(E('span'), [
-				_('Latency'), format_values_func(format_latency, dsl.downstream.interleave_delay, dsl.upstream.interleave_delay),
-				_('Impulse Noise Protection (INP)'), format_values('%.1f symbols', dsl.downstream.inp, dsl.upstream.inp),
-				_('Retransmission (G.INP)'), format_values_func(format_on_off, dsl.downstream.retx, dsl.upstream.retx)
-			]),
-			L.itemlist(E('span'), [
-				_('Line Attenuation (LATN)'), format_values('%.1f dB', dsl.downstream.latn, dsl.upstream.latn),
-				_('Signal Attenuation (SATN)'), format_values('%.1f dB', dsl.downstream.satn, dsl.upstream.satn),
-				_('Noise Margin (SNRM)'), format_values('%.1f dB', dsl.downstream.snr, dsl.upstream.snr),
-				_('Aggregate Transmit Power (ACTATP)'), format_values('%.1f dB', dsl.downstream.actatp, dsl.upstream.actatp)
-			]),
-			L.itemlist(E('span'), [
-				_('Forward Error Correction Seconds (FECS)'), format_values('%d', dsl.errors.near.fecs, dsl.errors.far.fecs),
-				_('Errored Seconds (ES)'), format_values('%d', dsl.errors.near.es, dsl.errors.far.es),
-				_('Severely Errored Seconds (SES)'), format_values('%d', dsl.errors.near.ses, dsl.errors.far.ses),
-				_('Loss of Signal Seconds (LOSS)'), format_values('%d', dsl.errors.near.loss, dsl.errors.far.loss),
-				_('Unavailable Seconds (UAS)'), format_values('%d', dsl.errors.near.uas, dsl.errors.far.uas),
-				_('Seconds with Low Error-Free Throughput (LEFTRS)'), format_values('%d', dsl.errors.near.leftrs, dsl.errors.far.leftrs)
-			]),
-			L.itemlist(E('span'), [
-				_('Channel CRC Errors (CV-C)'), format_values('%d', dsl.errors.near.cv_c, dsl.errors.far.cv_c),
-				_('Channel Errors Corrected by FEC (FEC-C)'), format_values('%d', dsl.errors.near.fec_c, dsl.errors.far.fec_c)
-			]),
-			L.itemlist(E('span'), [
-				_('ATM Header Error Code Errors (HEC)'), format_values('%d', dsl.errors.near.hec, dsl.errors.far.hec),
-				_('PTM Non Pre-emptive CRC Errors (CRC-P)'), format_values('%d', dsl.errors.near.crc_p, dsl.errors.far.crc_p),
-				_('PTM Pre-emptive CRC Errors (CRCP-P)'), format_values('%d', dsl.errors.near.crcp_p, dsl.errors.far.crcp_p)
-			]),
-			L.itemlist(E('span'), [
-				_('Retransmitted DTUs (rtx-tx)'), format_values('%d', dsl.errors.far.tx_retransmitted, dsl.errors.near.tx_retransmitted),
-				_('Corrected DTUs (rtx-c)'), format_values('%d', dsl.errors.near.rx_corrected, dsl.errors.far.rx_corrected),
-				_('Uncorrected DTUs (rtx-uc)'), format_values('%d', dsl.errors.near.rx_uncorrected_protected, dsl.errors.far.rx_uncorrected_protected)
-			]),
-			L.itemlist(E('span'), [
-				_('Modem Chipset'), dsl.chipset || '-',
-				_('Modem Firmware'), dsl.firmware_version || '-',
-				_('xTU-C Vendor ID'), dsl.atu_c.vendor || dsl.atu_c.vendor_id
-			]),
-			L.itemlist(E('span'), [
-				_('Power Management Mode'), dsl.power_state
+				_('Noise Margin'), format_values('%.1f dB', dsl.downstream.snr, dsl.upstream.snr),
 			])
 		])
 	]);


### PR DESCRIPTION
As discussed in #6224, create a new page for DSL information in luci-mod-dsl, and change luci-mod-status to only show the most important data on the overview page.