### PR TITLE
luci-proto-cni: add package

### DIFF
--- a/protocols/luci-proto-cni/Makefile
+++ b/protocols/luci-proto-cni/Makefile
@@ -1,0 +1,8 @@
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=Support for CNI protocol
+LUCI_DEPENDS:=+cni-protocol
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-cni/htdocs/luci-static/resources/protocol/cni.js
+++ b/protocols/luci-proto-cni/htdocs/luci-static/resources/protocol/cni.js
@@ -1,0 +1,8 @@
+'use strict';
+'require network';
+
+return network.registerProtocol('cni', {
+	getI18n: function () {
+		return _('CNI (Externally managed interface)');
+	}
+});


### PR DESCRIPTION
simple protocol support for *simple protocol* - cni protocol can be used with container networking, but even if it's name is cni protocol, it also works great with netavark (cni replacement for Podman)

cni-protocol is extremely useful when you want to create a firewall zone and manage firewalling of containers with openwrt's own firewall configuration, as it makes it possible to define a zone that doesn't exist yet (container not running yet?). There's not much to do with it at Luci, but with proto package, it at least won't say unsupported protocol or what ever it was that it says on occasions like that.