### PR TITLE
luci-base: ui.js: avoid polling in a tight loop on confirm/rollback

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4549,7 +4549,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 					E('p', _('Failed to confirm apply within %ds, waiting for rollback…')
 						.format(L.env.apply_rollback)));
 
-				var call = function(r, data, duration) {
+				var call = function(r) {
 					if (r.status === 204) {
 						UI.prototype.changes.displayStatus('warning', [
 							E('h4', _('Configuration changes have been rolled back!')),
@@ -4573,13 +4573,13 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 						return;
 					}
 
-					var delay = isNaN(duration) ? 0 : Math.max(1000 - duration, 0);
+					var delay = isNaN(r.duration) ? 0 : Math.max(1000 - r.duration, 0);
 					window.setTimeout(function() {
 						request.request(L.url('admin/uci/confirm'), {
 							method: 'post',
 							timeout: L.env.apply_timeout * 1000,
 							query: { sid: L.env.sessionid, token: L.env.token }
-						}).then(call, call.bind(null, { status: 0 }, null, 0));
+						}).then(call, call.bind(null, { status: 0, duration: 0 }));
 					}, delay);
 				};
 
@@ -4603,13 +4603,13 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 			if (override_token)
 				this.confirm_auth = { token: override_token };
 
-			var call = function(r, data, duration) {
+			var call = function(r) {
 				if (Date.now() >= deadline) {
 					window.clearTimeout(tt);
 					UI.prototype.changes.rollback(checked);
 					return;
 				}
-				else if (r && (r.status === 200 || r.status === 204)) {
+				else if (r.status === 200 || r.status === 204) {
 					document.dispatchEvent(new CustomEvent('uci-applied'));
 
 					UI.prototype.changes.setIndicator(0);
@@ -4625,13 +4625,13 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 					return;
 				}
 
-				var delay = isNaN(duration) ? 0 : Math.max(1000 - duration, 0);
+				var delay = isNaN(r.duration) ? 0 : Math.max(1000 - r.duration, 0);
 				window.setTimeout(function() {
 					request.request(L.url('admin/uci/confirm'), {
 						method: 'post',
 						timeout: L.env.apply_timeout * 1000,
 						query: UI.prototype.changes.confirm_auth
-					}).then(call, call);
+					}).then(call, call.bind(null, { status: 0, duration: 0 }));
 				}, delay);
 			};
 
@@ -4652,7 +4652,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 			tick();
 
 			/* wait a few seconds for the settings to become effective */
-			window.setTimeout(call, Math.max(L.env.apply_holdoff * 1000 - ((ts + L.env.apply_rollback * 1000) - deadline), 1));
+			window.setTimeout(call.bind(null, { status: 0 }), L.env.apply_holdoff * 1000);
 		},
 
 		/**


### PR DESCRIPTION
The call function was based on the legacy XHR interface and it has not been updated to comply with the new request interface which passes the duration as part of the response object rather than as a separate argument. This resulted in polling in a tight loop in certain cases since the duration was undefined.

In addition there is no need to adjust apply_holdoff based on elapsed time as no significant amount of time has elapsed at this point.