### PR TITLE
luci-app-pbr: update to 1.1.1-5

### DIFF
--- a/applications/luci-app-pbr/Makefile
+++ b/applications/luci-app-pbr/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.1.1-1
+PKG_VERSION:=1.1.1-5
 
 LUCI_TITLE:=Policy Based Routing Service Web UI
 LUCI_DESCRIPTION:=Provides Web UI for Policy Based Routing Service.


### PR DESCRIPTION
* Artificial version bump as WebUI compares version number to the principal package

Principal package PR: https://github.com/openwrt/packages/pull/20930