### PR TITLE
luci-app-https-dns-proxy: Add DNS0.EU filtered for kids support

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/kids.eu.dns0.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/kids.eu.dns0.lua
@@ -1,0 +1,6 @@
+return {
+	name = "kids.dns0.eu",
+	label = _("DNS0.EU Filtered for Kids"),
+	resolver_url = "https://kids.dns0.eu",
+	bootstrap_dns = "193.110.81.1,185.253.5.1,2a0f:fc80::1,2a0f:fc81::1"
+}


### PR DESCRIPTION
add support for the new dns0.eu filtered for kids service

Signed-off-by: artion karreci <artionkarreci@gmail.com>