### PR TITLE
luci-app-https-dns-proxy: update to 2022-10-15-11

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -5,11 +5,11 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2021-11-22-7
+PKG_VERSION:=2022-10-15-11
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
-LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +https-dns-proxy
+LUCI_DEPENDS:=+luci-compat +luci-base +https-dns-proxy
 LUCI_PKGARCH:=all
 
 include ../../luci.mk

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua
@@ -1,0 +1,8 @@
+return {
+	name = "dns-family.adguard.com",
+	label = _("AdGuard (Family Protection)"),
+	resolver_url = "https://dns-family.adguard.com/dns-query",
+	bootstrap_dns = "176.103.130.132,176.103.130.134",
+	help_link = "https://adguard.com/en/adguard-dns/overview.html",
+	help_link_text = "AdGuard.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua
@@ -1,0 +1,8 @@
+return {
+	name = "dns.adguard.com",
+	label = _("AdGuard (Standard)"),
+	resolver_url = "https://dns.adguard.com/dns-query",
+	bootstrap_dns = "176.103.130.130,176.103.130.131",
+	help_link = "https://adguard.com/en/adguard-dns/overview.html",
+	help_link_text = "AdGuard.com"
+}

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -120,7 +120,7 @@ if packageStatusCode ~= -1 then
 end
 
 c = m:section(NamedSection, "config", "https-dns-proxy", translate("Configuration"))
-d1 = c:option(ListValue, "update_dnsmasq_config", translate("Update DNSMASQ Config on Start/Stop"), translatef("If update option is selected, the 'DNS forwardings' section of %sDHCP and DNS%s will be automatically updated to use selected DoH providers (%smore information%s).", "<a href=\"" .. dispatcher.build_url("admin/network/dhcp") .. "\">", "</a>", "<a href=\"" .. readmeURL .. "#default-settings" .. "\" target=\"_blank\">", "</a>"))
+d1 = c:option(ListValue, "dnsmasq_config_update", translate("Update DNSMASQ Config on Start/Stop"), translatef("If update option is selected, the 'DNS forwardings' section of %sDHCP and DNS%s will be automatically updated to use selected DoH providers (%smore information%s).", "<a href=\"" .. dispatcher.build_url("admin/network/dhcp") .. "\">", "</a>", "<a href=\"" .. readmeURL .. "#default-settings" .. "\" target=\"_blank\">", "</a>"))
 d1:value('*', translate("Update all configs"))
 local dnsmasq_num = 0
 uci:foreach("dhcp", "dnsmasq", function(s)

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -13,15 +13,11 @@ msgstr ""
 msgid "360 Secure DNS - CN"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.adguard-dns.dns-family.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua:3
 msgid "AdGuard (Family Protection)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.adguard-dns.dns-nonfiltering.lua:3
-msgid "AdGuard (Non-filtering)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.adguard-dns.dns.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua:3
 msgid "AdGuard (Standard)"
 msgstr ""
 
@@ -169,17 +165,14 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware-ads-social.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p3.lua:3
 msgid "ControlD (Block Malware + Ads + Social)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware-ads.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p2.lua:3
 msgid "ControlD (Block Malware + Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p1.lua:3
 msgid "ControlD (Block Malware)"
 msgstr ""
@@ -189,7 +182,6 @@ msgid "ControlD (Family)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p0.lua:3
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.unfiltered.lua:3
 msgid "ControlD (Unfiltered)"
 msgstr ""
 
@@ -456,10 +448,6 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/app.tiar.doh.lua:3
 msgid "Tiarap Public DNS - SG"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.edu.tsinghua.tuna.dns.lua:3
-msgid "Tsinghua University Secure DNS - CN"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:65


### PR DESCRIPTION
* Makefile: change dependency from luci-mod-admin-full to luci-base
* Providers: add AdGuard and AdGuard Family
* Bugfix: update field value in CBI, fixes https://github.com/openwrt/luci/issues/6244

Signed-off-by: Stan Grishin <stangri@melmac.ca>