### PR TITLE
luci-mod-dashboard: hide wireless pane when there are no radios

### DIFF
--- a/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js
+++ b/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/30_wifi.js
@@ -262,6 +262,8 @@ return baseclass.extend({
 
 		this.renderUpdateData(data[0], data[1], data[2]);
 
-		return this.renderHtml();
+		if (this.params.wifi.radios.length)
+			return this.renderHtml();
+		return E([]);
 	}
 });


### PR DESCRIPTION
Implements feature request #4472.
