### PR TITLE
luci-mod-network: add support for creating cname records

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -262,6 +262,7 @@ return view.extend({
 		s.tab('hosts', _('Hostnames'));
 		s.tab('srvhosts', _('SRV'));
 		s.tab('mxhosts', _('MX'));
+		s.tab('cnamehosts', _('CNAME'));
 		s.tab('ipsets', _('IP Sets'));
 
 		s.taboption('general', form.Flag, 'domainneeded',
@@ -693,6 +694,27 @@ return view.extend({
 		so.rmempty = true;
 		so.datatype = 'range(0,65535)';
 		so.placeholder = '0';
+
+		o = s.taboption('cnamehosts', form.SectionValue, '__cname__', form.TableSection, 'cname', null, 
+			_('Set an alias for a hostname.'));
+
+		ss = o.subsection;
+
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable  = true;
+		ss.rowcolors = true;
+		ss.nodescriptions = true;
+
+		so = ss.option(form.Value, 'cname', _('Domain'));
+		so.rmempty = false;
+		so.datatype = 'hostname';
+		so.placeholder = 'www.example.com';
+
+		so = ss.option(form.Value, 'target', _('Target'));
+		so.rmempty = false;
+		so.datatype = 'hostname';
+		so.placeholder = 'example.com';
 
 		o = s.taboption('hosts', form.SectionValue, '__hosts__', form.GridSection, 'domain', null,
 			_('Hostnames are used to bind a domain name to an IP address. This setting is redundant for hostnames already configured with static leases, but it can be useful to rebind an FQDN.'));


### PR DESCRIPTION
I used the MX and SRV tabs as templates to create a new tab where users can create cname records in dnsmasq, using the cname and target options.