### PR TITLE
luci-app-firewall: fix the IPv6 forwards/snats view

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/forwards.js
@@ -10,7 +10,7 @@
 
 function rule_proto_txt(s, ctHelpers) {
 	var family = (uci.get('firewall', s, 'family') || '').toLowerCase().replace(/^(?:any|\*)$/, '');
-	var dip = uci.get('firewall', s, 'dest_ip') || ''
+	var dip = uci.get('firewall', s, 'dest_ip') || '';
 	var proto = L.toArray(uci.get('firewall', s, 'proto')).filter(function(p) {
 		return (p != '*' && p != 'any' && p != 'all');
 	}).map(function(p) {
@@ -38,8 +38,8 @@ function rule_proto_txt(s, ctHelpers) {
 	} : null;
 
 	return fwtool.fmt(_('Incoming %{ipv6?%{ipv4?<var>IPv4</var> and <var>IPv6</var>:<var>IPv6</var>}:<var>IPv4</var>}%{proto?, protocol %{proto#%{next?, }%{item.types?<var class="cbi-tooltip-container">%{item.name}<span class="cbi-tooltip">ICMP with types %{item.types#%{next?, }<var>%{item}</var>}</span></var>:<var>%{item.name}</var>}}}%{mark?, mark <var%{mark.inv? data-tooltip="Match fwmarks except %{mark.num}%{mark.mask? with mask %{mark.mask}}.":%{mark.mask? data-tooltip="Mask fwmark value with %{mark.mask} before compare."}}>%{mark.val}</var>}%{helper?, helper %{helper.inv?<var data-tooltip="Match any helper except &quot;%{helper.name}&quot;">%{helper.val}</var>:<var data-tooltip="%{helper.name}">%{helper.val}</var>}}'), {
-		ipv4: ((!family && (dip.indexOf(':') == -1)) || family == 'ipv4'),
-		ipv6: ((!family && (dip.indexOf(':') != -1)) || family == 'ipv6'),
+		ipv4: ((!family && dip.indexOf(':') == -1) || family == 'ipv4'),
+		ipv6: ((!family && dip.indexOf(':') != -1) || (!family && !dip) || family == 'ipv6'),
 		proto: proto,
 		helper: h,
 		mark:   f

--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/snats.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/snats.js
@@ -32,8 +32,8 @@ function rule_proto_txt(s) {
 	} : null;
 
 	return fwtool.fmt(_('Forwarded %{ipv6?%{ipv4?<var>IPv4</var> and <var>IPv6</var>:<var>IPv6</var>}:<var>IPv4</var>}%{proto?, protocol %{proto#%{next?, }<var>%{item.name}</var>}}%{mark?, mark <var%{mark.inv? data-tooltip="Match fwmarks except %{mark.num}%{mark.mask? with mask %{mark.mask}}.":%{mark.mask? data-tooltip="Mask fwmark value with %{mark.mask} before compare."}}>%{mark.val}</var>}'), {
-		ipv4: (family == 'ipv4' || (!family && (sip.indexOf(':') == -1 && dip.indexOf(':') == -1 && rwip.indexOf(':') == -1))),
-		ipv6: (family == 'ipv6' || (!family && (sip.indexOf(':') != -1 || dip.indexOf(':') != -1 || rwip.indexOf(':') != -1))),
+		ipv4: (family == 'ipv4' || (!family && sip.indexOf(':') == -1 && dip.indexOf(':') == -1 && rwip.indexOf(':') == -1)),
+		ipv6: (family == 'ipv6' || (!family && (!sip || !dip || !rwip)) || (!family && (sip.indexOf(':') != -1 || dip.indexOf(':') != -1 || rwip.indexOf(':') != -1))),
 		proto: proto,
 		mark:  f
 	});


### PR DESCRIPTION
* corrects the view as IPv4 and IPv6 for rules where the family is 'any' and the IP not set (this fixes #9c55500), e.g. a forward rule like that:

```
config redirect 'adblock_lan53'
	option name 'Adblock DNS (lan, 53)'
	option src 'lan'
	option proto 'tcp udp'
	option src_dport '53'
	option dest_port '53'
	option target 'DNAT'
	option family 'any'
```
**Old behavior**
Forward:
![forwards_old](https://user-images.githubusercontent.com/8061346/230042689-3b2be5c0-b362-4495-9d25-4a711c87d47b.png)

SNAT:
![snats_old](https://user-images.githubusercontent.com/8061346/230042923-a199d962-4d4d-4eac-9503-ebcedf1c8806.png)


**New behavior:**
Forward:
![forwards_new](https://user-images.githubusercontent.com/8061346/230042786-c416c804-d529-407e-8df7-4ae6fe39c5cc.png)

SNAT:
![snats_new](https://user-images.githubusercontent.com/8061346/230043002-f9558d82-a17b-44b7-8b09-db6c2f059a23.png)


Signed-off-by: Dirk Brenken <dev@brenken.org>
