### PR TITLE
luci-theme-bootstrap: File input background color

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -715,7 +715,6 @@ select,
 }
 
 input[type=file] {
-	background-color: #fff;
 	padding: initial;
 	border: initial;
 	line-height: initial;


### PR DESCRIPTION
Remove the white background color for the file input elements, this way it'll use the default color defined for input elements, matching the light/dark theme.