### PR TITLE
[22.03] luci-app-pbr: bugfixes

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -5,12 +5,14 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.0.1-10
+PKG_VERSION:=1.1.0-1
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_DESCRIPTION:=Provides Web UI for Policy Based Routing Service.
 LUCI_DEPENDS:=+luci-base +jsonfilter +pbr
 LUCI_PKGARCH:=all
+
+PKG_PROVIDES:=luci-app-vpnbypass luci-app-vpn-policy-routing
 
 include ../../luci.mk
 

--- a/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
+++ b/applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js
@@ -267,10 +267,12 @@ return view.extend({
 			o = s.option(form.Flag, "enabled", _("Enabled"));
 			o.optional = false;
 			o.editable = true;
+			o.rmempty = false;
 
 			o = s.option(form.Value, "path", _("Path"));
 			o.optional = false;
 			o.editable = true;
+			o.rmempty = false;
 
 			return Promise.all([status.render(), m.render()]);
 		})

--- a/applications/luci-app-pbr/po/templates/pbr.pot
+++ b/applications/luci-app-pbr/po/templates/pbr.pot
@@ -240,7 +240,7 @@ msgstr ""
 msgid "Output verbosity"
 msgstr ""
 
-#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:271
+#: applications/luci-app-pbr/htdocs/luci-static/resources/view/pbr/overview.js:272
 msgid "Path"
 msgstr ""
 


### PR DESCRIPTION
* do not remove non-empty custom user files fields
* add provides for vpnbypass and vpn-policy-routing luci apps 
  addresses https://github.com/openwrt/luci/pull/6127#pullrequestreview-1311512052

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 0d4b675e7062ddc0d1d2b9be2d0962186239c51b)