### PR TITLE
luci-app-uhttpd: fix redirect_https flag

### DIFF
--- a/applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua
+++ b/applications/luci-app-uhttpd/luasrc/model/cbi/uhttpd/uhttpd.lua
@@ -84,6 +84,8 @@ function lhttps.validate(self, value, section)
 end
 
 o = ucs:taboption("general", Flag, "redirect_https", translate("Redirect all HTTP to HTTPS"))
+o.enabled = "on"
+o.disabled = "off"
 o.default = o.enabled
 o.rmempty = false
 


### PR DESCRIPTION
`System -> Administration -> HTTP(S) Access` tab uses on/off insted of 1/0. So I synced them to properly show https redirect status.
