### PR TITLE
luci-app-advanced-reboot: add support for Linksys and Xiaomi devices …

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.0.1-3
+PKG_VERSION:=1.0.1-8
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/

--- a/applications/luci-app-advanced-reboot/htdocs/luci-static/resources/view/system/advanced_reboot.js
+++ b/applications/luci-app-advanced-reboot/htdocs/luci-static/resources/view/system/advanced_reboot.js
@@ -5,6 +5,11 @@
 'require uci';
 'require fs';
 
+var pkg = {
+	get Name() { return 'luci-app-advanced-reboot'; },
+	get URL() { return 'https://docs.openwrt.melmac.net/' + pkg.Name + '/'; }
+};
+
 return view.extend({
 	translateTable: {
 		NO_BOARD_NAME : function(args) { return _('Unable to find Device Board Name.')},
@@ -213,9 +218,13 @@ return view.extend({
 			body.appendChild(partitions_table);
 		} else {
 			body.appendChild(E('p', { 'class' : 'alert-message warning'},
-			device_info.rom_board_name ? _("Warning: Device (%s) is unknown or isn't a dual-partition device!").format(device_info.rom_board_name)
+			device_info.rom_board_name ? _("Warning: Device (%s) is unknown or isn't a dual-firmware device!" + "%s" +
+					"If you are seeing this on an OpenWrt dual-firmware supported device," + "%s" + "please refer to " +
+					"%sHow to add a new device section of the README%s.").format(device_info.rom_board_name, "<br /><br />", "<br />",
+						"<a href=\"" + pkg.URL + "#how-to-add-a-new-device\" target=\"_blank\">", "</a>" )
 				: _('Warning: Unable to obtain device information!')
 			));
+
 		}
 
 		body.appendChild(E('hr'));

--- a/applications/luci-app-advanced-reboot/root/etc/uci-defaults/40_luci-advanced-reboot
+++ b/applications/luci-app-advanced-reboot/root/etc/uci-defaults/40_luci-advanced-reboot
@@ -1,5 +1,4 @@
 #!/bin/sh
-
-/etc/init.d/rpcd reload
 rm -rf /var/luci-modulecache/; rm -f /var/luci-indexcache;
+[ -x /etc/init.d/rpcd ] && /etc/init.d/rpcd reload
 exit 0

--- a/applications/luci-app-advanced-reboot/root/usr/libexec/rpcd/luci.advanced_reboot
+++ b/applications/luci-app-advanced-reboot/root/usr/libexec/rpcd/luci.advanced_reboot
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright 2017-2020 Stan Grishin (stangri@melmac.net)
+# Copyright 2017-2020 Stan Grishin (stangri@melmac.ca)
 # shellcheck disable=SC2039,SC1091,SC3043,SC3057,SC3060
 
 readonly devices_dir="/usr/share/advanced-reboot/devices/"

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea8100v2.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea8100v2.json
@@ -1,14 +1,14 @@
 {
 	"vendorName": "Linksys",
-	"deviceName": "EA7500v2",
-	"boardNames": [ "linksys,ea7500-v2" ],
+	"deviceName": "EA8100v2",
+	"boardNames": [ "linksys,ea8100-v2" ],
 	"partition1MTD": "mtd5",
 	"partition2MTD": "mtd7",
 	"labelOffset": 32,
 	"bootEnv1": "boot_part",
 	"bootEnv1Partition1Value": 1,
 	"bootEnv1Partition2Value": 2,
-	"bootEnv2": "bootcmd",
-	"bootEnv2Partition1Value": "run nandboot",
-	"bootEnv2Partition2Value": "run altnandboot"
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
 }

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-whw01v1.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-whw01v1.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "WHW01 V1 (Velop)",
+	"boardNames": [ "linksys,whw01" ],
+	"partition1MTD": "mtd9",
+	"partition2MTD": "mtd11",
+	"labelOffset": 192,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax3600.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax3600.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Xiaomi",
+	"deviceName": "AX3600",
+	"boardNames": [ "xiaomi,ax3600" ],
+	"partition1MTD": "mtd12",
+	"partition2MTD": "mtd13",
+	"labelOffset": 266432,
+	"bootEnv1": "flag_boot_rootfs",
+	"bootEnv1Partition1Value": 0,
+	"bootEnv1Partition2Value": 1,
+	"bootEnv2": "flag_last_success",
+	"bootEnv2Partition1Value": 0,
+	"bootEnv2Partition2Value": 1
+}

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax9000.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/xiaomi-ax9000.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Xiaomi",
+	"deviceName": "AX9000",
+	"boardNames": [ "xiaomi,ax9000" ],
+	"partition1MTD": "mtd20",
+	"partition2MTD": "mtd21",
+	"labelOffset": 266432,
+	"bootEnv1": "flag_boot_rootfs",
+	"bootEnv1Partition1Value": 0,
+	"bootEnv1Partition2Value": 1,
+	"bootEnv2": "flag_last_success",
+	"bootEnv2Partition1Value": 0,
+	"bootEnv2Partition2Value": 1
+}


### PR DESCRIPTION
…and misc fixes

Fixes:
* change maintainer's email address
* add rpcd reload to uci-defaults script
* add better messaging with link to README when device isn't detected as dual-firmware

Add support for:
* linksys-ea8100v2
* linksys-whw01v1
* xiaomi-ax3600
* xiaomi-ax9000