### PR TITLE
luci-app-shadowsocks-libev: ACL support

### DIFF
--- a/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/shadowsocks-libev.js
+++ b/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/shadowsocks-libev.js
@@ -170,7 +170,7 @@ return baseclass.extend({
 		o.datatype = 'base64';
 		o.password = true;
 		o.size = 12;
-		o.modalonly = true;;
+		o.modalonly = true;
 
 		optfunc(form.Value, 'plugin', _('Plugin')).modalonly = true;
 

--- a/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/instances.js
+++ b/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/instances.js
@@ -108,6 +108,12 @@ return view.extend({
 							o.datatype = 'hostport';
 						}
 					}
+					if (stype === 'ss_local' || stype === 'ss_server') {
+						o = s.taboption('advanced', form.FileUpload, 'acl',
+							_('ACL file'),
+							_('File containing Access Control List'));
+						o.root_directory = '/etc/shadowsocks-libev';
+					}
 				}, this));
 			}
 		};


### PR DESCRIPTION
Added ability to pass an Access Control List (--acl param) to forbid access to specified IP addresses

Maintainer: @yousong
Compile tested: MediaTek MT7628AN ver:1 eco:2, TP-Link TL-WR841N v13, OpenWrt 22.03.3 r20028-43d71ad93e
Run tested: MediaTek MT7628AN ver:1 eco:2, TP-Link TL-WR841N v13, OpenWrt 22.03.3 r20028-43d71ad93e
