### PR TITLE
[22.03] luci-app-simple-adblock: update to 1.9.5

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.9.3-3
+PKG_VERSION:=1.9.5-1
 
 LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.

--- a/applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js
+++ b/applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js
@@ -170,14 +170,13 @@ var status = baseclass.extend({
 			var errorsDiv = [];
 			if (reply.errors && reply.errors.length) {
 				var errorTable = {
-					errorConfigValidationFail: _("Config (%s) validation failure!").format('/etc/config/' + pkg.Name),
+					errorConfigValidationFail: _("config (%s) validation failure!").format('/etc/config/' + pkg.Name),
 					errorServiceDisabled: _("%s is currently disabled").format(pkg.Name),
 					errorNoDnsmasqIpset: _("dnsmasq ipset support is enabled, but dnsmasq is either not installed or installed dnsmasq does not support ipset"),
 					errorNoIpset: _("dnsmasq ipset support is enabled, but ipset is either not installed or installed ipset does not support '%s' type").format("hash:net"),
 					errorNoDnsmasqNftset: _("dnsmasq nft set support is enabled, but dnsmasq is either not installed or installed dnsmasq does not support nft set"),
 					errorNoNft: _("dnsmasq nft sets support is enabled, but nft is not installed"),
-					errorMkdirFail: _("Unable to create directory for '%s'"),
-					errorNoWanGateway: _("The %s service failed to discover WAN gateway!").format(pkg.Name),
+					errorNoWanGateway: _("the %s failed to discover WAN gateway").format(pkg.Name),
 					errorOutputDirCreate: _("failed to create directory for %s file"),
 					errorOutputFileCreate: _("failed to create '%s' file").format(outputFile),
 					errorFailDNSReload: _("failed to restart/reload DNS resolver"),
@@ -284,9 +283,9 @@ var status = baseclass.extend({
 						btn_stop.disabled = true;
 						break;
 					default:
-						btn_start.disabled = true;
+						btn_start.disabled = false;
 						btn_action.disabled = true;
-						btn_stop.disabled = true;
+						btn_stop.disabled = false;
 						btn_enable.disabled = true;
 						btn_disable.disabled = true;
 					break;

--- a/applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js
+++ b/applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js
@@ -136,6 +136,13 @@ return view.extend({
 			o.value("1", _("Store compressed cache"));
 			o.default = ("0", _("Do not store compressed cache"));
 
+			o = s.taboption("tab_advanced", form.Value, "compressed_cache_dir", _("Directory for compressed cache file"),
+				_("Directory for compressed cache file of block-list in the persistent memory."));
+			o.datatype = 'string';
+			o.rmempty = true;
+			o.default = ("/etc");
+			o.depends('compressed_cache', '1');
+			
 			o = s.taboption("tab_advanced", form.ListValue, "debug", _("Enable Debugging"),
 				_("Enables debug output to /tmp/simple-adblock.log."));
 			o.value("0", _("Disable Debugging"));
@@ -155,6 +162,10 @@ return view.extend({
 			o.addremove = true;
 			o = s.option(form.DynamicList, "allowed_domains_url", _("Allowed Domain URLs"),
 				_("URLs to lists of domains to be allowed."));
+			o.depends('dnsmasq_config_file_url', '');
+			o.addremove = true;
+			o = s.option(form.DynamicList, "blocked_adblockplus_url", _("Blocked AdBlockPlus-style URLs"),
+				_("URLs to lists of AdBlockPlus-style formatted domains to be blocked."));
 			o.depends('dnsmasq_config_file_url', '');
 			o.addremove = true;
 			o = s.option(form.DynamicList, "blocked_domain", _("Blocked Domains"),

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -25,15 +25,15 @@ msgstr ""
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:156
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:163
 msgid "Allowed Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:152
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:159
 msgid "Allowed Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:146
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:153
 msgid "Allowed and Blocked Lists Management"
 msgstr ""
 
@@ -50,15 +50,19 @@ msgstr ""
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:164
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:167
+msgid "Blocked AdBlockPlus-style URLs"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:175
 msgid "Blocked Domain URLs"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:160
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:171
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:168
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:179
 msgid "Blocked Hosts URLs"
 msgstr ""
 
@@ -76,10 +80,6 @@ msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:133
 msgid "Compressed cache file found."
-msgstr ""
-
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:173
-msgid "Config (%s) validation failure!"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:42
@@ -102,22 +102,31 @@ msgstr ""
 msgid "DNS resolution option, see the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:270
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:139
+msgid "Directory for compressed cache file"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:140
+msgid ""
+"Directory for compressed cache file of block-list in the persistent memory."
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:269
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:37
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:39
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:141
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:143
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:148
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:150
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:266
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:265
 msgid "Disabling %s service"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:147
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:154
 msgid "Dnsmasq Config File URL"
 msgstr ""
 
@@ -143,21 +152,21 @@ msgstr ""
 msgid "Downloading lists"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:259
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:258
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:38
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:139
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:142
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:146
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:149
 msgid "Enable Debugging"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:140
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:147
 msgid "Enables debug output to /tmp/simple-adblock.log."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:255
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:254
 msgid "Enabling %s service"
 msgstr ""
 
@@ -173,7 +182,7 @@ msgstr ""
 msgid "Force DNS ports:"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:237
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:236
 msgid "Force Re-Download"
 msgstr ""
 
@@ -190,7 +199,7 @@ msgstr ""
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:233
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:232
 msgid "Force re-downloading %s block lists"
 msgstr ""
 
@@ -218,11 +227,11 @@ msgid ""
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:153
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:160
 msgid "Individual domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:161
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:172
 msgid "Individual domains to be blocked."
 msgstr ""
 
@@ -274,11 +283,11 @@ msgstr ""
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:304
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:303
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:204
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:203
 msgid "Service Errors"
 msgstr ""
 
@@ -310,7 +319,7 @@ msgstr ""
 msgid "Some output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:226
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:225
 msgid "Start"
 msgstr ""
 
@@ -318,11 +327,11 @@ msgstr ""
 msgid "Starting"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:222
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:221
 msgid "Starting %s service"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:248
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:247
 msgid "Stop"
 msgstr ""
 
@@ -334,7 +343,7 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:244
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:243
 msgid "Stopping %s service"
 msgstr ""
 
@@ -350,29 +359,25 @@ msgstr ""
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:180
-msgid "The %s service failed to discover WAN gateway!"
-msgstr ""
-
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:148
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:155
 msgid ""
 "URL to the external dnsmasq config file, see the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:157
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:168
+msgid "URLs to lists of AdBlockPlus-style formatted domains to be blocked."
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:164
 msgid "URLs to lists of domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:165
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:176
 msgid "URLs to lists of domains to be blocked."
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:169
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:180
 msgid "URLs to lists of hosts to be blocked."
-msgstr ""
-
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:179
-msgid "Unable to create directory for '%s'"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:130
@@ -391,6 +396,10 @@ msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:98
 msgid "Warning"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:173
+msgid "config (%s) validation failure!"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:127
@@ -440,91 +449,91 @@ msgstr ""
 msgid "dnsmasq servers file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:184
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:183
 msgid "failed to access shared memory"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:182
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:181
 msgid "failed to create '%s' file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:194
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:193
 msgid "failed to create block-list or restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:190
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:189
 msgid "failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:181
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:180
 msgid "failed to create directory for %s file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:202
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:201
 msgid "failed to create output/cache/gzip file directory"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:198
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:197
 msgid "failed to download"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:197
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:196
 msgid "failed to download Config Update file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:188
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:187
 msgid "failed to format data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:193
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:192
 msgid "failed to move '%s' to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:189
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:188
 msgid "failed to move temporary data file to '%s'"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:186
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:185
 msgid "failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:200
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:199
 msgid "failed to parse"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:199
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:198
 msgid "failed to parse Config Update file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:187
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:186
 msgid "failed to process allow-list"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:196
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:195
 msgid "failed to reload/restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:191
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:190
 msgid "failed to remove temporary files"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:183
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:182
 msgid "failed to restart/reload DNS resolver"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:185
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:184
 msgid "failed to sort data file"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:195
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:194
 msgid "failed to stop %s"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:192
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:191
 msgid "failed to unpack compressed cache"
 msgstr ""
 
-#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:201
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:200
 msgid "no HTTPS/SSL support on device"
 msgstr ""
 
@@ -534,6 +543,10 @@ msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:158
 msgid "some recommended packages are missing"
+msgstr ""
+
+#: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:179
+msgid "the %s failed to discover WAN gateway"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js:98

--- a/applications/luci-app-simple-adblock/root/usr/libexec/rpcd/luci.simple-adblock
+++ b/applications/luci-app-simple-adblock/root/usr/libexec/rpcd/luci.simple-adblock
@@ -7,6 +7,8 @@
 # ubus -v list luci.simple-adblock
 # ubus -S call luci.simple-adblock getInitList '{"name": "simple-adblock" }'
 # ubus -S call luci.simple-adblock getInitStatus '{"name": "simple-adblock" }'
+# ubus -S call luci.simple-adblock setInitAction '{"name": "simple-adblock", "action": "start" }'
+# ubus -S call luci.simple-adblock setInitAction '{"name": "simple-adblock", "action": "stop" }'
 # ubus -S call luci.simple-adblock getPlatformSupport '{"name": "simple-adblock" }'
 
 . /lib/functions.sh
@@ -16,22 +18,22 @@
 readonly packageName="simple-adblock"
 readonly dnsmasqAddnhostsFile="/var/run/${packageName}/dnsmasq.addnhosts"
 readonly dnsmasqAddnhostsCache="/var/run/${packageName}/dnsmasq.addnhosts.cache"
-readonly dnsmasqAddnhostsGzip="/etc/${packageName}.dnsmasq.addnhosts.gz"
+readonly dnsmasqAddnhostsGzip="${packageName}.dnsmasq.addnhosts.gz"
 readonly dnsmasqConfFile="/tmp/dnsmasq.d/${packageName}"
 readonly dnsmasqConfCache="/var/run/${packageName}/dnsmasq.conf.cache"
-readonly dnsmasqConfGzip="/etc/${packageName}.dnsmasq.conf.gz"
+readonly dnsmasqConfGzip="${packageName}.dnsmasq.conf.gz"
 readonly dnsmasqIpsetFile="/tmp/dnsmasq.d/${packageName}.ipset"
 readonly dnsmasqIpsetCache="/var/run/${packageName}/dnsmasq.ipset.cache"
-readonly dnsmasqIpsetGzip="/etc/${packageName}.dnsmasq.ipset.gz"
+readonly dnsmasqIpsetGzip="${packageName}.dnsmasq.ipset.gz"
 readonly dnsmasqNftsetFile="/tmp/dnsmasq.d/${packageName}.nftset"
 readonly dnsmasqNftsetCache="/var/run/${packageName}/dnsmasq.nftset.cache"
-readonly dnsmasqNftsetGzip="/etc/${packageName}.dnsmasq.nftset.gz"
+readonly dnsmasqNftsetGzip="${packageName}.dnsmasq.nftset.gz"
 readonly dnsmasqServersFile="/var/run/${packageName}/dnsmasq.servers"
 readonly dnsmasqServersCache="/var/run/${packageName}/dnsmasq.servers.cache"
-readonly dnsmasqServersGzip="/etc/${packageName}.dnsmasq.servers.gz"
+readonly dnsmasqServersGzip="${packageName}.dnsmasq.servers.gz"
 readonly unboundFile="/var/lib/unbound/adb_list.${packageName}"
 readonly unboundCache="/var/run/${packageName}/unbound.cache"
-readonly unboundGzip="/etc/${packageName}.unbound.gz"
+readonly unboundGzip="${packageName}.unbound.gz"
 readonly jsonFile="/var/run/${packageName}/${packageName}.json"
 
 str_contains() { [ -n "$1" ] &&[ -n "$2" ] && [ "${1//$2}" != "$1" ]; }
@@ -45,6 +47,7 @@ print_json_string() { json_init; json_add_string "$1" "$2"; json_dump; json_clea
 logger() { /usr/bin/logger -t "$packageName" "$@"; }
 ubus_get_status() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances.main.data.${1}"; }
 ubus_get_ports() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances.main.data.firewall.*.dest_port"; }
+sanitize_dir() { [ -d "$(readlink -fn "$1")" ] && readlink -fn "$1"; }
 json() {
 # shellcheck disable=SC2034
 	local action="$1" param="$2" value="$3" i
@@ -68,7 +71,7 @@ json() {
 get_init_list() {
 	local name
 	name="$(basename "$1")"
-	name="${name:-$packageName}" 
+	name="${name:-$packageName}"
 	json_init
 	json_add_object "$name"
 	json_add_boolean 'enabled' "$(is_enabled "$name")"
@@ -85,7 +88,7 @@ get_init_list() {
 set_init_action() {
 	local name action="$2" cmd
 	name="$(basename "$1")"
-	name="${name:-$packageName}" 
+	name="${name:-$packageName}"
 	if [ ! -f "/etc/init.d/$name" ]; then
 		print_json_string 'error' 'Init script not found!'
 		return
@@ -108,9 +111,18 @@ set_init_action() {
 get_init_status() {
 	local name
 	name="$(basename "$1")"
-	name="${name:-$packageName}" 
+	name="${name:-$packageName}"
 	local errors warnings ports dns outputFile outputCache outputGzip
-	local i
+	local i j
+# shellcheck disable=SC2034
+	local compressed_cache_dir
+	config_load "$name"
+	config_get compressed_cache_dir 'config' 'compressed_cache_dir' '/etc'
+	if [ -n "$(sanitize_dir "$compressed_cache_dir")" ]; then
+		compressed_cache_dir="$(sanitize_dir "$compressed_cache_dir")"
+	else
+		compressed_cache_dir="/etc"
+	fi
 	errors="$(ubus_get_status errors)"
 	warnings="$(ubus_get_status warnings)"
 	ports="$(ubus_get_ports)"
@@ -123,38 +135,42 @@ get_init_status() {
 		dnsmasq.addnhosts)
 			outputFile="$dnsmasqAddnhostsFile"
 			outputCache="$dnsmasqAddnhostsCache"
-			outputGzip="$dnsmasqAddnhostsGzip"
+			outputGzip="${compressed_cache_dir}/${dnsmasqAddnhostsGzip}"
 		;;
 		dnsmasq.conf)
 			outputFile="$dnsmasqConfFile"
 			outputCache="$dnsmasqConfCache"
-			outputGzip="$dnsmasqConfGzip"
+			outputGzip="${compressed_cache_dir}/${dnsmasqConfGzip}"
 		;;
 		dnsmasq.ipset)
 			outputFile="$dnsmasqIpsetFile"
 			outputCache="$dnsmasqIpsetCache"
-			outputGzip="$dnsmasqIpsetGzip"
+			outputGzip="${compressed_cache_dir}/${dnsmasqIpsetGzip}"
 		;;
 		dnsmasq.nftset)
 			outputFile="$dnsmasqNftsetFile"
 			outputCache="$dnsmasqNftsetCache"
-			outputGzip="$dnsmasqNftsetGzip"
+			outputGzip="${compressed_cache_dir}/${dnsmasqNftsetGzip}"
 		;;
 		dnsmasq.servers)
 			outputFile="$dnsmasqServersFile"
 			outputCache="$dnsmasqServersCache"
-			outputGzip="$dnsmasqServersGzip"
+			outputGzip="${compressed_cache_dir}/${dnsmasqServersGzip}"
 		;;
 		unbound.adb_list)
 			outputFile="$unboundFile"
 			outputCache="$unboundCache"
-			outputGzip="$unboundGzip"
+			outputGzip="${compressed_cache_dir}/${unboundGzip}"
 		;;
 	esac
 	json_init
 	json_add_object  "$name"
 	json_add_boolean 'enabled' "$(is_enabled "$name")"
 	i="$(json 'get' 'status')"
+	j="$(ubus_get_status 'status')"
+	if [ "$i" = 'statusSuccess' ] && [ "$i" != "$j" ]; then
+		i='statusStopped'
+	fi
 	json_add_string 'status' "$i"
 	if [ "$i" = 'statusSuccess' ]; then
 		json_add_boolean 'running' '1'
@@ -253,7 +269,7 @@ check_dnsmasq_nftset() {
 get_platform_support() {
 	local name
 	name="$(basename "$1")"
-	name="${name:-$packageName}" 
+	name="${name:-$packageName}"
 	json_init
 	json_add_object "$name"
 	if check_ipset; then


### PR DESCRIPTION
* update to support corresponding principal package

Depends on https://github.com/openwrt/packages/pull/20769

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit b7be432ba79e1320661a7a92d2203358bcbde88c)