### PR TITLE
luci-app-https-dns-proxy: add DNS0.EU support

### DIFF
--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/eu.dns0.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/eu.dns0.lua
@@ -1,0 +1,6 @@
+return {
+	name = "dns0.eu",
+	label = _("DNS0.EU"),
+	resolver_url = "https://dns0.eu",
+	bootstrap_dns = "193.110.81.0,185.253.5.0,2a0f:fc80::,2a0f:fc81::"
+}


### PR DESCRIPTION
add support for the new dns0.eu service

Signed-off-by: artion karreci artionkarreci@gmail.com