### PR TITLE
luci-theme-openwrt-2020: fix readability issues

### DIFF
--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -383,6 +383,8 @@ tr.placeholder > td {
 	justify-content: space-around;
 	max-width: 120px;
 	padding: .2em;
+	white-space: normal;
+	text-align: center;
 }
 
 .assoclist td > .ifacebadge::after {

--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -677,7 +677,7 @@ p > a {
 	flex-direction: column;
 	padding: 0;
 	text-align: center;
-	width: 100%;
+	min-width: 100%;
 	max-width: 150px;
 }
 
@@ -721,7 +721,7 @@ p > a {
 
 .network-status-table > .ifacebox {
 	max-width: none;
-	flex: 1 1 45%;
+	flex-grow: 1;
 	margin: .25em;
 	min-width: 250px;
 }

--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -687,6 +687,7 @@ p > a {
 }
 
 .ifacebox-body {
+	width: 100%;
 	text-align: center;
 	padding: .3em .25em .25em .25em;
 	white-space: nowrap;


### PR DESCRIPTION
# Context

I've started using this theme (which I really like it) and I've spotted two issues:

## Issue 1: iface badges cuts the iface name because it overflows

This is how it looks currently:

![image](https://user-images.githubusercontent.com/186349/234213529-b6c04cfc-d7e3-4a0c-82ca-cb0696e39308.png)

Fix by setting `white-space: normal` and `text-align: center`:

![image](https://user-images.githubusercontent.com/186349/234213572-bcbba4f9-9146-45b4-936d-a736dd8cda00.png)

## Issue 2: iface boxes (Network and Wireless sections in Status->Overview) cuts text in small resolutions and center content with too much space in big resolutions with different margins/paddings.

This is how it looks currently:

![image](https://user-images.githubusercontent.com/186349/234215089-2a3fe34b-9c3e-4281-a1ae-3a863e17e888.png)

![image](https://user-images.githubusercontent.com/186349/234215126-c63b9d2d-b9dc-4b67-8bb8-7eff6f5f8221.png)

Fix by setting `.ifacebox-body` `width: 100%` and changing `.network-status-table > .ifacebox` flex settings to `flex-grow: 1` and `.ifacebox` `width` to `min-width`, this way there is no more weird margins on high resolutions or cut test in small resolutions:

![image](https://user-images.githubusercontent.com/186349/234223008-1a6a6214-3639-4d85-b99f-7e523d8b19ff.png)

![image](https://user-images.githubusercontent.com/186349/234222864-6d112b3f-f4b6-4155-9601-d465b9a5f41b.png)


