### PR TITLE
luci-ssl: make crypto lib generic

### DIFF
--- a/collections/luci-ssl/Makefile
+++ b/collections/luci-ssl/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TYPE:=col
 LUCI_BASENAME:=ssl
 
-LUCI_TITLE:=LuCI with HTTPS support (mbedtls as SSL backend)
-LUCI_DEPENDS:=+luci-light +libustream-mbedtls +px5g-mbedtls
+LUCI_TITLE:=LuCI with HTTPS support
+LUCI_DEPENDS:=+luci-light +libustream-ssl +px5g
 
 PKG_LICENSE:=Apache-2.0
 


### PR DESCRIPTION
Instead of a hard dependency, only require some crypto lib to be there. This simplifies upgrading while staying with the sames packages, i.e. using something like `auc` to upgrade the image without swichting the underlying crypto libary.

DRAF: package libustream-ssl doesn't exists yet.