### PR TITLE
luci-mod-status: nftables add counter and comment for empty match

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/nftables.js
@@ -515,7 +515,7 @@ return view.extend({
 		}
 
 		if (empty)
-			dom.content(row.childNodes[0], E('em', [ _('Any packet', 'nft match any traffic') ]));
+			dom.append(row.childNodes[0], E('span', { 'class': 'ifacebadge' }, '<em>%h</em>'.format(_('Any packet', 'nft match any traffic'))));
 
 		return row;
 	},


### PR DESCRIPTION
Fixes #6264 by adding counter and comment for empty match / "Any packet" in nftables.