### PR TITLE
luci-lib-px5g: refactor to use PKG_BUILD_FLAGS:=no-mips16

### DIFF
--- a/libs/luci-lib-px5g/Makefile
+++ b/libs/luci-lib-px5g/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=RSA/X.509 Key Generator (required for LuCId SSL support)
 LUCI_DEPENDS:=+lua +luci-lib-nixio
 
-PKG_USE_MIPS16:=0
+PKG_BUILD_FLAGS:=no-mips16
 PKG_LICENSE:=LGPL-2.1
 
 include ../../luci.mk


### PR DESCRIPTION
See commit 5c545bdb "treewide: replace PKG_USE_MIPS16:=0 with PKG_BUILD_FLAGS:=no-mips16" on the main repository.