### PR TITLE
luci-mod-network: add stricter wireless interface name validation

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -426,6 +426,15 @@ var ValidatorFactory = baseclass.extend({
 			return this.assert(this.value.match(/^[a-zA-Z0-9_]+$/), _('valid UCI identifier'));
 		},
 
+		netdevname: function() {
+			var v = this.value;
+
+			if (v == '.' || v == '..')
+				return this.assert(false, _('Must be a valid network device name'));
+
+			return this.assert(v.match(/^[^:/%\s]{1,15}$/), _('Must be a valid network device name'));
+		},
+
 		range: function(min, max) {
 			var val = this.factory.parseDecimal(this.value);
 			return this.assert(val >= +min && val <= +max, _('value between %f and %f').format(min, max));

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js
@@ -1150,9 +1150,9 @@ return view.extend({
 					o.depends('mode', 'ap');
 					o.depends('mode', 'ap-wds');
 
-					o = ss.taboption('advanced', form.Value, 'ifname', _('Interface name'), _('Override default interface name'));
+					o = ss.taboption('advanced', form.Value, 'ifname', _('Interface name'), _('Override default interface name - the name can not be ".", "..", nor contain the characters :, /, %, or whitespace and must contain from 1 to 15 characters'));
 					o.optional = true;
-					o.datatype = 'maxlength(15)';
+					o.datatype = 'netdevname';
 					o.placeholder = radioNet.getIfname();
 					if (/^radio\d+\.network/.test(o.placeholder))
 						o.placeholder = '';


### PR DESCRIPTION
@hnyman 
Linux wireless interface names have the following restrictions:

 * It must not be an empty string
 * It must not be '.' or '..'
 * It must not contain any /, : or space character ( , \t, \n, ...)
 * It must be less than 16 chars
 * It likely must not contain any % either

Fixes: 8673aef8db luci-mod-network: remove uciname validation from wireless interface

This is discussed in #6101 and @jow- dug up the [restrictions on the interface name](https://elixir.bootlin.com/linux/latest/source/net/core/dev.c#L995). He suggests that `%` probably can't be used either, but provides no documentation of this. I've opted to disallow `%` to err on the side of caution. The validation is done as a datatype to make it reuseable. This has not been tested as I'm currently not setup to test this. I think its important to have the validation be stricter because allowing names which the kernel will not accept is a bad user experience. Everything looks like it succeeded when changing the interface name, but the interface will not come up and the user is left wondering why, which is not obvious.