### PR TITLE
luci-app-acme: remove deprecated state_dir field

### DIFF
--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -26,11 +26,6 @@ return view.extend({
 		s = m.section(form.TypedSection, "acme", _("ACME global config"));
 		s.anonymous = true;
 
-		o = s.option(form.Value, "state_dir", _("State directory"),
-			_("Where certs and other state files are kept."));
-		o.rmempty = false;
-		o.datatype = "directory";
-
 		o = s.option(form.Value, "account_email", _("Account email"),
 			_("Email address to associate with account key."))
 		o.rmempty = false;


### PR DESCRIPTION
The state_dir option was marked as deprecated in the acme package. This commit removes it from the UI.

Signed-off-by:  Miguel Angel Mulero <migmul@gmail.com>

This PR fixes https://github.com/openwrt/luci/issues/6273