### PR TITLE
luci-proto-wireguard: adding an Addresses option to the wireguard peer config generator

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -692,7 +692,7 @@ return network.registerProtocol('wireguard', {
 
 		o.modalonly = true;
 
-		o.createPeerConfig = function(section_id, endpoint, ips) {
+		o.createPeerConfig = function(section_id, endpoint, ips, eips) {
 			var pub = s.formvalue(s.section, 'public_key'),
 			    port = s.formvalue(s.section, 'listen_port') || '51820',
 			    prv = this.section.formvalue(section_id, 'private_key'),
@@ -708,6 +708,7 @@ return network.registerProtocol('wireguard', {
 			return [
 				'[Interface]',
 				'PrivateKey = ' + prv,
+				eips && eips.length ? 'Address = ' + eips.join(', ') : '# Address not defined',
 				eport ? 'ListenPort = ' + eport : '# ListenPort not defined',
 				'',
 				'[Peer]',
@@ -723,7 +724,8 @@ return network.registerProtocol('wireguard', {
 			var mapNode = ss.getActiveModalMap(),
 			    headNode = mapNode.parentNode.querySelector('h4'),
 			    configGenerator = this.createPeerConfig.bind(this, section_id),
-			    parent = this.map;
+			    parent = this.map,
+				eips = this.section.formvalue(section_id, 'allowed_ips');
 
 			return Promise.all([
 				network.getWANNetworks(),
@@ -754,7 +756,7 @@ return network.registerProtocol('wireguard', {
 
 				var qrm, qrs, qro;
 
-				qrm = new form.JSONMap({ config: { endpoint: hostnames[0], allowed_ips: ips } }, null, _('The generated configuration can be imported into a WireGuard client application to set up a connection towards this device.'));
+				qrm = new form.JSONMap({ config: { endpoint: hostnames[0], allowed_ips: ips, addresses: eips } }, null, _('The generated configuration can be imported into a WireGuard client application to set up a connection towards this device.'));
 				qrm.parent = parent;
 
 				qrs = qrm.section(form.NamedSection, 'config');
@@ -764,9 +766,10 @@ return network.registerProtocol('wireguard', {
 					    conf = this.map.findElement('.client-config'),
 					    endpoint = this.section.getUIElement(section_id, 'endpoint'),
 					    ips = this.section.getUIElement(section_id, 'allowed_ips');
+					    eips = this.section.getUIElement(section_id, 'addresses');
 
 					if (this.isValid(section_id)) {
-						conf.firstChild.data = configGenerator(endpoint.getValue(), ips.getValue());
+						conf.firstChild.data = configGenerator(endpoint.getValue(), ips.getValue(), eips.getValue());
 						code.style.opacity = '.5';
 
 						invokeQREncode(conf.firstChild.data, code);
@@ -784,9 +787,15 @@ return network.registerProtocol('wireguard', {
 				ips.forEach(function(ip) { qro.value(ip) });
 				qro.onchange = handleConfigChange;
 
+				qro = qrs.option(form.DynamicList, 'addresses', _('Addresses'), _('IP addresses for the peer to use inside the tunnel. Some clients require this setting.'));
+				qro.datatype = 'ipaddr';
+				qro.default = eips;
+				eips.forEach(function(eip) { qro.value(eip) });
+				qro.onchange = handleConfigChange;
+
 				qro = qrs.option(form.DummyValue, 'output');
 				qro.renderWidget = function() {
-					var peer_config = configGenerator(hostnames[0], ips);
+					var peer_config = configGenerator(hostnames[0], ips, eips);
 
 					var node = E('div', {
 						'style': 'display:flex;flex-wrap:wrap;align-items:center;gap:.5em;width:100%'


### PR DESCRIPTION
Some clients like iOS require this explicitly, and so this change adds the appropriate config with some sensible defaults. If the intended behavior is at all different from what was agreed upon in the issue, let me know and I will se what I can do.
Addresses issue #6050
Signed-off-by: Nicholaos Mouzourakis <nevumx@gmail.com>