### PR TITLE
luci-app-transmission: update web interface path

### DIFF
--- a/applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js
+++ b/applications/luci-app-transmission/htdocs/luci-static/resources/view/transmission.js
@@ -22,7 +22,7 @@ return view.extend({
 	load: function() {
 		return Promise.all([
 			L.resolveDefault(callServiceList('transmission')),
-			L.resolveDefault(fs.stat('/usr/share/transmission/web/index.html')),
+			L.resolveDefault(fs.stat('/usr/share/transmission/public_html/index.html')),
 			uci.load('transmission')
 		]);
 	},

--- a/applications/luci-app-transmission/root/usr/share/rpcd/acl.d/luci-app-transmission.json
+++ b/applications/luci-app-transmission/root/usr/share/rpcd/acl.d/luci-app-transmission.json
@@ -5,7 +5,7 @@
 			"file": {
 				"/etc/group": [ "read" ],
 				"/etc/passwd": [ "read" ],
-				"/usr/share/transmission/web/index.html": [ "list" ]
+				"/usr/share/transmission/public_html/index.html": [ "list" ]
 			},
 			"ubus": {
 				"file": [ "stat" ],


### PR DESCRIPTION
~~Depends on https://github.com/openwrt/packages/pull/20739/commits~~

---------------

Transmission 4.0 web interface files changed from /web to /public_html.

This is necessary to make "Open Web interface" button visible again.