### PR TITLE
luci-app-smartdns: bump to 1.2023.42

### DIFF
--- a/applications/luci-app-smartdns/Makefile
+++ b/applications/luci-app-smartdns/Makefile
@@ -6,8 +6,8 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Nick Peng <pymumu@gmail.com>
-PKG_VERSION:=1.2022.38
-PKG_RELEASE:=2
+PKG_VERSION:=1.2023.42
+PKG_RELEASE:=1
 
 LUCI_TITLE:=LuCI for smartdns
 LUCI_DESCRIPTION:=Provides Luci for smartdns

--- a/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
+++ b/applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js
@@ -1,6 +1,6 @@
 /*************************************************************************
  *
- * Copyright (C) 2018-2020 Ruilin Peng (Nick) <pymumu@gmail.com>.
+ * Copyright (C) 2018-2023 Ruilin Peng (Nick) <pymumu@gmail.com>.
  *
  * smartdns is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -38,11 +38,11 @@ var pollAdded = false;
 function getServiceStatus() {
 	return L.resolveDefault(callServiceList(conf), {})
 		.then(function (res) {
-			var isrunning = false;
+			var is_running = false;
 			try {
-				isrunning = res[conf]['instances']['smartdns']['running'];
+				is_running = res[conf]['instances']['smartdns']['running'];
 			} catch (e) { }
-			return isrunning;
+			return is_running;
 		});
 }
 
@@ -73,7 +73,7 @@ function smartdnsRenderStatus(res) {
 		uci.unload('dhcp');
 		uci.load('dhcp');
 		if (dnsmasqServer == undefined || dnsmasqServer.indexOf(matchLine) < 0) {
-			renderHTML += "<br /><span style=\"color:red;font-weight:bold\">" + _("Dnsmasq Forwared To Smartdns Failure") + "</span>";
+			renderHTML += "<br /><span style=\"color:red;font-weight:bold\">" + _("Dnsmasq Forwarded To Smartdns Failure") + "</span>";
 		}
 	}
 
@@ -89,6 +89,8 @@ return view.extend({
 	},
 	render: function (stats) {
 		var m, s, o;
+		var ss, so;
+		var servers, download_files;
 
 		m = new form.Map('smartdns', _('SmartDNS'));
 		m.title = _("SmartDNS Server");
@@ -120,14 +122,23 @@ return view.extend({
 			]);
 		}
 
+		////////////////
 		// Basic;
+		////////////////
 		s = m.section(form.TypedSection, "smartdns", _("Settings"), _("General Settings"));
 		s.anonymous = true;
 
 		s.tab("settings", _("General Settings"));
+		s.tab("advanced", _('Advanced Settings'));
 		s.tab("seconddns", _("Second Server Settings"));
+		s.tab("dns64", _("DNS64 Server Settings"));
+		s.tab("files", _("Download Files Setting"), _("Download domain list files for domain-rule and include config files, please refresh the page after download to take effect."));
+		s.tab("proxy", _("Proxy Server Settings"));
 		s.tab("custom", _("Custom Settings"));
 
+		///////////////////////////////////////
+		// Basic Settings
+		///////////////////////////////////////
 		o = s.taboption("settings", form.Flag, "enabled", _("Enable"), _("Enable or disable smartdns server"));
 		o.rmempty = false;
 		o.default = o.disabled;
@@ -145,65 +156,176 @@ return view.extend({
 		o.default = 53;
 		o.datatype = "port";
 		o.rempty = false;
-
-		// Enable TCP server;
-		o = s.taboption("settings", form.Flag, "tcp_server", _("TCP Server"), _("Enable TCP DNS Server"));
-		o.rmempty = false;
-		o.default = o.enabled;
-
-		// Support IPV6;
-		o = s.taboption("settings", form.Flag, "ipv6_server", _("IPV6 Server"), _("Enable IPV6 DNS Server"));
-		o.rmempty = false;
-		o.default = o.enabled;
-
-		// Support DualStack ip selection;
-		o = s.taboption("settings", form.Flag, "dualstack_ip_selection", _("Dual-stack IP Selection"),
-			_("Enable IP selection between IPV4 and IPV6"));
-		o.rmempty = false;
-		o.default = o.enabled;
-
-		// Domain prefetch load ;
-		o = s.taboption("settings", form.Flag, "prefetch_domain", _("Domain prefetch"),
-			_("Enable domain prefetch, accelerate domain response speed."));
-		o.rmempty = false;
-		o.default = o.disabled;
-
-		// Domain Serve expired
-		o = s.taboption("settings", form.Flag, "serve_expired", _("Serve expired"),
-			_("Attempts to serve old responses from cache with a TTL of 0 in the response without waiting for the actual resolution to finish."));
-		o.rmempty = false;
-		o.default = o.enabled;
-
-		// cache-size;
-		o = s.taboption("settings", form.Value, "cache_size", _("Cache Size"), _("DNS domain result cache size"));
-		o.rempty = true;
-
-		// cache-size;
-		o = s.taboption("settings", form.Flag, "resolve_local_hostnames", _("Resolve Local Hostnames"), _("Resolve local hostnames by reading Dnsmasq lease file."));
-		o.rmempty = false;
-		o.default = o.enabled;
-
+		
 		// auto-conf-dnsmasq;
 		o = s.taboption("settings", form.Flag, "auto_set_dnsmasq", _("Automatically Set Dnsmasq"), _("Automatically set as upstream of dnsmasq when port changes."));
 		o.rmempty = false;
 		o.default = o.enabled;
 
-		// Force AAAA SOA
-		o = s.taboption("settings", form.Flag, "force_aaaa_soa", _("Force AAAA SOA"), _("Force AAAA SOA."));
+		///////////////////////////////////////
+		// advanced settings;
+		///////////////////////////////////////
+		// Speed check mode;
+		o = s.taboption("advanced", form.Value, "speed_check_mode", _("Speed Check Mode"), _("Smartdns speed check mode."));
+		o.rmempty = true;
+		o.placeholder = "default";
+		o.value("", _("default"));
+		o.value("ping,tcp:80,tcp:443");
+		o.value("ping,tcp:443,tcp:80");
+		o.value("tcp:80,tcp:443,ping");
+		o.value("tcp:443,tcp:80,ping");
+		o.value("none", _("None"));
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			if (value == "none") {
+				return true;
+			}
+
+			var check_mode = value.split(",")
+			for (var i = 0; i < check_mode.length; i++) {
+				if (check_mode[i] == "ping") {
+					continue;
+				}
+
+				if (check_mode[i].indexOf("tcp:") == 0) {
+					var port = check_mode[i].split(":")[1];
+					if (port == "") {
+						return _("TCP port is empty");
+					}
+
+					continue;
+				}
+
+				return _("Speed check mode is invalid.");
+			}
+
+			return true;
+		}
+
+		// response mode;
+		o = s.taboption("advanced", form.ListValue, "response_mode", _("Response Mode"),
+			_("Smartdns response mode, First Ping: return the first ping IP, Fastest IP: return the fastest IP, Fastest Response: return the fastest DNS response."));
+		o.rmempty = true;
+		o.placeholder = "default";
+		o.value("", _("default"));
+		o.value("first-ping", _("First Ping"));
+		o.value("fastest-ip", _("Fastest IP"));
+		o.value("fastest-response", _("Fastest Response"));
+
+		// Enable TCP server;
+		o = s.taboption("advanced", form.Flag, "tcp_server", _("TCP Server"), _("Enable TCP DNS Server"));
 		o.rmempty = false;
+		o.default = o.enabled;
+
+		// Support IPV6;
+		o = s.taboption("advanced", form.Flag, "ipv6_server", _("IPV6 Server"), _("Enable IPV6 DNS Server"));
+		o.rmempty = false;
+		o.default = o.enabled;
+
+		// bind to device;
+		o = s.taboption("advanced", form.Flag, "bind_device", _("Bind Device"), _("Listen only on the specified interfaces."));
+		o.rmempty = false;
+		o.default = o.enabled;
+
+		// bind device name;
+		o = s.taboption("advanced", form.Value, "bind_device_name", _("Bind Device Name"), _("Name of device name listen on."));
+		o.placeholder = "default";
+		o.rempty = true;
+		o.datatype = "string";
+
+		// Support DualStack ip selection;
+		o = s.taboption("advanced", form.Flag, "dualstack_ip_selection", _("Dual-stack IP Selection"),
+			_("Enable IP selection between IPV4 and IPV6"));
+		o.rmempty = false;
+		o.default = o.enabled;
+
+		// Domain prefetch load ;
+		o = s.taboption("advanced", form.Flag, "prefetch_domain", _("Domain prefetch"),
+			_("Enable domain prefetch, accelerate domain response speed."));
+		o.rmempty = true;
+		o.default = o.disabled;
+
+		// Domain Serve expired
+		o = s.taboption("advanced", form.Flag, "serve_expired", _("Serve expired"),
+			_("Attempts to serve old responses from cache with a TTL of 0 in the response without waiting for the actual resolution to finish."));
+		o.rmempty = false;
+		o.default = o.enabled;
+
+		// cache-size;
+		o = s.taboption("advanced", form.Value, "cache_size", _("Cache Size"), _("DNS domain result cache size"));
+		o.rempty = true;
+
+		// cache-persist;
+		o = s.taboption("advanced", form.Flag, "cache_persist", _("Cache Persist"), _("Write cache to disk on exit and load on startup."));
+		o.rmempty = false;
+		o.default = o.enabled;
+
+		// cache-size;
+		o = s.taboption("advanced", form.Flag, "resolve_local_hostnames", _("Resolve Local Hostnames"), _("Resolve local hostnames by reading Dnsmasq lease file."));
+		o.rmempty = false;
+		o.default = o.enabled;
+
+		// Force AAAA SOA
+		o = s.taboption("advanced", form.Flag, "force_aaaa_soa", _("Force AAAA SOA"), _("Force AAAA SOA."));
+		o.rmempty = true;
 		o.default = o.disabled;
 
 		// Force HTTPS SOA
-		o = s.taboption("settings", form.Flag, "force_https_soa", _("Force HTTPS SOA"), _("Force HTTPS SOA."));
+		o = s.taboption("advanced", form.Flag, "force_https_soa", _("Force HTTPS SOA"), _("Force HTTPS SOA."));
 		o.rmempty = false;
-		o.default = o.disabled;
+		o.default = o.enabled;
+
+		// Ipset no speed.
+		o = s.taboption("advanced", form.Value, "ipset_no_speed", _("No Speed IPset Name"), 
+			_("Ipset name, Add domain result to ipset when speed check fails."));
+		o.rmempty = true;
+		o.datatype = "string";
+		o.rempty = true;
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var ipset = value.split(",")
+			for (var i = 0; i < ipset.length; i++) {
+				if (!ipset[i].match(/^(#[4|6]:)?[a-zA-Z0-9\-_]+$/)) {
+					return _("ipset name format error, format: [#[4|6]:]ipsetname");
+				}
+			}
+
+			return true;
+		}
+
+		// NFTset no speed.
+		o = s.taboption("advanced", form.Value, "nftset_no_speed", _("No Speed NFTset Name"), 
+			_("Nftset name, Add domain result to nftset when speed check fails, format: [#[4|6]:[family#table#set]]"));
+		o.rmempty = true;
+		o.datatype = "string";
+		o.rempty = true;
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var nftset = value.split(",")
+			for (var i = 0; i < nftset.length; i++) {
+				if (!nftset[i].match(/^#[4|6]:[a-zA-Z0-9\-_]+#[a-zA-Z0-9\-_]+#[a-zA-Z0-9\-_]+$/)) {
+					return _("NFTset name format error, format: [#[4|6]:[family#table#set]]");
+				}
+			}
+
+			return true;
+		}
 
 		// rr-ttl;
-		o = s.taboption("settings", form.Value, "rr_ttl", _("Domain TTL"), _("TTL for all domain result."));
+		o = s.taboption("advanced", form.Value, "rr_ttl", _("Domain TTL"), _("TTL for all domain result."));
 		o.rempty = true;
 
 		// rr-ttl-min;
-		o = s.taboption("settings", form.Value, "rr_ttl_min", _("Domain TTL Min"),
+		o = s.taboption("advanced", form.Value, "rr_ttl_min", _("Domain TTL Min"),
 			_("Minimum TTL for all domain result."));
 		o.rempty = true;
 		o.placeholder = "600";
@@ -211,21 +333,45 @@ return view.extend({
 		o.optional = true;
 
 		// rr-ttl-max;
-		o = s.taboption("settings", form.Value, "rr_ttl_max", _("Domain TTL Max"),
+		o = s.taboption("advanced", form.Value, "rr_ttl_max", _("Domain TTL Max"),
 			_("Maximum TTL for all domain result."));
 		o.rempty = true;
 
 		// rr-ttl-reply-max;
-		o = s.taboption("settings", form.Value, "rr_ttl_reply_max", _("Reply Domain TTL Max"),
+		o = s.taboption("advanced", form.Value, "rr_ttl_reply_max", _("Reply Domain TTL Max"),
 			_("Reply maximum TTL for all domain result."));
 		o.rempty = true;
 
+		// other args
+		o = s.taboption("advanced", form.Value, "server_flags", _("Additional Server Args"), 
+			_("Additional server args, refer to the help description of the bind option."))
+		o.default = ""
+		o.rempty = true
+
+		// include config
+		download_files = uci.sections('smartdns', 'download-file');
+		o = s.taboption("advanced", form.DynamicList, "conf_files", _("Include Config Files<br>/etc/smartdns/conf.d"),
+			_("Include other config files from /etc/smartdns/conf.d or custom path, can be downloaded from the download page."));
+		for (var i = 0; i < download_files.length; i++) {
+			if (download_files[i].type == undefined) {
+				continue;
+			}
+
+			if (download_files[i].type != 'config') {
+				continue
+			}
+
+			o.value(download_files[i].name);
+		}
+
+		///////////////////////////////////////
 		// second dns server;
-		// Eanble;
+		///////////////////////////////////////
+		// Enable;
 		o = s.taboption("seconddns", form.Flag, "seconddns_enabled", _("Enable"),
 			_("Enable or disable second DNS server."));
 		o.default = o.disabled;
-		o.rempty = false;
+		o.rempty = true;
 
 		// Port;
 		o = s.taboption("seconddns", form.Value, "seconddns_port", _("Local Port"), _("Smartdns local server port"));
@@ -249,52 +395,194 @@ return view.extend({
 
 		o = s.taboption("seconddns", form.Flag, "seconddns_no_speed_check", _("Skip Speed Check"),
 			_("Do not check speed."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
 
 		// skip address rules;
 		o = s.taboption("seconddns", form.Flag, "seconddns_no_rule_addr", _("Skip Address Rules"),
 			_("Skip address rules."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
 
 		// skip name server rules;
 		o = s.taboption("seconddns", form.Flag, "seconddns_no_rule_nameserver", _("Skip Nameserver Rule"),
 			_("Skip nameserver rules."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
 
 		// skip ipset rules;
 		o = s.taboption("seconddns", form.Flag, "seconddns_no_rule_ipset", _("Skip Ipset Rule"),
 			_("Skip ipset rules."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
 
 		// skip soa address rule;
 		o = s.taboption("seconddns", form.Flag, "seconddns_no_rule_soa", _("Skip SOA Address Rule"),
 			_("Skip SOA address rules."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
 
 		o = s.taboption("seconddns", form.Flag, "seconddns_no_dualstack_selection", _("Skip Dualstack Selection"),
 			_("Skip Dualstack Selection."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
 
 		// skip cache;
 		o = s.taboption("seconddns", form.Flag, "seconddns_no_cache", _("Skip Cache"), _("Skip Cache."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
 
 		// Force AAAA SOA
 		o = s.taboption("seconddns", form.Flag, "seconddns_force_aaaa_soa", _("Force AAAA SOA"), _("Force AAAA SOA."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
 
+		o = s.taboption("seconddns", form.Value, "seconddns_ipset_name", _("IPset Name"), _("IPset name."));
+		o.rmempty = true;
+		o.datatype = "string";
+		o.rempty = true;
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var ipset = value.split(",")
+			for (var i = 0; i < ipset.length; i++) {
+				if (!ipset[i].match(/^(#[4|6]:)?[a-zA-Z0-9\-_]+$/)) {
+					return _("ipset name format error, format: [#[4|6]:]ipsetname");
+				}
+			}
+
+			return true;
+		}
+
+		o = s.taboption("seconddns", form.Value, "seconddns_nftset_name", _("NFTset Name"), _("NFTset name, format: [#[4|6]:[family#table#set]]"));
+		o.rmempty = true;
+		o.datatype = "string";
+		o.rempty = true;
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var nftset = value.split(",")
+			for (var i = 0; i < nftset.length; i++) {
+				if (!nftset[i].match(/^#[4|6]:[a-zA-Z0-9\-_]+#[a-zA-Z0-9\-_]+#[a-zA-Z0-9\-_]+$/)) {
+					return _("NFTset name format error, format: [#[4|6]:[family#table#set]]");
+				}
+			}
+
+			return true;
+		}
+
+		// other args
+		o = s.taboption("seconddns", form.Value, "seconddns_server_flags", _("Additional Server Args"), 
+			_("Additional server args, refer to the help description of the bind option."))
+		o.default = ""
+		o.rempty = true
+
+		///////////////////////////////////////
+		// DNS64 Settings
+		///////////////////////////////////////
+		o = s.taboption("dns64", form.Value, "dns64", _("DNS64"));
+		o.placeholder = "64:ff9b::/96";
+		o.datatype = "ip6addr";
+		o.rempty = true;
+
+		///////////////////////////////////////
+		// download Files Settings
+		///////////////////////////////////////
+		o = s.taboption("files", form.Flag, "enable_auto_update", _("Enable Auto Update"), _("Enable daily auto update."));
+		o.rmempty = true;
+		o.default = o.disabled;
+		o.rempty = true;
+
+		o = s.taboption("files", form.FileUpload, "upload_conf_file", _("Upload Config File"),
+			_("Upload smartdns config file to /etc/smartdns/conf.d"));
+		o.rmempty = true
+		o.datatype = "file"
+		o.rempty = true
+		o.root_directory = "/etc/smartdns/conf.d"
+
+		o = s.taboption("files", form.FileUpload, "upload_list_file", _("Upload Domain List File"),
+			_("Upload domain list file to /etc/smartdns/domain-set"));
+		o.rmempty = true
+		o.datatype = "file"
+		o.rempty = true
+		o.root_directory = "/etc/smartdns/domain-set"
+
+		o = s.taboption('files', form.DummyValue, "_update", _("Update Files"));
+		o.renderWidget = function () {
+			return E('button', {
+				'class': 'btn cbi-button cbi-button-apply',
+				'id': 'btn_update',
+				'click': ui.createHandlerFn(this, function () {
+					return fs.exec('/etc/init.d/smartdns', ['updatefiles'])
+						.catch(function (e) { ui.addNotification(null, E('p', e.message), 'error') });
+				})
+			}, [_("Update")]);
+		}
+
+		o = s.taboption('files', form.SectionValue, '__files__', form.GridSection, 'download-file', _('Download Files'),
+			_('List of files to download.'));
+
+		ss = o.subsection;
+
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable = true;
+
+		so = ss.option(form.Value, 'name', _('File Name'), _('File Name'));
+		so.rmempty = true;
+		so.datatype = 'file';
+
+		so = ss.option(form.Value, 'url', _('URL'), _('URL'));
+		so.rmempty = true;
+		so.datatype = 'string';
+		so.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			if (!value.match(/^(http|https|ftp|sftp):\/\//)) {
+				return _("URL format error, format: http:// or https://");
+			}
+
+			return true;
+		}
+
+		so = ss.option(form.ListValue, "type", _("type"), _("File Type"));
+		so.value("list", _("domain list (/etc/smartdns/domain-set)"));
+		so.value("config", _("smartdns config (/etc/smartdns/conf.d)"));
+		so.default = "list";
+		so.rempty = false;
+
+		so = ss.option(form.Value, 'desc', _('Description'), _('Description'));
+		so.rmempty = true;
+		so.datatype = 'string';
+
+		///////////////////////////////////////
+		// Proxy server settings;
+		///////////////////////////////////////
+		o = s.taboption("proxy", form.Value, "proxy_server", _("Proxy Server"), _("Proxy Server URL, format: [socks5|http]://user:pass@ip:port."));
+		o.datatype = 'string';
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			if (!value.match(/^(socks5|http):\/\//)) {
+				return _("Proxy server URL format error, format: [socks5|http]://user:pass@ip:port.");
+			}
+
+			return true;
+		}
+
+		///////////////////////////////////////
 		// custom settings;
+		///////////////////////////////////////
 		o = s.taboption("custom", form.TextValue, "custom_conf",
 			"", _("smartdns custom settings"));
-
 		o.rows = 20;
 		o.cfgvalue = function (section_id) {
 			return fs.trimmed('/etc/smartdns/custom.conf');
@@ -310,14 +598,42 @@ return view.extend({
 
 		o = s.taboption("custom", form.Flag, "coredump", _("Generate Coredump"),
 			_("Generate Coredump file when smartdns crash, coredump file is located at /tmp/smartdns.xxx.core."));
-		o.rmempty = false;
+		o.rmempty = true;
 		o.default = o.disabled;
+
+		o = s.taboption("custom", form.Value, "log_size", _("Log Size"));
+		o.rmempty = true;
+		o.placeholder = "default";
+
+		o = s.taboption("custom", form.ListValue, "log_level", _("Log Level"));
+		o.rmempty = true;
+		o.placeholder = "default";
+		o.value("", _("default"));
+		o.value("debug");
+		o.value("info");
+		o.value("notice");
+		o.value("warn");
+		o.value("error");
+		o.value("fatal");
+		o.value("off");
+
+		o = s.taboption("custom", form.Value, "log_num", _("Log Number"));
+		o.rmempty = true;
+		o.placeholder = "default";
+
+		o = s.taboption("custom", form.Value, "log_file", _("Log File"))
+		o.rmempty = true
+		o.placeholder = "/var/log/smartdns/smartdns.log"
+
+		////////////////
 		// Upstream servers;
+		////////////////
 		s = m.section(form.GridSection, "server", _("Upstream Servers"),
 			_("Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS servers, "
 				+ "including multiple foreign DNS servers."));
 		s.anonymous = true;
 		s.addremove = true;
+		s.sortable = true;
 
 		s.tab('general', _('General Settings'));
 		s.tab('advanced', _('Advanced Settings'));
@@ -355,20 +671,36 @@ return view.extend({
 		o.default = "udp";
 		o.rempty = false;
 
-		// Advanced Options
 		// server group
-		o = s.taboption("advanced", form.Value, "server_group", _("Server Group"), _("DNS Server group belongs to, "
-			+ "used with nameserver, such as office, home."))
-		o.rmempty = true
-		o.placeholder = "default"
-		o.datatype = "hostname"
-		o.rempty = true
+		o = s.taboption("general", form.Value, "server_group", _("Server Group"), _("DNS Server group"))
+		o.rmempty = true;
+		o.placeholder = "default";
+		o.datatype = "hostname";
+		o.rempty = true;
+		servers = uci.sections('smartdns', 'server');
+		var groupnames = new Set();
+		for (var i = 0; i < servers.length; i++) {
+			if (servers[i].server_group == undefined) {
+				continue;
+			}
+			groupnames.add(servers[i].server_group);
+		}
+
+		for (const groupname of groupnames) {
+			o.value(groupname);
+		}
+
+		// Advanced Options
+		o = s.taboption("advanced", form.Flag, "exclude_default_group", _("Exclude Default Group"), _("Exclude DNS Server from default group."))
+		o.rmempty = true;
+		o.default = o.disabled;
+		o.editable = true;
 		o.modalonly = true;
 
 		// blacklist_ip
 		o = s.taboption("advanced", form.Flag, "blacklist_ip", _("IP Blacklist Filtering"),
 			_("Filtering IP with blacklist"))
-		o.rmempty = false
+		o.rmempty = true
 		o.default = o.disabled
 		o.modalonly = true;
 
@@ -385,7 +717,7 @@ return view.extend({
 		// certificate verify
 		o = s.taboption("advanced", form.Flag, "no_check_certificate", _("No check certificate"),
 			_("Do not check certificate."))
-		o.rmempty = false
+		o.rmempty = true
 		o.default = o.disabled
 		o.modalonly = true;
 		o.depends("type", "tls")
@@ -393,7 +725,7 @@ return view.extend({
 
 		// SNI host name
 		o = s.taboption("advanced", form.Value, "host_name", _("TLS SNI name"),
-			_("Sets the server name indication for query."))
+			_("Sets the server name indication for query. '-' for disable SNI name."))
 		o.default = ""
 		o.datatype = "hostname"
 		o.rempty = true
@@ -421,6 +753,40 @@ return view.extend({
 		o.depends("type", "tls")
 		o.depends("type", "https")
 
+		// mark
+		o = s.taboption("advanced", form.Value, "set_mark", _("Marking Packets"),
+			_("Set mark on packets."))
+		o.default = ""
+		o.rempty = true
+		o.datatype = "uinteger"
+		o.modalonly = true;
+
+		// use proxy
+		o = s.taboption("advanced", form.Flag, "use_proxy", _("Use Proxy"),
+			_("Use proxy to connect to upstream DNS server."))
+		o.default = o.disabled
+		o.modalonly = true;
+		o.optional = true;
+		o.rempty = true;
+		o.validate = function (section_id, value) {
+			var flag = this.formvalue(section_id);
+			if (flag == "0") {
+				return true;
+			}
+
+			var proxy_server = uci.sections("smartdns", "smartdns")[0].proxy_server;
+			var server_type = this.section.formvalue(section_id, "type");
+			if (proxy_server == "" || proxy_server == undefined) {
+				return _("Please set proxy server first.");
+			}
+
+			if (server_type == "udp" && !proxy_server.match(/^(socks5):\/\//)) {
+				return _("Only socks5 proxy support udp server.");
+			}
+
+			return true;
+		}
+
 		// other args
 		o = s.taboption("advanced", form.Value, "addition_arg", _("Additional Server Args"),
 			_("Additional Args for upstream dns servers"))
@@ -428,13 +794,326 @@ return view.extend({
 		o.rempty = true
 		o.modalonly = true;
 
-		// Doman addresss;
-		s = m.section(form.TypedSection, "smartdns", _("Advanced Settings"), _("Advanced Settings"));
+		////////////////
+		// domain rules;
+		////////////////
+		s = m.section(form.TypedSection, "domain-rule", _("Domain Rules"), _("Domain Rules Settings"));
 		s.anonymous = true;
+		s.nodescriptions = true;
 
+		s.tab("forwarding", _('DNS Forwarding Setting'));
+		s.tab("block", _("DNS Block Setting"));
+		s.tab("domain-rule-list", _("Domain Rule List"), _("Set Specific domain rule list."));
 		s.tab("domain-address", _("Domain Address"), _("Set Specific domain ip address."));
 		s.tab("blackip-list", _("IP Blacklist"), _("Set Specific ip blacklist."));
 
+		///////////////////////////////////////
+		// domain forwarding;
+		///////////////////////////////////////
+		o = s.taboption("forwarding", form.Value, "server_group", _("Server Group"), _("DNS Server group belongs to, such as office, home."))
+		o.rmempty = true
+		o.placeholder = "default"
+		o.datatype = "hostname"
+		o.rempty = true
+		for (const groupname of groupnames) {
+			o.value(groupname);
+		}
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var val = uci.sections('smartdns', 'server');
+			for (var i = 0; i < val.length; i++) {
+				if (value == val[i].server_group) {
+					return true;
+				}
+			}
+
+			return _('Server Group %s not exists').format(value);
+
+		}
+
+		o = s.taboption("forwarding", form.Flag, "no_speed_check", _("Skip Speed Check"),
+			_("Do not check speed."));
+		o.rmempty = true;
+		o.default = o.disabled;
+
+		o = s.taboption("forwarding", form.Flag, "force_aaaa_soa", _("Force AAAA SOA"), _("Force AAAA SOA."));
+		o.rmempty = true;
+		o.default = o.disabled;
+
+		o = s.taboption("forwarding", form.Value, "ipset_name", _("IPset Name"), _("IPset name."));
+		o.rmempty = true;
+		o.datatype = "string";
+		o.rempty = true;
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var ipset = value.split(",")
+			for (var i = 0; i < ipset.length; i++) {
+				if (!ipset[i].match(/^(#[4|6]:)?[a-zA-Z0-9\-_]+$/)) {
+					return _("ipset name format error, format: [#[4|6]:]ipsetname");
+				}
+			}
+
+			return true;
+		}
+
+		o = s.taboption("forwarding", form.Value, "nftset_name", _("NFTset Name"), _("NFTset name, format: [#[4|6]:[family#table#set]]"));
+		o.rmempty = true;
+		o.datatype = "string";
+		o.rempty = true;
+		o.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var nftset = value.split(",")
+			for (var i = 0; i < nftset.length; i++) {
+				if (!nftset[i].match(/^#[4|6]:[a-zA-Z0-9\-_]+#[a-zA-Z0-9\-_]+#[a-zA-Z0-9\-_]+$/)) {
+					return _("NFTset name format error, format: [#[4|6]:[family#table#set]]");
+				}
+			}
+
+			return true;
+		}
+
+		// other args
+		o = s.taboption("forwarding", form.Value, "addition_flag", _("Additional Rule Flag"),
+			_("Additional Flags for rules, read help on domain-rule for more information."))
+		o.default = ""
+		o.rempty = true
+		o.modalonly = true;
+
+		o = s.taboption("forwarding", form.FileUpload, "forwarding_domain_set_file", _("Domain List File"),
+			_("Upload domain list file, or configure auto download from Download File Setting page."));
+		o.rmempty = true
+		o.datatype = "file"
+		o.rempty = true
+		o.editable = true
+		o.root_directory = "/etc/smartdns/domain-set"
+
+		o = s.taboption("forwarding", form.TextValue, "domain_forwarding_list",
+			_("Domain List"), _("Configure forwarding domain name list."));
+		o.rows = 10;
+		o.cols = 64;
+		o.monospace = true;
+		o.cfgvalue = function (section_id) {
+			return fs.trimmed('/etc/smartdns/domain-forwarding.list').catch(function (e) {
+				return "";
+			});
+		};
+		o.write = function (section_id, formvalue) {
+			return this.cfgvalue(section_id).then(function (value) {
+				if (value == formvalue) {
+					return
+				}
+				return fs.write('/etc/smartdns/domain-forwarding.list', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			});
+		};
+
+		///////////////////////////////////////
+		// domain block;
+		///////////////////////////////////////
+		o = s.taboption("block", form.FileUpload, "block_domain_set_file", _("Domain List File"), _("Upload domain list file."));
+		o.rmempty = true
+		o.datatype = "file"
+		o.rempty = true
+		o.editable = true
+		o.root_directory = "/etc/smartdns/domain-set"
+
+		o = s.taboption("block", form.TextValue, "domain_block_list",
+			_("Domain List"), _("Configure block domain list."));
+		o.rows = 10;
+		o.cols = 64;
+		o.cfgvalue = function (section_id) {
+			return fs.trimmed('/etc/smartdns/domain-block.list').catch(function (e) {
+				return "";
+			});
+		};
+		o.write = function (section_id, formvalue) {
+			return this.cfgvalue(section_id).then(function (value) {
+				if (value == formvalue) {
+					return
+				}
+				return fs.write('/etc/smartdns/domain-block.list', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			});
+		};
+
+		///////////////////////////////////////
+		// domain rule list;
+		///////////////////////////////////////
+		o = s.taboption('domain-rule-list', form.SectionValue, '__domain-rule-list__', form.GridSection, 'domain-rule-list', _('Domain Rule List'),
+			_('Configure domain rule list.'));
+
+		ss = o.subsection;
+
+		ss.addremove = true;
+		ss.anonymous = true;
+		ss.sortable = true;
+
+		// enable flag;
+		so = ss.option(form.Flag, "enabled", _("Enable"), _("Enable"));
+		so.rmempty = false;
+		so.default = so.enabled;
+		so.editable = true;
+
+		// name;
+		so = ss.option(form.Value, "name", _("Domain Rule Name"), _("Domain Rule Name"));
+
+		so = ss.option(form.Value, "server_group", _("Server Group"), _("DNS Server group belongs to, such as office, home."))
+		so.rmempty = true
+		so.placeholder = "default"
+		so.datatype = "hostname"
+		so.rempty = true
+		for (const groupname of groupnames) {
+			so.value(groupname);
+		}
+		so.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var val = uci.sections('smartdns', 'server');
+			for (var i = 0; i < val.length; i++) {
+				if (value == val[i].server_group) {
+					return true;
+				}
+			}
+
+			return _('Server Group %s not exists').format(value);
+
+		}
+
+		so = ss.option(form.FileUpload, "domain_list_file", _("Domain List File"),
+			_("Upload domain list file, or configure auto download from Download File Setting page."));
+		so.rmempty = true
+		so.datatype = "file"
+		so.rempty = true
+		so.root_directory = "/etc/smartdns/domain-set"
+
+		so = ss.option(form.ListValue, "block_domain_type", _("Block domain"), _("Block domain."));
+		so.rmempty = true;
+		so.value("none", _("None"));
+		so.value("all", "IPv4/IPv6");
+		so.value("ipv4", "IPv4");
+		so.value("ipv6", "IPv6");
+		so.modalonly = true;
+
+		// Support DualStack ip selection;
+		so = ss.option(form.ListValue, "dualstack_ip_selection", _("Dual-stack IP Selection"),
+			_("Enable IP selection between IPV4 and IPV6"));
+		so.rmempty = true;
+		so.default = "default";
+		so.modalonly = true;
+		so.value("", _("default"));
+		so.value("yes", _("Yes"));
+		so.value("no", _("No"));
+
+		so = ss.option(form.Value, "speed_check_mode", _("Speed Check Mode"), _("Smartdns speed check mode."));
+		so.rmempty = true;
+		so.placeholder = "default";
+		so.modalonly = true;
+		so.value("", _("default"));
+		so.value("ping,tcp:80,tcp:443");
+		so.value("ping,tcp:443,tcp:80");
+		so.value("tcp:80,tcp:443,ping");
+		so.value("tcp:443,tcp:80,ping");
+		so.value("none", _("None"));
+		so.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			if (value == "none") {
+				return true;
+			}
+
+			var check_mode = value.split(",")
+			for (var i = 0; i < check_mode.length; i++) {
+				if (check_mode[i] == "ping") {
+					continue;
+				}
+
+				if (check_mode[i].indexOf("tcp:") == 0) {
+					var port = check_mode[i].split(":")[1];
+					if (port == "") {
+						return _("TCP port is empty");
+					}
+
+					continue;
+				}
+
+				return _("Speed check mode is invalid.");
+			}
+
+			return true;
+		}
+
+		so = ss.option(form.Flag, "force_aaaa_soa", _("Force AAAA SOA"), _("Force AAAA SOA."));
+		so.rmempty = true;
+		so.default = so.disabled;
+		so.modalonly = true;
+
+
+		so = ss.option(form.Value, "ipset_name", _("IPset Name"), _("IPset name."));
+		so.rmempty = true;
+		so.datatype = "hostname";
+		so.rempty = true;
+		so.modalonly = true;
+
+		so = ss.option(form.Value, "nftset_name", _("NFTset Name"), _("NFTset name, format: [#[4|6]:[family#table#set]]"));
+		so.rmempty = true;
+		so.datatype = "string";
+		so.rempty = true;
+		so.modalonly = true;
+		so.validate = function (section_id, value) {
+			if (value == "") {
+				return true;
+			}
+
+			var nftset = value.split(",")
+			for (var i = 0; i < nftset.length; i++) {
+				if (!nftset[i].match(/#[4|6]:[a-zA-Z0-9\-_]+#[a-zA-Z0-9\-_]+#[a-zA-Z0-9\-_]+$/)) {
+					return _("NFTset name format error, format: [#[4|6]:[family#table#set]]");
+				}
+			}
+
+			return true;
+		}
+
+		// other args
+		so = ss.option(form.Value, "addition_flag", _("Additional Rule Flag"),
+			_("Additional Flags for rules, read help on domain-rule for more information."))
+		so.default = ""
+		so.rempty = true
+		so.modalonly = true;
+
+		///////////////////////////////////////
+		// IP Blacklist;
+		///////////////////////////////////////
+		// blacklist;
+		o = s.taboption("blackip-list", form.TextValue, "blackip_ip_conf",
+			"", _("Configure IP blacklists that will be filtered from the results of specific DNS server."));
+		o.rows = 20;
+		o.cfgvalue = function (section_id) {
+			return fs.trimmed('/etc/smartdns/blacklist-ip.conf');
+		};
+		o.write = function (section_id, formvalue) {
+			return this.cfgvalue(section_id).then(function (value) {
+				if (value == formvalue) {
+					return
+				}
+				return fs.write('/etc/smartdns/blacklist-ip.conf', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
+			});
+		};
+
+		///////////////////////////////////////
+		// domain address
+		///////////////////////////////////////
 		o = s.taboption("domain-address", form.TextValue, "address_conf",
 			"",
 			_("Specify an IP address to return for any host in the given domains, Queries in the domains are never "
@@ -452,24 +1131,9 @@ return view.extend({
 			});
 		};
 
-		// IP Blacklist;
-		// blacklist;
-		o = s.taboption("blackip-list", form.TextValue, "blackip_ip_conf",
-			"", _("Configure IP blacklists that will be filtered from the results of specific DNS server."));
-		o.rows = 20;
-		o.cfgvalue = function (section_id) {
-			return fs.trimmed('/etc/smartdns/blacklist-ip.conf');
-		};
-		o.write = function (section_id, formvalue) {
-			return this.cfgvalue(section_id).then(function (value) {
-				if (value == formvalue) {
-					return
-				}
-				return fs.write('/etc/smartdns/blacklist-ip.conf', formvalue.trim().replace(/\r\n/g, '\n') + '\n');
-			});
-		};
-
-		// Doman addresss;
+		////////////////
+		// Support
+		////////////////
 		s = m.section(form.TypedSection, "smartdns", _("Technical Support"),
 			_("If you like this software, please buy me a cup of coffee."));
 		s.anonymous = true;
@@ -480,6 +1144,14 @@ return view.extend({
 		o.inputstyle = "apply";
 		o.onclick = function () {
 			window.open("https://pymumu.github.io/smartdns", '_blank');
+		};
+
+		o = s.option(form.Button, "report");
+		o.title = _("Report bugs");
+		o.inputtitle = _("Report bugs");
+		o.inputstyle = "apply";
+		o.onclick = function () {
+			window.open("https://github.com/pymumu/smartdns/issues", '_blank');
 		};
 
 		o = s.option(form.Button, "Donate");

--- a/applications/luci-app-smartdns/po/de/smartdns.po
+++ b/applications/luci-app-smartdns/po/de/smartdns.po
@@ -10,20 +10,39 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.16-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:792
 msgid "Additional Args for upstream dns servers"
 msgstr "Zusätzliche Argumente für Upstream-DNS-Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:886
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1090
+msgid ""
+"Additional Flags for rules, read help on domain-rule for more information."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:885
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1089
+msgid "Additional Rule Flag"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:346
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:791
 msgid "Additional Server Args"
 msgstr "Zusätzliche Server Parameter"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:347
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:480
+msgid ""
+"Additional server args, refer to the help description of the bind option."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:132
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:639
 msgid "Advanced Settings"
 msgstr "Erweiterte Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:253
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
@@ -31,23 +50,43 @@ msgstr ""
 "Versuche, eine alte Antwort vom Cache mit TTL 0 zurückzugeben, ohne auf die "
 "eigentliche Auflösung zu warten."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically Set Dnsmasq"
 msgstr "Dnsmasq automatisch setzen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically set as upstream of dnsmasq when port changes."
 msgstr "Setze automatisch als Upstream von dnsmasq when sich der Port ändert."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Bind Device"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Bind Device Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Cache Persist"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "Cache Size"
 msgstr "Zwischenspeichergröße"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:121
 msgid "Collecting data ..."
 msgstr "Sammle Daten..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1100
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
@@ -55,145 +94,267 @@ msgstr ""
 "Definition einer IP basierten Blockierliste, welche Ergebnisse eines "
 "spezifischen DNS Servers filtert."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Configure block domain list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:950
+msgid "Configure domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+msgid "Configure forwarding domain name list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:137
 msgid "Custom Settings"
 msgstr "Benutzerdefinierte Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:805
+msgid "DNS Block Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:804
+msgid "DNS Forwarding Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:648
 msgid "DNS Server Name"
 msgstr "DNS Server Name"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
-msgid ""
-"DNS Server group belongs to, used with nameserver, such as office, home."
-msgstr "DNS-Server-Gruppe, zu jener der Nameserver gehört, z. B. Büro, Zuhause."
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+msgid "DNS Server group"
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
+msgid "DNS Server group belongs to, such as office, home."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "DNS Server ip"
 msgstr "DNS-Server IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "DNS Server port"
 msgstr "DNS-Server-Port"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "DNS Server type"
 msgstr "DNS-Server Typ"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "DNS domain result cache size"
 msgstr "DNS Domain Ergebnisspeichergröße"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
-msgid "Dnsmasq Forwared To Smartdns Failure"
-msgstr "Fehler der Dnsmasq-Weiterleitung an Smartdns"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+msgid "DNS64"
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:134
+msgid "DNS64 Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:560
+msgid "Description"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
+msgid "Dnsmasq Forwarded To Smartdns Failure"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:719
 msgid "Do not check certificate."
 msgstr "Zertifikat nicht prüfen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:397
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:838
 msgid "Do not check speed."
 msgstr "Geschwindigkeit nicht testen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Domain Address"
 msgstr "Domain Adresse"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Domain List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:891
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:991
+msgid "Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:949
+msgid "Domain Rule List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:965
+msgid "Domain Rule Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "Domain TTL"
 msgstr "Domäne TTL"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:336
 msgid "Domain TTL Max"
 msgstr "Domäne TTL Max"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:328
 msgid "Domain TTL Min"
 msgstr "Domäne TTL Min"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:246
 msgid "Domain prefetch"
 msgstr "Vorabruf der Domäne"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1159
 msgid "Donate"
 msgstr "Spenden"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1158
 msgid "Donate to smartdns"
 msgstr "An smartdns spenden"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:526
+msgid "Download Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid "Download Files Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid ""
+"Download domain list files for domain-rule and include config files, please "
+"refresh the page after download to take effect."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:240
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1007
 msgid "Dual-stack IP Selection"
 msgstr "Dual-Stack-IP-Auswahl"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:371
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:642
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:959
 msgid "Enable"
 msgstr "aktivieren"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable Auto Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:241
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1008
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "Aktiviere Wahl zwischen IPv4 und IPv6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "Enable IPV6 DNS Server"
 msgstr "Aktivere IPv6 DNS-Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "Enable TCP DNS Server"
 msgstr "Aktiviere TCP DNS Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable daily auto update."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:247
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr ""
 "Aktivieren Sie Domänen-Prefetch, um die Reaktionsgeschwindigkeit der Domäne "
 "zu beschleunigen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:372
 msgid "Enable or disable second DNS server."
 msgstr "Aktivieren oder deaktivieren des zweiten DNS-Servers."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
 msgid "Enable or disable smartdns server"
 msgstr "Aktivieren oder deaktivieren des Smartdns-Servers"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude DNS Server from default group."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude Default Group"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+msgid "Fastest IP"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+msgid "Fastest Response"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:535
+msgid "File Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+msgid "File Type"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:702
 msgid "Filtering IP with blacklist"
 msgstr "Filtern von IP mit negativ-Liste"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+msgid "First Ping"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA"
 msgstr "Erzwinge AAAA SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA."
 msgstr "Erzwinge AAAA SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA"
 msgstr "Erzwinge HTTPS SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA."
 msgstr "Erzwinge HTTPS SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:638
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:599
 msgid "Generate Coredump"
 msgstr "Generiere Coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:600
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -205,50 +366,176 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "Zugriff auf die LuCI-App smartdns gewähren"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:737
 msgid "HTTP Host"
 msgstr "HTTP-Host"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "IP Blacklist"
 msgstr "IP Negativ-Liste"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:701
 msgid "IP Blacklist Filtering"
 msgstr "Filterung von IP-Blacklists"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "IPV6 Server"
 msgstr "IPV6-Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset name."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1138
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr ""
 "Wenn Ihnen diese Software gefällt, spendieren Sie mir bitte eine Tasse "
 "Kaffee."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+msgid "Include Config Files<br>/etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+msgid ""
+"Include other config files from /etc/smartdns/conf.d or custom path, can be "
+"downloaded from the download page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:283
+msgid "Ipset name, Add domain result to ipset when speed check fails."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:527
+msgid "List of files to download."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Listen only on the specified interfaces."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Local Port"
 msgstr "Lokaler Port"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:624
+msgid "Log File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:608
+msgid "Log Level"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:620
+msgid "Log Number"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:604
+msgid "Log Size"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:757
+msgid "Marking Packets"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:337
 msgid "Maximum TTL for all domain result."
 msgstr "Maximale TTL für alle Ergebnisse der Domäne."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:329
 msgid "Minimum TTL for all domain result."
 msgstr "Minimale TTL für alle Ergebnisse der Domäne."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:471
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:877
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1081
+msgid "NFTset name format error, format: [#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset name, format: [#[4|6]:[family#table#set]]"
+msgstr ""
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr "LÄUFT NICHT"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Name of device name listen on."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:304
+msgid ""
+"Nftset name, Add domain result to nftset when speed check fails, format: "
+"[#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1014
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+msgid "No Speed IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+msgid "No Speed NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:718
 msgid "No check certificate"
 msgstr "Kein Check der Zertifikate"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:177
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1000
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1025
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:784
+msgid "Only socks5 proxy support udp server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:780
+msgid "Please set proxy server first."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+msgid "Proxy Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server URL, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:575
+msgid ""
+"Proxy server URL format error, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:390
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr ""
 "Abfrage von DNS über eine bestimmte DNS-Servergruppe, z. B. Büro, Zuhause."
@@ -257,60 +544,84 @@ msgstr ""
 msgid "RUNNING"
 msgstr "LÄUFT"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:341
 msgid "Reply Domain TTL Max"
 msgstr "Max TTL der Antwortdomäne"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:342
 msgid "Reply maximum TTL for all domain result."
 msgstr "Maximale Antwort-TTL für alle Domänen-Ergebnisse."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1151
+msgid "Report bugs"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve Local Hostnames"
 msgstr "Lokale Hostnamen auflösen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve local hostnames by reading Dnsmasq lease file."
 msgstr "Lokale Hostnamen durch Lesen der Dnsmasq-Lease-Datei auflösen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
+msgid "Response Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1174
 msgid "Restart"
 msgstr "Neustart"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1165
 msgid "Restart Service"
 msgstr "Dienst neu starten"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:133
 msgid "Second Server Settings"
 msgstr "Einstellungen für den zweiten Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:252
 msgid "Serve expired"
 msgstr "Serve abgelaufen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:389
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
 msgid "Server Group"
 msgstr "Servergruppe"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:833
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:987
+msgid "Server Group %s not exists"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Server Name"
 msgstr "Servername"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Set Specific domain ip address."
 msgstr "Spezifische Domänen-IP-Adresse einstellen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+msgid "Set Specific domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "Set Specific ip blacklist."
 msgstr "Spezifische IP-Blacklist einstellen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:709
 msgid "Set TLS hostname to verify."
 msgstr "TLS-Hostname zur Überprüfung einstellen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:758
+msgid "Set mark on packets."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:738
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
@@ -318,76 +629,77 @@ msgstr ""
 "Legt den für die Abfrage verwendeten HTTP-Host fest. Verwenden Sie diesen "
 "Parameter, wenn der Host der URL-Adresse eine IP-Adresse ist."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
-msgid "Sets the server name indication for query."
-msgstr "Legt die Anzeige des Servernamens für die Abfrage fest."
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:728
+msgid "Sets the server name indication for query. '-' for disable SNI name."
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:402
 msgid "Skip Address Rules"
 msgstr "Adressregeln überspringen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache"
 msgstr "Cache überspringen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache."
 msgstr "Cache überspringen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Skip Dualstack Selection"
 msgstr "Dualstack-Auswahl überspringen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Skip Dualstack Selection."
 msgstr "Dualstack-Auswahl überspringen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "Skip Ipset Rule"
 msgstr "Ipset-Regel überspringen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:408
 msgid "Skip Nameserver Rule"
 msgstr "Nameserver-Regel überspringen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:420
 msgid "Skip SOA Address Rule"
 msgstr "SOA-Adressregel überspringen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:421
 msgid "Skip SOA address rules."
 msgstr "SOA-Adressregeln überspringen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:837
 msgid "Skip Speed Check"
 msgstr "Geschwindigkeitsprüfung überspringen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:403
 msgid "Skip address rules."
 msgstr "Adressregeln überspringen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid "Skip ipset rules."
 msgstr "ipset-Regeln überspringen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:409
 msgid "Skip nameserver rules."
 msgstr "Nameserver-Regeln überspringen."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr "SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
 msgid "SmartDNS Server"
 msgstr "SmartDNS-Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:97
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
@@ -396,15 +708,15 @@ msgstr ""
 "schnellsten IP unterstützt, die Filterung von Werbung und die Vermeidung von "
 "DNS-Poisoning ermöglicht."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1142
 msgid "SmartDNS official website"
 msgstr "Offizielle Website von SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Smartdns local server port"
 msgstr "Lokaler Smartdns-Serverport"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:154
 msgid ""
 "Smartdns local server port, smartdns will be automatically set as main dns "
 "when the port is 53."
@@ -412,11 +724,22 @@ msgstr ""
 "Lokaler Smartdns-Serverport, smartdns wird automatisch als Haupt-DNS "
 "eingestellt, wenn 53 der Port ist."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
+msgid ""
+"Smartdns response mode, First Ping: return the first ping IP, Fastest IP: "
+"return the fastest IP, Fastest Response: return the fastest DNS response."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Smartdns server name"
 msgstr "Smartdns-Servername"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Smartdns speed check mode."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1119
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
@@ -427,36 +750,94 @@ msgstr ""
 "werden nie weitergeleitet und immer mit der angegebenen IP-Adresse "
 "beantwortet, die IPv4 oder IPv6 sein kann."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Speed Check Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1050
+msgid "Speed check mode is invalid."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "TCP Server"
 msgstr "TCP-Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1044
+msgid "TCP port is empty"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
 msgid "TLS Hostname Verify"
 msgstr "Überprüfung des TLS-Hostnamens"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:727
 msgid "TLS SNI name"
 msgstr "TLS-SNI-Name"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:746
 msgid "TLS SPKI Pinning"
 msgstr "TLS-SPKI-Pinning"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "TTL for all domain result."
 msgstr "TTL für alle Domänenergebnisse."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1137
 msgid "Technical Support"
 msgstr "Technische Unterstützung"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:539
+msgid "URL"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:548
+msgid "URL format error, format: http:// or https://"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:523
+msgid "Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:514
+msgid "Update Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:500
+msgid "Upload Config File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:507
+msgid "Upload Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:508
+msgid "Upload domain list file to /etc/smartdns/domain-set"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:892
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:992
+msgid ""
+"Upload domain list file, or configure auto download from Download File "
+"Setting page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+msgid "Upload domain list file."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:501
+msgid "Upload smartdns config file to /etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:631
 msgid "Upstream Servers"
 msgstr "Upstream-Server"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:632
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -465,7 +846,15 @@ msgstr ""
 "konfigurieren Sie mehrere DNS-Server, einschließlich mehrerer ausländischer "
 "DNS-Server."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:765
+msgid "Use Proxy"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:766
+msgid "Use proxy to connect to upstream DNS server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:747
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -475,41 +864,83 @@ msgstr ""
 "ist ein Base64-kodierter SPKI-Fingerabdruck, leer lassen bedeutet, dass die "
 "Gültigkeit von TLS nicht überprüft wird."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Write cache to disk on exit and load on startup."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1013
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:213
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:611
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1012
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1020
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:555
+msgid "domain list (/etc/smartdns/domain-set)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:670
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "ip"
 msgstr "IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:295
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:858
+msgid "ipset name format error, format: [#[4|6]:]ipsetname"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1143
 msgid "open website"
 msgstr "Webseite öffnen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "port"
 msgstr "Port"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:556
+msgid "smartdns config (/etc/smartdns/conf.d)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:585
 msgid "smartdns custom settings"
 msgstr "Benutzerdefinierte SmartDNS-Einstellungen"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:668
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:669
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "type"
 msgstr "Typ"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:667
 msgid "udp"
 msgstr "udp"
+
+#~ msgid ""
+#~ "DNS Server group belongs to, used with nameserver, such as office, home."
+#~ msgstr ""
+#~ "DNS-Server-Gruppe, zu jener der Nameserver gehört, z. B. Büro, Zuhause."
+
+#~ msgid "Dnsmasq Forwared To Smartdns Failure"
+#~ msgstr "Fehler der Dnsmasq-Weiterleitung an Smartdns"
+
+#~ msgid "Sets the server name indication for query."
+#~ msgstr "Legt die Anzeige des Servernamens für die Abfrage fest."
 
 #~ msgid "none"
 #~ msgstr "kein"

--- a/applications/luci-app-smartdns/po/es/smartdns.po
+++ b/applications/luci-app-smartdns/po/es/smartdns.po
@@ -13,20 +13,39 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.16-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:792
 msgid "Additional Args for upstream dns servers"
 msgstr "Args adicionales para servidores DNS aguas arriba"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:886
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1090
+msgid ""
+"Additional Flags for rules, read help on domain-rule for more information."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:885
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1089
+msgid "Additional Rule Flag"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:346
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:791
 msgid "Additional Server Args"
 msgstr "Args adicionales del servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:347
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:480
+msgid ""
+"Additional server args, refer to the help description of the bind option."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:132
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:639
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:253
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
@@ -34,25 +53,45 @@ msgstr ""
 "Intenta servir respuestas antiguas de la memoria caché con un TTL de 0 en la "
 "respuesta sin esperar a que finalice la resolución real."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically Set Dnsmasq"
 msgstr "Establecer Dnsmasq automáticamente"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically set as upstream of dnsmasq when port changes."
 msgstr ""
 "Establecido automáticamente como conexión ascendente de dnsmasq cuando "
 "cambia el puerto."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Bind Device"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Bind Device Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Cache Persist"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "Cache Size"
 msgstr "Tamaño del caché"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:121
 msgid "Collecting data ..."
 msgstr "Recolectando datos..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1100
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
@@ -60,147 +99,267 @@ msgstr ""
 "Configure listas negras de IP que se filtrarán de los resultados de un "
 "servidor DNS específico."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Configure block domain list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:950
+msgid "Configure domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+msgid "Configure forwarding domain name list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:137
 msgid "Custom Settings"
 msgstr "Configuraciones personalizadas"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:805
+msgid "DNS Block Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:804
+msgid "DNS Forwarding Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:648
 msgid "DNS Server Name"
 msgstr "Nombre del servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
-msgid ""
-"DNS Server group belongs to, used with nameserver, such as office, home."
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+msgid "DNS Server group"
 msgstr ""
-"El grupo del servidor DNS pertenece a, usado con el servidor de nombres, "
-"como la oficina, el hogar."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
+msgid "DNS Server group belongs to, such as office, home."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "DNS Server ip"
 msgstr "IP del servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "DNS Server port"
 msgstr "Puerto del servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "DNS Server type"
 msgstr "Tipo de servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "DNS domain result cache size"
 msgstr "Tamaño del caché de resultados del dominio DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
-msgid "Dnsmasq Forwared To Smartdns Failure"
-msgstr "Fallo en el reenvío de dnsmasq a SmartDNS"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+msgid "DNS64"
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:134
+msgid "DNS64 Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:560
+msgid "Description"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
+msgid "Dnsmasq Forwarded To Smartdns Failure"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:719
 msgid "Do not check certificate."
 msgstr "No verifique el certificado."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:397
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:838
 msgid "Do not check speed."
 msgstr "No verifique la velocidad."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Domain Address"
 msgstr "Dirección de dominio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Domain List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:891
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:991
+msgid "Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:949
+msgid "Domain Rule List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:965
+msgid "Domain Rule Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "Domain TTL"
 msgstr "TTL del dominio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:336
 msgid "Domain TTL Max"
 msgstr "TTL Máx. del dominio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:328
 msgid "Domain TTL Min"
 msgstr "TTL Mín. del dominio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:246
 msgid "Domain prefetch"
 msgstr "Prebúsqueda de dominios"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1159
 msgid "Donate"
 msgstr "Donar"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1158
 msgid "Donate to smartdns"
 msgstr "Donar a smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:526
+msgid "Download Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid "Download Files Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid ""
+"Download domain list files for domain-rule and include config files, please "
+"refresh the page after download to take effect."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:240
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1007
 msgid "Dual-stack IP Selection"
 msgstr "Selección de IP de doble pila"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:371
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:642
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:959
 msgid "Enable"
 msgstr "Activar"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable Auto Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:241
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1008
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "Activar la selección de IP entre IPv4 e IPv6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "Enable IPV6 DNS Server"
 msgstr "Activar servidor DNS IPv6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "Enable TCP DNS Server"
 msgstr "Activar el servidor DNS TCP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable daily auto update."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:247
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr ""
 "Active la captación previa del dominio, acelere la velocidad de respuesta "
 "del dominio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:372
 msgid "Enable or disable second DNS server."
 msgstr "Activar o desactivar el segundo servidor DNS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
 msgid "Enable or disable smartdns server"
 msgstr "Activar o desactivar el servidor smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude DNS Server from default group."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude Default Group"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+msgid "Fastest IP"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+msgid "Fastest Response"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:535
+msgid "File Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+msgid "File Type"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:702
 msgid "Filtering IP with blacklist"
 msgstr "Filtrado de IP con lista negra"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+msgid "First Ping"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA"
 msgstr "Forzar AAAA SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA."
 msgstr "Forzar AAAA SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA"
 msgstr "Forzar HTTPS SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA."
 msgstr "Forzar HTTPS SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:638
 msgid "General Settings"
 msgstr "Configuración general"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:599
 msgid "Generate Coredump"
 msgstr "Generar Coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:600
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -212,48 +371,174 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "Conceder acceso a la aplicación LuCI smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:737
 msgid "HTTP Host"
 msgstr "Host HTTP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "IP Blacklist"
 msgstr "Lista negra de IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:701
 msgid "IP Blacklist Filtering"
 msgstr "Filtrado de la lista negra de IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "IPV6 Server"
 msgstr "Servidor IPv6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset name."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1138
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr "Si le gusta este software, cómpreme una taza de café."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+msgid "Include Config Files<br>/etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+msgid ""
+"Include other config files from /etc/smartdns/conf.d or custom path, can be "
+"downloaded from the download page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:283
+msgid "Ipset name, Add domain result to ipset when speed check fails."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:527
+msgid "List of files to download."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Listen only on the specified interfaces."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Local Port"
 msgstr "Puerto local"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:624
+msgid "Log File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:608
+msgid "Log Level"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:620
+msgid "Log Number"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:604
+msgid "Log Size"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:757
+msgid "Marking Packets"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:337
 msgid "Maximum TTL for all domain result."
 msgstr "TTL máximo para todos los resultados de dominio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:329
 msgid "Minimum TTL for all domain result."
 msgstr "TTL mínimo para todos los resultados de dominio."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:471
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:877
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1081
+msgid "NFTset name format error, format: [#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset name, format: [#[4|6]:[family#table#set]]"
+msgstr ""
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr "NO SE ESTÁ EJECUTANDO"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Name of device name listen on."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:304
+msgid ""
+"Nftset name, Add domain result to nftset when speed check fails, format: "
+"[#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1014
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+msgid "No Speed IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+msgid "No Speed NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:718
 msgid "No check certificate"
 msgstr "No verificar el certificado"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:177
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1000
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1025
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:784
+msgid "Only socks5 proxy support udp server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:780
+msgid "Please set proxy server first."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+msgid "Proxy Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server URL, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:575
+msgid ""
+"Proxy server URL format error, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:390
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr ""
 "Consulta DNS a través de un grupo de servidores dns específico, como "
@@ -263,62 +548,86 @@ msgstr ""
 msgid "RUNNING"
 msgstr "EJECUTANDO"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:341
 msgid "Reply Domain TTL Max"
 msgstr "TTL máximo del dominio de respuesta"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:342
 msgid "Reply maximum TTL for all domain result."
 msgstr "Responda el TTL máximo para todos los resultados del dominio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1151
+msgid "Report bugs"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve Local Hostnames"
 msgstr "Resolver nombres de host locales"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve local hostnames by reading Dnsmasq lease file."
 msgstr ""
 "Resuelva los nombres de host locales leyendo el archivo de concesiones de "
 "Dnsmasq."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
+msgid "Response Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1174
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1165
 msgid "Restart Service"
 msgstr "Reiniciar servicio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:133
 msgid "Second Server Settings"
 msgstr "Segunda configuración del servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:252
 msgid "Serve expired"
 msgstr "Servir expirado"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:389
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
 msgid "Server Group"
 msgstr "Grupo de servidores"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:833
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:987
+msgid "Server Group %s not exists"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Server Name"
 msgstr "Nombre del servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Set Specific domain ip address."
 msgstr "Establecer dirección IP de dominio específico."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+msgid "Set Specific domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "Set Specific ip blacklist."
 msgstr "Establecer lista negra de IP específica."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:709
 msgid "Set TLS hostname to verify."
 msgstr "Establezca el nombre de host TLS para verificar."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:758
+msgid "Set mark on packets."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:738
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
@@ -326,76 +635,77 @@ msgstr ""
 "Establezca el host HTTP utilizado para la consulta. Use este parámetro "
 "cuando el host de la dirección URL sea una dirección IP."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
-msgid "Sets the server name indication for query."
-msgstr "Establece la indicación del nombre del servidor para la consulta."
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:728
+msgid "Sets the server name indication for query. '-' for disable SNI name."
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Settings"
 msgstr "Configuraciones"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:402
 msgid "Skip Address Rules"
 msgstr "Omitir reglas de dirección"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache"
 msgstr "Omitir caché"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache."
 msgstr "Omitir caché."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Skip Dualstack Selection"
 msgstr "Omitir selección de pila doble"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Skip Dualstack Selection."
 msgstr "Omitir selección de pila doble."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "Skip Ipset Rule"
 msgstr "Omitir regla de Ipset"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:408
 msgid "Skip Nameserver Rule"
 msgstr "Omitir regla de servidor de nombres"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:420
 msgid "Skip SOA Address Rule"
 msgstr "Omitir regla de dirección SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:421
 msgid "Skip SOA address rules."
 msgstr "Omita las reglas de dirección SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:837
 msgid "Skip Speed Check"
 msgstr "Omitir comprobación de velocidad"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:403
 msgid "Skip address rules."
 msgstr "Omitir reglas de dirección."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid "Skip ipset rules."
 msgstr "Omitir las reglas de ipset."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:409
 msgid "Skip nameserver rules."
 msgstr "Omitir las reglas del servidor de nombres."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr "SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
 msgid "SmartDNS Server"
 msgstr "Servidor SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:97
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
@@ -404,15 +714,15 @@ msgstr ""
 "la IP más rápida, admite el filtrado de anuncios y evita el envenenamiento "
 "de DNS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1142
 msgid "SmartDNS official website"
 msgstr "Sitio web oficial de SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Smartdns local server port"
 msgstr "Puerto del servidor local Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:154
 msgid ""
 "Smartdns local server port, smartdns will be automatically set as main dns "
 "when the port is 53."
@@ -420,11 +730,22 @@ msgstr ""
 "Puerto del servidor local de Smartdns, se configurará automáticamente como "
 "DNS principal cuando el puerto sea 53."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
+msgid ""
+"Smartdns response mode, First Ping: return the first ping IP, Fastest IP: "
+"return the fastest IP, Fastest Response: return the fastest DNS response."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Smartdns server name"
 msgstr "Nombre del servidor de Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Smartdns speed check mode."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1119
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
@@ -434,36 +755,94 @@ msgstr ""
 "dominios dados, las consultas en los dominios nunca se reenvían y siempre se "
 "responden con la dirección IP especificada que puede ser IPv4 o IPv6."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Speed Check Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1050
+msgid "Speed check mode is invalid."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "TCP Server"
 msgstr "Servidor TCP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1044
+msgid "TCP port is empty"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
 msgid "TLS Hostname Verify"
 msgstr "Verificar nombre de host TLS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:727
 msgid "TLS SNI name"
 msgstr "Nombre SNI de TLS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:746
 msgid "TLS SPKI Pinning"
 msgstr "TLS SPKI Anclado"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "TTL for all domain result."
 msgstr "TTL para todos los resultados de dominio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1137
 msgid "Technical Support"
 msgstr "Soporte técnico"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:539
+msgid "URL"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:548
+msgid "URL format error, format: http:// or https://"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:523
+msgid "Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:514
+msgid "Update Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:500
+msgid "Upload Config File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:507
+msgid "Upload Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:508
+msgid "Upload domain list file to /etc/smartdns/domain-set"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:892
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:992
+msgid ""
+"Upload domain list file, or configure auto download from Download File "
+"Setting page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+msgid "Upload domain list file."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:501
+msgid "Upload smartdns config file to /etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:631
 msgid "Upstream Servers"
 msgstr "Servidores aguas arriba"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:632
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -471,7 +850,15 @@ msgstr ""
 "Servidores aguas arriba, soporte UDP, protocolo TCP. Configure varios "
 "servidores DNS, incluidos varios servidores DNS externos."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:765
+msgid "Use Proxy"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:766
+msgid "Use proxy to connect to upstream DNS server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:747
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -481,41 +868,84 @@ msgstr ""
 "digital SPKI codificada en Base64, y se deja en blanco para indicar que no "
 "se verifica la validez de TLS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Write cache to disk on exit and load on startup."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1013
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:213
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:611
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1012
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1020
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:555
+msgid "domain list (/etc/smartdns/domain-set)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:670
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "ip"
 msgstr "ip"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:295
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:858
+msgid "ipset name format error, format: [#[4|6]:]ipsetname"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1143
 msgid "open website"
 msgstr "abrir sitio web"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "port"
 msgstr "puerto"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:556
+msgid "smartdns config (/etc/smartdns/conf.d)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:585
 msgid "smartdns custom settings"
 msgstr "configuraciones personalizadas de smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:668
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:669
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "type"
 msgstr "tipo"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:667
 msgid "udp"
 msgstr "udp"
+
+#~ msgid ""
+#~ "DNS Server group belongs to, used with nameserver, such as office, home."
+#~ msgstr ""
+#~ "El grupo del servidor DNS pertenece a, usado con el servidor de nombres, "
+#~ "como la oficina, el hogar."
+
+#~ msgid "Dnsmasq Forwared To Smartdns Failure"
+#~ msgstr "Fallo en el reenvío de dnsmasq a SmartDNS"
+
+#~ msgid "Sets the server name indication for query."
+#~ msgstr "Establece la indicación del nombre del servidor para la consulta."
 
 #~ msgid "IPV4 53 Port Redirect Failure"
 #~ msgstr "Error de reenvío de puerto IPv4 53"

--- a/applications/luci-app-smartdns/po/pt-BR/smartdns.po
+++ b/applications/luci-app-smartdns/po/pt-BR/smartdns.po
@@ -10,20 +10,39 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:792
 msgid "Additional Args for upstream dns servers"
 msgstr "Args adicionais para servidores dns upstream"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:886
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1090
+msgid ""
+"Additional Flags for rules, read help on domain-rule for more information."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:885
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1089
+msgid "Additional Rule Flag"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:346
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:791
 msgid "Additional Server Args"
 msgstr "Args Adicionais Sobre o Servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:347
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:480
+msgid ""
+"Additional server args, refer to the help description of the bind option."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:132
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:639
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:253
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
@@ -31,24 +50,44 @@ msgstr ""
 "Tentativas de servir respostas antigas do cache com um TTL de 0 na resposta "
 "sem esperar o término da resolução real."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically Set Dnsmasq"
 msgstr "Definir o Dnsmasq automaticamente"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically set as upstream of dnsmasq when port changes."
 msgstr ""
 "Definido automaticamente como upstream do dnsmasq quando a porta se alterar."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Bind Device"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Bind Device Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Cache Persist"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "Cache Size"
 msgstr "Tamanho do Cache"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:121
 msgid "Collecting data ..."
 msgstr "Coletando dados ..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1100
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
@@ -56,147 +95,267 @@ msgstr ""
 "Configure as listas negras dos IP que serão filtradas a partir dos "
 "resultados de um servidor DNS específico."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Configure block domain list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:950
+msgid "Configure domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+msgid "Configure forwarding domain name list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:137
 msgid "Custom Settings"
 msgstr "Configurações Personalizadas"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:805
+msgid "DNS Block Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:804
+msgid "DNS Forwarding Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:648
 msgid "DNS Server Name"
 msgstr "Nome do Servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
-msgid ""
-"DNS Server group belongs to, used with nameserver, such as office, home."
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+msgid "DNS Server group"
 msgstr ""
-"O grupo do Servidor DNS pertence a, usado em conjunto com o nameserver (nome "
-"do servidor), assim como em office, em casa."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
+msgid "DNS Server group belongs to, such as office, home."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "DNS Server ip"
 msgstr "Endereço IP do Servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "DNS Server port"
 msgstr "Porta do Servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "DNS Server type"
 msgstr "Tipo do Servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "DNS domain result cache size"
 msgstr "Tamanho do cache para o resultado do domínio DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
-msgid "Dnsmasq Forwared To Smartdns Failure"
-msgstr "Encaminhamento do Dnsmasq para Falha do Smartdns"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+msgid "DNS64"
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:134
+msgid "DNS64 Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:560
+msgid "Description"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
+msgid "Dnsmasq Forwarded To Smartdns Failure"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:719
 msgid "Do not check certificate."
 msgstr "Não verifique o certificado."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:397
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:838
 msgid "Do not check speed."
 msgstr "Não verifique a velocidade."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Domain Address"
 msgstr "Endereço do domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Domain List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:891
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:991
+msgid "Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:949
+msgid "Domain Rule List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:965
+msgid "Domain Rule Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "Domain TTL"
 msgstr "TTL do domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:336
 msgid "Domain TTL Max"
 msgstr "TTL Max. do Domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:328
 msgid "Domain TTL Min"
 msgstr "TTL Min. do Domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:246
 msgid "Domain prefetch"
 msgstr "Pré-aquisição do Domínio"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1159
 msgid "Donate"
 msgstr "Doe"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1158
 msgid "Donate to smartdns"
 msgstr "Doar para o smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:526
+msgid "Download Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid "Download Files Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid ""
+"Download domain list files for domain-rule and include config files, please "
+"refresh the page after download to take effect."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:240
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1007
 msgid "Dual-stack IP Selection"
 msgstr "Seleção IP com pilha dupla"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:371
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:642
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:959
 msgid "Enable"
 msgstr "Ativar"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable Auto Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:241
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1008
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "Ative a seleção do IP entre o IPV4 e o IPV6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "Enable IPV6 DNS Server"
 msgstr "Ativar o Servidor IPV6 do DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "Enable TCP DNS Server"
 msgstr "Ative o TCP do servidor DNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable daily auto update."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:247
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr ""
 "Ative a pré-aquisição do domínio, acelera a velocidade de resposta do "
 "domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:372
 msgid "Enable or disable second DNS server."
 msgstr "Ative ou desative o segundo servidor DNS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
 msgid "Enable or disable smartdns server"
 msgstr "Ative ou desative o servidor smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude DNS Server from default group."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude Default Group"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+msgid "Fastest IP"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+msgid "Fastest Response"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:535
+msgid "File Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+msgid "File Type"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:702
 msgid "Filtering IP with blacklist"
 msgstr "Filtrando o IP com um alista negra"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+msgid "First Ping"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA"
 msgstr "Impor AAAA SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA."
 msgstr "Impor AAAA SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA"
 msgstr "Impor o HTTPS SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA."
 msgstr "Impor o HTTPS SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:638
 msgid "General Settings"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:599
 msgid "Generate Coredump"
 msgstr "Gerar Coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:600
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -208,48 +367,174 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "Conceda acesso ao LuCI app smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:737
 msgid "HTTP Host"
 msgstr "Host HTTP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "IP Blacklist"
 msgstr "Lista negra de IPs"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:701
 msgid "IP Blacklist Filtering"
 msgstr "Filtragem da Lista Negra dos IPs"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "IPV6 Server"
 msgstr "Servidor IPV6"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset name."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1138
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr "Caso goste deste software, por favor, me pague uma xícara de café."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+msgid "Include Config Files<br>/etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+msgid ""
+"Include other config files from /etc/smartdns/conf.d or custom path, can be "
+"downloaded from the download page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:283
+msgid "Ipset name, Add domain result to ipset when speed check fails."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:527
+msgid "List of files to download."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Listen only on the specified interfaces."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Local Port"
 msgstr "Porta Local"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:624
+msgid "Log File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:608
+msgid "Log Level"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:620
+msgid "Log Number"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:604
+msgid "Log Size"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:757
+msgid "Marking Packets"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:337
 msgid "Maximum TTL for all domain result."
 msgstr "TTL máximo para todos os resultados do domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:329
 msgid "Minimum TTL for all domain result."
 msgstr "TTL mínimo para todos os resultados do domínio."
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:471
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:877
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1081
+msgid "NFTset name format error, format: [#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset name, format: [#[4|6]:[family#table#set]]"
+msgstr ""
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr "NÃO ESTÁ EM EXECUÇÃO"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Name of device name listen on."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:304
+msgid ""
+"Nftset name, Add domain result to nftset when speed check fails, format: "
+"[#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1014
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+msgid "No Speed IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+msgid "No Speed NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:718
 msgid "No check certificate"
 msgstr "Não verifique o certificado"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:177
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1000
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1025
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:784
+msgid "Only socks5 proxy support udp server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:780
+msgid "Please set proxy server first."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+msgid "Proxy Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server URL, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:575
+msgid ""
+"Proxy server URL format error, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:390
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr ""
 "Consulta o DNS através de um grupo específico de servidores dns, como "
@@ -259,60 +544,84 @@ msgstr ""
 msgid "RUNNING"
 msgstr "EM EXECUÇÃO"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:341
 msgid "Reply Domain TTL Max"
 msgstr "Responda ao domínio com TTL Max"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:342
 msgid "Reply maximum TTL for all domain result."
 msgstr "Responda com TTL máximo em todos os resultados do domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1151
+msgid "Report bugs"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve Local Hostnames"
 msgstr "Resolve os nomes dos host locais"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve local hostnames by reading Dnsmasq lease file."
 msgstr "Resolve os nomes dos hosts lendo o arquivo de concessão do Dnsmasq."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
+msgid "Response Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1174
 msgid "Restart"
 msgstr "Reiniciar"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1165
 msgid "Restart Service"
 msgstr "Reiniciar o serviço"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:133
 msgid "Second Server Settings"
 msgstr "Configurações do Segundo Servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:252
 msgid "Serve expired"
 msgstr "O servir expirou"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:389
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
 msgid "Server Group"
 msgstr "Grupo dos Servidores"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:833
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:987
+msgid "Server Group %s not exists"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Server Name"
 msgstr "Nome do Servidor"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Set Specific domain ip address."
 msgstr "Defina um endereço IP específico para o domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+msgid "Set Specific domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "Set Specific ip blacklist."
 msgstr "Defina um IP específico para a lista negra."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:709
 msgid "Set TLS hostname to verify."
 msgstr "Defina o nome do host TLS para verificar."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:758
+msgid "Set mark on packets."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:738
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
@@ -320,76 +629,77 @@ msgstr ""
 "Defina o host HTTP utilizado para a consulta. Use este parâmetro quando o "
 "host da URL do endereço for um endereço IP."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
-msgid "Sets the server name indication for query."
-msgstr "Define a indicação do nome do servidor para consulta."
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:728
+msgid "Sets the server name indication for query. '-' for disable SNI name."
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Settings"
 msgstr "Configurações"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:402
 msgid "Skip Address Rules"
 msgstr "Ignora as Regras do Endereço"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache"
 msgstr "Ignora a Cache"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache."
 msgstr "Ignora a Cache."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Skip Dualstack Selection"
 msgstr "Ignora a Seleção da Pilha Dupla"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Skip Dualstack Selection."
 msgstr "Ignora a Seleção da Pilha Dupla."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "Skip Ipset Rule"
 msgstr "Ignora a Regra Ipset"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:408
 msgid "Skip Nameserver Rule"
 msgstr "Ignora a Regra do Servidor de Nomes"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:420
 msgid "Skip SOA Address Rule"
 msgstr "Ignorar a Regra do Endereço SOA"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:421
 msgid "Skip SOA address rules."
 msgstr "Ignorar a Regra do Endereço SOA."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:837
 msgid "Skip Speed Check"
 msgstr "Ignorar a Verificação da Velocidade"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:403
 msgid "Skip address rules."
 msgstr "Ignora as Regras do Endereço."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid "Skip ipset rules."
 msgstr "Ignore as regras do ipset."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:409
 msgid "Skip nameserver rules."
 msgstr "Ignora a regra do servidor de nomes."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr "SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
 msgid "SmartDNS Server"
 msgstr "Servidor SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:97
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
@@ -398,15 +708,15 @@ msgstr ""
 "localização rápida do IP, suporta filtragem de anúncios e previne o "
 "envenenamento do DNS."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1142
 msgid "SmartDNS official website"
 msgstr "Site oficial do SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Smartdns local server port"
 msgstr "Porta do servidor local Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:154
 msgid ""
 "Smartdns local server port, smartdns will be automatically set as main dns "
 "when the port is 53."
@@ -414,11 +724,22 @@ msgstr ""
 "Porta do servidor local do Smartdns, o smartdns será automaticamente "
 "definido como dns principal quando a porta for 53."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
+msgid ""
+"Smartdns response mode, First Ping: return the first ping IP, Fastest IP: "
+"return the fastest IP, Fastest Response: return the fastest DNS response."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Smartdns server name"
 msgstr "Nome do servidor Smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Smartdns speed check mode."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1119
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
@@ -429,36 +750,94 @@ msgstr ""
 "respondidas de forma especificada com o endereço IP que tanto pode ser IPv4 "
 "ou IPv6."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Speed Check Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1050
+msgid "Speed check mode is invalid."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "TCP Server"
 msgstr "Servidor TCP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1044
+msgid "TCP port is empty"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
 msgid "TLS Hostname Verify"
 msgstr "Verificar o Nome do Host TLS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:727
 msgid "TLS SNI name"
 msgstr "Nome TLS SNI"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:746
 msgid "TLS SPKI Pinning"
 msgstr "Fixação TLS SPKI"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "TTL for all domain result."
 msgstr "O TTL para todos os resultados do domínio."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1137
 msgid "Technical Support"
 msgstr "Suporte Técnico"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:539
+msgid "URL"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:548
+msgid "URL format error, format: http:// or https://"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:523
+msgid "Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:514
+msgid "Update Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:500
+msgid "Upload Config File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:507
+msgid "Upload Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:508
+msgid "Upload domain list file to /etc/smartdns/domain-set"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:892
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:992
+msgid ""
+"Upload domain list file, or configure auto download from Download File "
+"Setting page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+msgid "Upload domain list file."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:501
+msgid "Upload smartdns config file to /etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:631
 msgid "Upstream Servers"
 msgstr "Servidores upstream"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:632
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -466,7 +845,15 @@ msgstr ""
 "Servidores upstream, suporte UDP, protocolo TCP. Configure os vários "
 "servidores DNS, incluindo vários servidores DNS externos."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:765
+msgid "Use Proxy"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:766
+msgid "Use proxy to connect to upstream DNS server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:747
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -476,41 +863,84 @@ msgstr ""
 "digital SPKI codificada com base64, deixando em branco para indicar que a "
 "validade do TLS não será verificada."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Write cache to disk on exit and load on startup."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1013
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:213
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:611
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1012
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1020
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:555
+msgid "domain list (/etc/smartdns/domain-set)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:670
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "ip"
 msgstr "IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:295
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:858
+msgid "ipset name format error, format: [#[4|6]:]ipsetname"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1143
 msgid "open website"
 msgstr "abrir o website"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "port"
 msgstr "porta"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:556
+msgid "smartdns config (/etc/smartdns/conf.d)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:585
 msgid "smartdns custom settings"
 msgstr "configurações personalizadas do smartdns"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:668
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:669
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "type"
 msgstr "tipo"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:667
 msgid "udp"
 msgstr "udp"
+
+#~ msgid ""
+#~ "DNS Server group belongs to, used with nameserver, such as office, home."
+#~ msgstr ""
+#~ "O grupo do Servidor DNS pertence a, usado em conjunto com o nameserver "
+#~ "(nome do servidor), assim como em office, em casa."
+
+#~ msgid "Dnsmasq Forwared To Smartdns Failure"
+#~ msgstr "Encaminhamento do Dnsmasq para Falha do Smartdns"
+
+#~ msgid "Sets the server name indication for query."
+#~ msgstr "Define a indicação do nome do servidor para consulta."
 
 #~ msgid "IPV4 53 Port Redirect Failure"
 #~ msgstr "Falha no Redirecionamento da Porta IPV4 53"

--- a/applications/luci-app-smartdns/po/templates/smartdns.pot
+++ b/applications/luci-app-smartdns/po/templates/smartdns.pot
@@ -1,184 +1,345 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:792
 msgid "Additional Args for upstream dns servers"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:886
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1090
+msgid ""
+"Additional Flags for rules, read help on domain-rule for more information."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:885
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1089
+msgid "Additional Rule Flag"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:346
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:791
 msgid "Additional Server Args"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:347
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:480
+msgid ""
+"Additional server args, refer to the help description of the bind option."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:132
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:639
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:253
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically Set Dnsmasq"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically set as upstream of dnsmasq when port changes."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Bind Device"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Bind Device Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Cache Persist"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "Cache Size"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:121
 msgid "Collecting data ..."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1100
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Configure block domain list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:950
+msgid "Configure domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+msgid "Configure forwarding domain name list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:137
 msgid "Custom Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:805
+msgid "DNS Block Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:804
+msgid "DNS Forwarding Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:648
 msgid "DNS Server Name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
-msgid ""
-"DNS Server group belongs to, used with nameserver, such as office, home."
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+msgid "DNS Server group"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
+msgid "DNS Server group belongs to, such as office, home."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "DNS Server ip"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "DNS Server port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "DNS Server type"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "DNS domain result cache size"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
-msgid "Dnsmasq Forwared To Smartdns Failure"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+msgid "DNS64"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:134
+msgid "DNS64 Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:560
+msgid "Description"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
+msgid "Dnsmasq Forwarded To Smartdns Failure"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:719
 msgid "Do not check certificate."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:397
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:838
 msgid "Do not check speed."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Domain Address"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Domain List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:891
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:991
+msgid "Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:949
+msgid "Domain Rule List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:965
+msgid "Domain Rule Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "Domain TTL"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:336
 msgid "Domain TTL Max"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:328
 msgid "Domain TTL Min"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:246
 msgid "Domain prefetch"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1159
 msgid "Donate"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1158
 msgid "Donate to smartdns"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:526
+msgid "Download Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid "Download Files Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid ""
+"Download domain list files for domain-rule and include config files, please "
+"refresh the page after download to take effect."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:240
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1007
 msgid "Dual-stack IP Selection"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:371
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:642
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:959
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable Auto Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:241
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1008
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "Enable IPV6 DNS Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "Enable TCP DNS Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable daily auto update."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:247
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:372
 msgid "Enable or disable second DNS server."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
 msgid "Enable or disable smartdns server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude DNS Server from default group."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude Default Group"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+msgid "Fastest IP"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+msgid "Fastest Response"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:535
+msgid "File Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+msgid "File Type"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:702
 msgid "Filtering IP with blacklist"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+msgid "First Ping"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:638
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:599
 msgid "Generate Coredump"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:600
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -188,48 +349,174 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:737
 msgid "HTTP Host"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "IP Blacklist"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:701
 msgid "IP Blacklist Filtering"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "IPV6 Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset name."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1138
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+msgid "Include Config Files<br>/etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+msgid ""
+"Include other config files from /etc/smartdns/conf.d or custom path, can be "
+"downloaded from the download page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:283
+msgid "Ipset name, Add domain result to ipset when speed check fails."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:527
+msgid "List of files to download."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Listen only on the specified interfaces."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Local Port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:624
+msgid "Log File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:608
+msgid "Log Level"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:620
+msgid "Log Number"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:604
+msgid "Log Size"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:757
+msgid "Marking Packets"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:337
 msgid "Maximum TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:329
 msgid "Minimum TTL for all domain result."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:471
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:877
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1081
+msgid "NFTset name format error, format: [#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset name, format: [#[4|6]:[family#table#set]]"
 msgstr ""
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Name of device name listen on."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:304
+msgid ""
+"Nftset name, Add domain result to nftset when speed check fails, format: "
+"[#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1014
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+msgid "No Speed IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+msgid "No Speed NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:718
 msgid "No check certificate"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:177
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1000
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1025
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:784
+msgid "Only socks5 proxy support udp server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:780
+msgid "Please set proxy server first."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+msgid "Proxy Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server URL, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:575
+msgid ""
+"Proxy server URL format error, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:390
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr ""
 
@@ -237,239 +524,372 @@ msgstr ""
 msgid "RUNNING"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:341
 msgid "Reply Domain TTL Max"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:342
 msgid "Reply maximum TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1151
+msgid "Report bugs"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve Local Hostnames"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve local hostnames by reading Dnsmasq lease file."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
+msgid "Response Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1174
 msgid "Restart"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1165
 msgid "Restart Service"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:133
 msgid "Second Server Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:252
 msgid "Serve expired"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:389
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
 msgid "Server Group"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:833
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:987
+msgid "Server Group %s not exists"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Server Name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Set Specific domain ip address."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+msgid "Set Specific domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "Set Specific ip blacklist."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:709
 msgid "Set TLS hostname to verify."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:758
+msgid "Set mark on packets."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:738
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
-msgid "Sets the server name indication for query."
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:728
+msgid "Sets the server name indication for query. '-' for disable SNI name."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:402
 msgid "Skip Address Rules"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Skip Dualstack Selection"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Skip Dualstack Selection."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "Skip Ipset Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:408
 msgid "Skip Nameserver Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:420
 msgid "Skip SOA Address Rule"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:421
 msgid "Skip SOA address rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:837
 msgid "Skip Speed Check"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:403
 msgid "Skip address rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid "Skip ipset rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:409
 msgid "Skip nameserver rules."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
 msgid "SmartDNS Server"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:97
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1142
 msgid "SmartDNS official website"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Smartdns local server port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:154
 msgid ""
 "Smartdns local server port, smartdns will be automatically set as main dns "
 "when the port is 53."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
+msgid ""
+"Smartdns response mode, First Ping: return the first ping IP, Fastest IP: "
+"return the fastest IP, Fastest Response: return the fastest DNS response."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Smartdns server name"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Smartdns speed check mode."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1119
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
 "IP address which may be IPv4 or IPv6."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
-msgid "TCP Server"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
-msgid "TLS Hostname Verify"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
-msgid "TLS SNI name"
-msgstr ""
-
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
-msgid "TLS SPKI Pinning"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Speed Check Mode"
 msgstr ""
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1050
+msgid "Speed check mode is invalid."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
+msgid "TCP Server"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1044
+msgid "TCP port is empty"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
+msgid "TLS Hostname Verify"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:727
+msgid "TLS SNI name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:746
+msgid "TLS SPKI Pinning"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "TTL for all domain result."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1137
 msgid "Technical Support"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:539
+msgid "URL"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:548
+msgid "URL format error, format: http:// or https://"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:523
+msgid "Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:514
+msgid "Update Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:500
+msgid "Upload Config File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:507
+msgid "Upload Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:508
+msgid "Upload domain list file to /etc/smartdns/domain-set"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:892
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:992
+msgid ""
+"Upload domain list file, or configure auto download from Download File "
+"Setting page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+msgid "Upload domain list file."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:501
+msgid "Upload smartdns config file to /etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:631
 msgid "Upstream Servers"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:632
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:765
+msgid "Use Proxy"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:766
+msgid "Use proxy to connect to upstream DNS server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:747
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
 "verified."
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Write cache to disk on exit and load on startup."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1013
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:213
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:611
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1012
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1020
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:555
+msgid "domain list (/etc/smartdns/domain-set)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:670
 msgid "https"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "ip"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:295
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:858
+msgid "ipset name format error, format: [#[4|6]:]ipsetname"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1143
 msgid "open website"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "port"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:556
+msgid "smartdns config (/etc/smartdns/conf.d)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:585
 msgid "smartdns custom settings"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:668
 msgid "tcp"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:669
 msgid "tls"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "type"
 msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:667
 msgid "udp"
 msgstr ""

--- a/applications/luci-app-smartdns/po/zh_Hans/smartdns.po
+++ b/applications/luci-app-smartdns/po/zh_Hans/smartdns.po
@@ -10,184 +10,346 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:792
 msgid "Additional Args for upstream dns servers"
 msgstr "额外的上游 DNS 服务器参数"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:886
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1090
+msgid ""
+"Additional Flags for rules, read help on domain-rule for more information."
+msgstr "额外的规则标识，具体参考domain-rule的帮助说明。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:885
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1089
+msgid "Additional Rule Flag"
+msgstr "额外规则标识"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:346
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:791
 msgid "Additional Server Args"
 msgstr "额外的服务器参数"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:347
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:480
+msgid ""
+"Additional server args, refer to the help description of the bind option."
+msgstr "额外的服务器参数，参考bind选项的帮助说明。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:132
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:639
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:253
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
 msgstr "查询性能优化，有请求时尝试回应TTL为0的过期记录，以避免查询等待。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically Set Dnsmasq"
 msgstr "自动设置Dnsmasq"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically set as upstream of dnsmasq when port changes."
 msgstr "端口更改时自动设为 dnsmasq 的上游。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Bind Device"
+msgstr "绑定到设备"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Bind Device Name"
+msgstr "绑定的设备名称"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain"
+msgstr "屏蔽域名"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain."
+msgstr "屏蔽域名。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Cache Persist"
+msgstr "持久化缓存"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "Cache Size"
 msgstr "缓存大小"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:121
 msgid "Collecting data ..."
 msgstr "正在收集数据..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1100
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
 msgstr "配置需要从指定域名服务器结果过滤的IP黑名单。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Configure block domain list."
+msgstr "配置屏蔽域名列表。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:950
+msgid "Configure domain rule list."
+msgstr "配置域名规则列表。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+msgid "Configure forwarding domain name list."
+msgstr "配置分流域名列表。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:137
 msgid "Custom Settings"
 msgstr "自定义设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:805
+msgid "DNS Block Setting"
+msgstr "域名屏蔽设置"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:804
+msgid "DNS Forwarding Setting"
+msgstr "域名分流设置"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:648
 msgid "DNS Server Name"
 msgstr "DNS服务器名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
-msgid ""
-"DNS Server group belongs to, used with nameserver, such as office, home."
-msgstr "DNS服务器所属组， 配合nameserver使用，例如：office，home。"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+msgid "DNS Server group"
+msgstr "服务器组"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
+msgid "DNS Server group belongs to, such as office, home."
+msgstr "设置服务器组，例如office，home。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "DNS Server ip"
 msgstr "DNS服务器IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "DNS Server port"
 msgstr "DNS服务器端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "DNS Server type"
 msgstr "协议类型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "DNS domain result cache size"
-msgstr "缓存DNS的结果，缓存大小，配置零则不缓存"
+msgstr "缓存DNS的结果，缓存大小，配置零则不缓存。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+msgid "DNS64"
+msgstr "DNS64"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:134
+msgid "DNS64 Server Settings"
+msgstr "DNS64服务器配置"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:560
+msgid "Description"
+msgstr "描述"
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
-msgid "Dnsmasq Forwared To Smartdns Failure"
+msgid "Dnsmasq Forwarded To Smartdns Failure"
 msgstr "重定向dnsmasq到smartdns失败"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:719
 msgid "Do not check certificate."
 msgstr "不校验证书的合法性。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:397
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:838
 msgid "Do not check speed."
 msgstr "禁用测速。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Domain Address"
 msgstr "域名地址"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Domain List"
+msgstr "域名列表"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:891
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:991
+msgid "Domain List File"
+msgstr "域名列表文件"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:949
+msgid "Domain Rule List"
+msgstr "域名规则列表"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:965
+msgid "Domain Rule Name"
+msgstr "域名规则名称"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules"
+msgstr "域名规则"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules Settings"
+msgstr "域名规则设置"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "Domain TTL"
 msgstr "域名TTL"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:336
 msgid "Domain TTL Max"
 msgstr "域名TTL最大值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:328
 msgid "Domain TTL Min"
 msgstr "域名TTL最小值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:246
 msgid "Domain prefetch"
 msgstr "域名预加载"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1159
 msgid "Donate"
 msgstr "捐助"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1158
 msgid "Donate to smartdns"
 msgstr "捐助smartdns项目"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:526
+msgid "Download Files"
+msgstr "下载文件"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid "Download Files Setting"
+msgstr "下载文件设置"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid ""
+"Download domain list files for domain-rule and include config files, please "
+"refresh the page after download to take effect."
+msgstr ""
+"下载域名规则所需要的域名列表文件和smartdns配置文件，下载完成后刷新页面。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:240
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1007
 msgid "Dual-stack IP Selection"
 msgstr "双栈IP优选"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:371
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:642
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:959
 msgid "Enable"
 msgstr "启用"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable Auto Update"
+msgstr "启用自动更新"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:241
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1008
 msgid "Enable IP selection between IPV4 and IPV6"
-msgstr "启用 IPV4 和 IPV6 间的 IP 优选策略"
+msgstr "启用 IPV4 和 IPV6 间的 IP 优选策略。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "Enable IPV6 DNS Server"
-msgstr "启用IPV6服务器"
+msgstr "启用IPV6服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "Enable TCP DNS Server"
-msgstr "启用TCP服务器"
+msgstr "启用TCP服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable daily auto update."
+msgstr "启用每日自动更新"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:247
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr "启用域名预加载，加速域名响应速度。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:372
 msgid "Enable or disable second DNS server."
 msgstr "是否启用第二DNS服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
 msgid "Enable or disable smartdns server"
 msgstr "启用或禁用SmartDNS服务"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude DNS Server from default group."
+msgstr "从default默认服务器组中排除。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude Default Group"
+msgstr "从默认组中排除"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+msgid "Fastest IP"
+msgstr "最快IP"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+msgid "Fastest Response"
+msgstr "最快响应"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:535
+msgid "File Name"
+msgstr "文件名"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+msgid "File Type"
+msgstr "文件类型"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:702
 msgid "Filtering IP with blacklist"
 msgstr "使用IP黑名单过滤"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+msgid "First Ping"
+msgstr "最快PING"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA"
 msgstr "停用IPV6地址解析"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA."
 msgstr "停用IPV6地址解析。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA"
 msgstr "停用HTTPS地址解析"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA."
 msgstr "停用HTTPS地址解析。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:638
 msgid "General Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:599
 msgid "Generate Coredump"
 msgstr "生成coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:600
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -198,48 +360,176 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "授予访问 LuCI 应用 smartdns 的权限"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:737
 msgid "HTTP Host"
 msgstr "HTTP主机"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "IP Blacklist"
 msgstr "IP黑名单"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:701
 msgid "IP Blacklist Filtering"
 msgstr "IP黑名单过滤"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "IPV6 Server"
 msgstr "IPV6服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset Name"
+msgstr "IPset名称"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset name."
+msgstr "IPset名称。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1138
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr "如果本软件对你有帮助，请给作者加个蛋。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+msgid "Include Config Files<br>/etc/smartdns/conf.d"
+msgstr "包含配置文件<br>/etc/smartdns/conf.d"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+msgid ""
+"Include other config files from /etc/smartdns/conf.d or custom path, can be "
+"downloaded from the download page."
+msgstr ""
+"包含配置文件，路径为/etc/smartdns/conf.d，或自定义配置文件路径，可以从下载页"
+"配置自动下载。面配置自动下载。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:283
+msgid "Ipset name, Add domain result to ipset when speed check fails."
+msgstr "IPset名称，当测速失败时，将查询到的结果添加到对应的IPSet集合中。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:527
+msgid "List of files to download."
+msgstr "下载文件列表。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Listen only on the specified interfaces."
+msgstr "监听在指定的设备上，避免非本地网络的DNS查询请求。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Local Port"
 msgstr "本地端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:624
+msgid "Log File"
+msgstr "日志文件路径"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:608
+msgid "Log Level"
+msgstr "日志级别"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:620
+msgid "Log Number"
+msgstr "日志数量"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:604
+msgid "Log Size"
+msgstr "日志大小"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:757
+msgid "Marking Packets"
+msgstr "数据包标记"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:337
 msgid "Maximum TTL for all domain result."
 msgstr "所有域名的最大 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:329
 msgid "Minimum TTL for all domain result."
 msgstr "所有域名的最小 TTL 值。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset Name"
+msgstr "NFTSet名称"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:471
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:877
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1081
+msgid "NFTset name format error, format: [#[4|6]:[family#table#set]]"
+msgstr "NFTSet名称格式错误，格式：[#[4|6]:[family#table#set]]"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset name, format: [#[4|6]:[family#table#set]]"
+msgstr "NFTSet名称，格式：[#[4|6]:[family#table#set]]"
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr "未运行"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Name of device name listen on."
+msgstr "绑定的设备名称。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:304
+msgid ""
+"Nftset name, Add domain result to nftset when speed check fails, format: "
+"[#[4|6]:[family#table#set]]"
+msgstr "NFTset名称，当测速失败时，将查询到的结果添加到对应的NFTSet集合中。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1014
+msgid "No"
+msgstr "否"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+msgid "No Speed IPset Name"
+msgstr "无速度时IPSet名称"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+msgid "No Speed NFTset Name"
+msgstr "无速度时NFTSet名称"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:718
 msgid "No check certificate"
 msgstr "停用证书校验"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:177
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1000
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1025
+msgid "None"
+msgstr "无"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:784
+msgid "Only socks5 proxy support udp server."
+msgstr "仅SOCKS5代理支持UDP服务器。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:780
+msgid "Please set proxy server first."
+msgstr "请先设置代理服务器。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server"
+msgstr "代理服务器"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+msgid "Proxy Server Settings"
+msgstr "代理服务器设置"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server URL, format: [socks5|http]://user:pass@ip:port."
+msgstr "代理服务器地址，格式：[socks5|http]://user:pass@ip:port。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:575
+msgid ""
+"Proxy server URL format error, format: [socks5|http]://user:pass@ip:port."
+msgstr "代理服务器地址格式错误，格式：[socks5|http]://user:pass@ip:port。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:390
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr "使用指定服务器组查询，比如office, home。"
 
@@ -247,160 +537,198 @@ msgstr "使用指定服务器组查询，比如office, home。"
 msgid "RUNNING"
 msgstr "运行中"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:341
 msgid "Reply Domain TTL Max"
 msgstr "回应的域名TTL最大值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:342
 msgid "Reply maximum TTL for all domain result."
 msgstr "设置返回给客户端的域名TTL最大值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1151
+msgid "Report bugs"
+msgstr "报告BUG"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve Local Hostnames"
 msgstr "解析本地主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve local hostnames by reading Dnsmasq lease file."
 msgstr "读取Dnsmasq的租约文件解析本地主机名。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
+msgid "Response Mode"
+msgstr "响应模式"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1174
 msgid "Restart"
 msgstr "重启"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1165
 msgid "Restart Service"
 msgstr "重启服务"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:133
 msgid "Second Server Settings"
 msgstr "第二DNS服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:252
 msgid "Serve expired"
 msgstr "缓存过期服务"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:389
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
 msgid "Server Group"
 msgstr "服务器组"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:833
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:987
+msgid "Server Group %s not exists"
+msgstr "服务器组%s不存在"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Server Name"
 msgstr "服务器名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Set Specific domain ip address."
 msgstr "设置指定域名的IP地址。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+msgid "Set Specific domain rule list."
+msgstr "设置指定域名的规则列表。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "Set Specific ip blacklist."
 msgstr "设置指定的 IP 黑名单列表。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:709
 msgid "Set TLS hostname to verify."
 msgstr "设置校验TLS主机名。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:758
+msgid "Set mark on packets."
+msgstr "设置数据包标记。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:738
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
 msgstr "设置查询时使用的HTTP主机，当URL地址的host是IP地址时，使用此参数。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
-msgid "Sets the server name indication for query."
-msgstr "设置查询时使用的服务器SNI名称。"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:728
+msgid "Sets the server name indication for query. '-' for disable SNI name."
+msgstr "设置服务器SNI名称，‘-’表示禁用SNI名称。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Settings"
 msgstr "设置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:402
 msgid "Skip Address Rules"
 msgstr "跳过address规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache"
 msgstr "跳过cache"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache."
 msgstr "跳过cache。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Skip Dualstack Selection"
 msgstr "跳过双栈优选"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Skip Dualstack Selection."
 msgstr "跳过双栈优选。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "Skip Ipset Rule"
 msgstr "跳过ipset规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:408
 msgid "Skip Nameserver Rule"
 msgstr "跳过Nameserver规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:420
 msgid "Skip SOA Address Rule"
 msgstr "跳过address SOA(#)规则"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:421
 msgid "Skip SOA address rules."
 msgstr "跳过address SOA(#)规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:837
 msgid "Skip Speed Check"
 msgstr "跳过测速"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:403
 msgid "Skip address rules."
 msgstr "跳过address规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid "Skip ipset rules."
 msgstr "跳过ipset规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:409
 msgid "Skip nameserver rules."
 msgstr "跳过Nameserver规则。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr "SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
 msgid "SmartDNS Server"
 msgstr "SmartDNS 服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:97
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
 msgstr "SmartDNS是一个本地高性能DNS服务器，支持返回最快IP，支持广告过滤。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1142
 msgid "SmartDNS official website"
 msgstr "SmartDNS官方网站"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Smartdns local server port"
 msgstr "SmartDNS本地服务端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:154
 msgid ""
 "Smartdns local server port, smartdns will be automatically set as main dns "
 "when the port is 53."
 msgstr ""
 "SmartDNS本地服务端口，当端口号设置为53时，smartdns将会自动配置为主dns。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
+msgid ""
+"Smartdns response mode, First Ping: return the first ping IP, Fastest IP: "
+"return the fastest IP, Fastest Response: return the fastest DNS response."
+msgstr ""
+"SmartDNS响应模式，最快PING： 返回最早有ping结果的IP，速度适中；最快IP： 返回"
+"最快IP，查询请求可能延长； 最快响应：返回最快响应的结果，查询请求时间短。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Smartdns server name"
 msgstr "SmartDNS的服务器名称，默认为smartdns，留空为主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Smartdns speed check mode."
+msgstr "SmartDNS测速模式。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1119
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
@@ -409,36 +737,94 @@ msgstr ""
 "配置特定域名返回特定的IP地址，域名查询将不到上游服务器请求，直接返回配置的IP"
 "地址，可用于广告屏蔽。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Speed Check Mode"
+msgstr "测速模式"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1050
+msgid "Speed check mode is invalid."
+msgstr "测速模式无效。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "TCP Server"
 msgstr "TCP服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1044
+msgid "TCP port is empty"
+msgstr "TCP端口号为空"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
 msgid "TLS Hostname Verify"
 msgstr "校验TLS主机名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:727
 msgid "TLS SNI name"
 msgstr "TLS SNI名称"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:746
 msgid "TLS SPKI Pinning"
 msgstr "TLS SPKI 指纹"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "TTL for all domain result."
 msgstr "设置所有域名的 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1137
 msgid "Technical Support"
 msgstr "技术支持"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:539
+msgid "URL"
+msgstr "URL"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:548
+msgid "URL format error, format: http:// or https://"
+msgstr "URL格式错误，格式：http://或https://"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:523
+msgid "Update"
+msgstr "更新"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:514
+msgid "Update Files"
+msgstr "更新文件"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:500
+msgid "Upload Config File"
+msgstr "上传配置文件"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:507
+msgid "Upload Domain List File"
+msgstr "上传域名列表文件"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:508
+msgid "Upload domain list file to /etc/smartdns/domain-set"
+msgstr "上传域名列表文件到/etc/smartdns/domain-set"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:892
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:992
+msgid ""
+"Upload domain list file, or configure auto download from Download File "
+"Setting page."
+msgstr "上传域名列表文件，或在下载文件设置页面设置自动下载。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+msgid "Upload domain list file."
+msgstr "上传域名列表文件"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:501
+msgid "Upload smartdns config file to /etc/smartdns/conf.d"
+msgstr "上传配置文件到/etc/smartdns/conf.d"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:631
 msgid "Upstream Servers"
 msgstr "上游服务器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:632
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -446,7 +832,15 @@ msgstr ""
 "上游 DNS 服务器，支持 UDP，TCP 协议。请配置多个上游 DNS 服务器，包括多个国内"
 "外服务器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:765
+msgid "Use Proxy"
+msgstr "使用代理"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:766
+msgid "Use proxy to connect to upstream DNS server."
+msgstr "使用代理连接上游DNS服务器。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:747
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -455,59 +849,69 @@ msgstr ""
 "用于校验 TLS 服务器的有效性，数值为 Base64 编码的 SPKI 指纹，留空表示不验证 "
 "TLS 的合法性。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Write cache to disk on exit and load on startup."
+msgstr "退出时保存cache到磁盘，启动时加载。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1013
+msgid "Yes"
+msgstr "是"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:213
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:611
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1012
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1020
+msgid "default"
+msgstr "默认"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:555
+msgid "domain list (/etc/smartdns/domain-set)"
+msgstr "域名列表（/etc/smartdns/domain-set）"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:670
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "ip"
 msgstr "ip"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:295
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:858
+msgid "ipset name format error, format: [#[4|6]:]ipsetname"
+msgstr "IPset名称格式错误，格式：[#[4|6]:]ipsetname"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1143
 msgid "open website"
 msgstr "打开网站"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "port"
 msgstr "端口"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:556
+msgid "smartdns config (/etc/smartdns/conf.d)"
+msgstr "smartdns 配置文件（/etc/smartdns/conf.d）"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:585
 msgid "smartdns custom settings"
 msgstr "smartdns 自定义设置，具体配置参数参考指导"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:668
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:669
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "type"
 msgstr "类型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:667
 msgid "udp"
 msgstr "udp"
-
-#~ msgid "IPV4 53 Port Redirect Failure"
-#~ msgstr "IPV4 53端口重定向失败"
-
-#~ msgid "IPV6 53 Port Redirect Failure"
-#~ msgstr "IPV6 53端口重定向失败"
-
-#~ msgid "Redirect"
-#~ msgstr "重定向"
-
-#~ msgid "Redirect 53 port to SmartDNS"
-#~ msgstr "重定向53端口到SmartDNS"
-
-#~ msgid "Run as dnsmasq upstream server"
-#~ msgstr "作为dnsmasq的上游服务器"
-
-#~ msgid "SmartDNS redirect mode"
-#~ msgstr "SmartDNS 重定向模式"
-
-#~ msgid "none"
-#~ msgstr "无"

--- a/applications/luci-app-smartdns/po/zh_Hant/smartdns.po
+++ b/applications/luci-app-smartdns/po/zh_Hant/smartdns.po
@@ -10,184 +10,345 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:792
 msgid "Additional Args for upstream dns servers"
 msgstr "額外的上游 DNS 伺服器參數"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:886
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1090
+msgid ""
+"Additional Flags for rules, read help on domain-rule for more information."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:885
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1089
+msgid "Additional Rule Flag"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:346
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:791
 msgid "Additional Server Args"
 msgstr "額外的伺服器參數"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:323
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:432
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:347
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:480
+msgid ""
+"Additional server args, refer to the help description of the bind option."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:132
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:639
 msgid "Advanced Settings"
 msgstr "進階設定"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:173
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:253
 msgid ""
 "Attempts to serve old responses from cache with a TTL of 0 in the response "
 "without waiting for the actual resolution to finish."
 msgstr "查詢性能優化，有請求時嘗試回應 TTL 為 0 的過期記錄，以避免查詢等待。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically Set Dnsmasq"
 msgstr "自動設置 Dnsmasq"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:187
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
 msgid "Automatically set as upstream of dnsmasq when port changes."
 msgstr "通訊埠更改時自動設為 dnsmasq 的上游。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Bind Device"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Bind Device Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:998
+msgid "Block domain."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Cache Persist"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "Cache Size"
 msgstr "緩存大小"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:119
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:121
 msgid "Collecting data ..."
 msgstr "正在收集數據..."
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:458
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1100
 msgid ""
 "Configure IP blacklists that will be filtered from the results of specific "
 "DNS server."
 msgstr "配置需要从指定域名伺服器結果過濾的 IP 黑名單。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:129
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Configure block domain list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:950
+msgid "Configure domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+msgid "Configure forwarding domain name list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:137
 msgid "Custom Settings"
 msgstr "自定義設置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:332
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:805
+msgid "DNS Block Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:804
+msgid "DNS Forwarding Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:648
 msgid "DNS Server Name"
 msgstr "DNS 伺服器名稱"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
-msgid ""
-"DNS Server group belongs to, used with nameserver, such as office, home."
-msgstr "DNS 伺服器所屬組， 配合 nameserver 使用，例如：office，home。"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+msgid "DNS Server group"
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
+msgid "DNS Server group belongs to, such as office, home."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "DNS Server ip"
 msgstr "DNS 伺服器 IP"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "DNS Server port"
 msgstr "DNS 伺服器通訊埠"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "DNS Server type"
 msgstr "協議類型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:178
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:258
 msgid "DNS domain result cache size"
 msgstr "緩存 DNS 的結果，緩存大小，配置零則不緩存"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
-msgid "Dnsmasq Forwared To Smartdns Failure"
-msgstr "重定向 dnsmasq 到 smartdns 失敗"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+msgid "DNS64"
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:387
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:134
+msgid "DNS64 Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:560
+msgid "Description"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:76
+msgid "Dnsmasq Forwarded To Smartdns Failure"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:719
 msgid "Do not check certificate."
 msgstr "不校驗憑證的合法性。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:251
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:397
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:838
 msgid "Do not check speed."
 msgstr "禁用測速。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Domain Address"
 msgstr "域名位址"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:900
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:929
+msgid "Domain List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:891
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:991
+msgid "Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:949
+msgid "Domain Rule List"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:965
+msgid "Domain Rule Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:800
+msgid "Domain Rules Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "Domain TTL"
 msgstr "域名 TTL"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:336
 msgid "Domain TTL Max"
 msgstr "域名 TTL 最大值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:206
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:328
 msgid "Domain TTL Min"
 msgstr "域名 TTL 最小值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:166
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:246
 msgid "Domain prefetch"
 msgstr "域名預加載"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:487
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1159
 msgid "Donate"
 msgstr "捐贈"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:486
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1158
 msgid "Donate to smartdns"
 msgstr "捐贈 smartdns 項目"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:160
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:526
+msgid "Download Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid "Download Files Setting"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:135
+msgid ""
+"Download domain list files for domain-rule and include config files, please "
+"refresh the page after download to take effect."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:240
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1007
 msgid "Dual-stack IP Selection"
 msgstr "雙棧 IP 優選"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:225
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:326
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:371
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:642
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:959
 msgid "Enable"
 msgstr "启用"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:161
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable Auto Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:241
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1008
 msgid "Enable IP selection between IPV4 and IPV6"
 msgstr "启用 IPV4 和 IPV6 間的 IP 優選策略"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "Enable IPV6 DNS Server"
 msgstr "启用 IPV6 伺服器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "Enable TCP DNS Server"
 msgstr "启用 TCP 伺服器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:167
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:495
+msgid "Enable daily auto update."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:247
 msgid "Enable domain prefetch, accelerate domain response speed."
 msgstr "启用域名預加載，加速域名響應速度。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:226
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:372
 msgid "Enable or disable second DNS server."
 msgstr "是否启用第二 DNS 伺服器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
 msgid "Enable or disable smartdns server"
 msgstr "启用或禁用 SmartDNS 服務"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:370
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude DNS Server from default group."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:694
+msgid "Exclude Default Group"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+msgid "Fastest IP"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:216
+msgid "Fastest Response"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:535
+msgid "File Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+msgid "File Type"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:702
 msgid "Filtering IP with blacklist"
 msgstr "使用 IP 黑名單過濾"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:214
+msgid "First Ping"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA"
 msgstr "停用 IPV6 位址解析"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:192
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:290
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:272
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:842
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1056
 msgid "Force AAAA SOA."
 msgstr "停用 IPV6 位址解析。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA"
 msgstr "停用 HTTPS 位址解析"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:197
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:277
 msgid "Force HTTPS SOA."
 msgstr "停用 HTTPS 位址解析。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:127
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:322
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:131
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:638
 msgid "General Settings"
 msgstr "常規設置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:311
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:599
 msgid "Generate Coredump"
 msgstr "生成 coredump"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:312
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:600
 msgid ""
 "Generate Coredump file when smartdns crash, coredump file is located at /tmp/"
 "smartdns.xxx.core."
@@ -198,48 +359,174 @@ msgstr ""
 msgid "Grant access to LuCI app smartdns"
 msgstr "授予訪問 LuCI 應用 smartdns 的權限"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:405
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:737
 msgid "HTTP Host"
 msgstr "HTTP 主機"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "IP Blacklist"
 msgstr "IP 黑名單"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:369
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:701
 msgid "IP Blacklist Filtering"
 msgstr "IP 黑名單過濾"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:155
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:224
 msgid "IPV6 Server"
 msgstr "IPV6 伺服器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:474
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:846
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1062
+msgid "IPset name."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1138
 msgid "If you like this software, please buy me a cup of coffee."
 msgstr "如果本软件对你有帮助，请给作者加个蛋。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:142
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+msgid "Include Config Files<br>/etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+msgid ""
+"Include other config files from /etc/smartdns/conf.d or custom path, can be "
+"downloaded from the download page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:283
+msgid "Ipset name, Add domain result to ipset when speed check fails."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:527
+msgid "List of files to download."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:229
+msgid "Listen only on the specified interfaces."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:153
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Local Port"
 msgstr "本地通訊埠"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:215
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:624
+msgid "Log File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:608
+msgid "Log Level"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:620
+msgid "Log Number"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:604
+msgid "Log Size"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:757
+msgid "Marking Packets"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:337
 msgid "Maximum TTL for all domain result."
 msgstr "所有域名的最大 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:207
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:329
 msgid "Minimum TTL for all domain result."
 msgstr "所有域名的最小 TTL 值。"
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:471
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:877
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1081
+msgid "NFTset name format error, format: [#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:459
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:865
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1068
+msgid "NFTset name, format: [#[4|6]:[family#table#set]]"
+msgstr ""
 
 #: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:66
 msgid "NOT RUNNING"
 msgstr "未運行"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:386
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:234
+msgid "Name of device name listen on."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:304
+msgid ""
+"Nftset name, Add domain result to nftset when speed check fails, format: "
+"[#[4|6]:[family#table#set]]"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1014
+msgid "No"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:282
+msgid "No Speed IPset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:303
+msgid "No Speed NFTset Name"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:718
 msgid "No check certificate"
 msgstr "停用憑證校驗"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:244
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:177
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1000
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1025
+msgid "None"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:784
+msgid "Only socks5 proxy support udp server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:780
+msgid "Please set proxy server first."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+msgid "Proxy Server Settings"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:567
+msgid "Proxy Server URL, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:575
+msgid ""
+"Proxy server URL format error, format: [socks5|http]://user:pass@ip:port."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:390
 msgid "Query DNS through specific dns server group, such as office, home."
 msgstr "使用指定伺服器組查詢，比如office, home。"
 
@@ -247,198 +534,294 @@ msgstr "使用指定伺服器組查詢，比如office, home。"
 msgid "RUNNING"
 msgstr "運行中"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:341
 msgid "Reply Domain TTL Max"
 msgstr "回應的域名 TTL 最大值"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:220
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:342
 msgid "Reply maximum TTL for all domain result."
 msgstr "設置返回给用戶端的域名 TTL 最大值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1150
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1151
+msgid "Report bugs"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve Local Hostnames"
 msgstr "解析本地主機名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:182
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:267
 msgid "Resolve local hostnames by reading Dnsmasq lease file."
 msgstr "讀取 Dnsmasq 的租約文檔解析本地主機名。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:502
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:209
+msgid "Response Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1174
 msgid "Restart"
 msgstr "重啟"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:493
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1165
 msgid "Restart Service"
 msgstr "重啟服務"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:133
 msgid "Second Server Settings"
 msgstr "第二 DNS 伺服器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:252
 msgid "Serve expired"
 msgstr "緩存過期服務"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:243
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:360
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:389
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:675
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:813
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:967
 msgid "Server Group"
 msgstr "伺服器組"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:833
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:987
+msgid "Server Group %s not exists"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Server Name"
 msgstr "伺服器名稱"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:435
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:807
 msgid "Set Specific domain ip address."
 msgstr "設置指定域名的 IP 位址。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:436
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:806
+msgid "Set Specific domain rule list."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:808
 msgid "Set Specific ip blacklist."
 msgstr "設置指定的 IP 黑名單列表。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:709
 msgid "Set TLS hostname to verify."
 msgstr "設置校驗 TLS 主機名。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:406
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:758
+msgid "Set mark on packets."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:738
 msgid ""
 "Set the HTTP host used for the query. Use this parameter when the host of "
 "the URL address is an IP address."
-msgstr "設置查詢時使用的 HTTP 主機，當 URL 位址的 host 是 IP 位址時，使用此參數。"
+msgstr ""
+"設置查詢時使用的 HTTP 主機，當 URL 位址的 host 是 IP 位址時，使用此參數。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
-msgid "Sets the server name indication for query."
-msgstr "設置查詢時使用的伺服器 SNI 名稱。"
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:728
+msgid "Sets the server name indication for query. '-' for disable SNI name."
+msgstr ""
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:124
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:128
 msgid "Settings"
 msgstr "設置"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:256
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:402
 msgid "Skip Address Rules"
 msgstr "跳過 address 规則"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache"
 msgstr "跳過 cache"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:285
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:431
 msgid "Skip Cache."
 msgstr "跳過 cache。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:279
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:425
 msgid "Skip Dualstack Selection"
 msgstr "跳過双栈優選"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:280
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:426
 msgid "Skip Dualstack Selection."
 msgstr "跳過双栈優選。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:268
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
 msgid "Skip Ipset Rule"
 msgstr "跳過 ipset 规則"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:408
 msgid "Skip Nameserver Rule"
 msgstr "跳過 Nameserver 规則"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:274
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:420
 msgid "Skip SOA Address Rule"
 msgstr "跳過 address SOA(#) 规則"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:275
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:421
 msgid "Skip SOA address rules."
 msgstr "跳過 address SOA(#) 规則。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:250
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:396
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:837
 msgid "Skip Speed Check"
 msgstr "跳過測速"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:257
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:403
 msgid "Skip address rules."
 msgstr "跳過 address 规則。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:269
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
 msgid "Skip ipset rules."
 msgstr "跳過 ipset 规則。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:263
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:409
 msgid "Skip nameserver rules."
 msgstr "跳過 Nameserver 规則。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:93
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
 #: applications/luci-app-smartdns/root/usr/share/luci/menu.d/luci-app-smartdns.json:3
 msgid "SmartDNS"
 msgstr "SmartDNS"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:94
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:96
 msgid "SmartDNS Server"
 msgstr "SmartDNS 伺服器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:95
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:97
 msgid ""
 "SmartDNS is a local high-performance DNS server, supports finding fastest "
 "IP, supports ad filtering, and supports avoiding DNS poisoning."
 msgstr "SmartDNS 是一个本地高性能 DNS 伺服器，支持返回最快 IP，支持廣告過濾。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:478
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1142
 msgid "SmartDNS official website"
 msgstr "SmartDNS 官方網站"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:231
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:377
 msgid "Smartdns local server port"
 msgstr "SmartDNS 本地服務通訊埠"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:143
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:154
 msgid ""
 "Smartdns local server port, smartdns will be automatically set as main dns "
 "when the port is 53."
 msgstr ""
-"SmartDNS 本地服務通訊埠，當通訊埠号設置為 53 時，smartdns 将会自動配置為主 dns。"
+"SmartDNS 本地服務通訊埠，當通訊埠号設置為 53 時，smartdns 将会自動配置為主 "
+"dns。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:136
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:210
+msgid ""
+"Smartdns response mode, First Ping: return the first ping IP, Fastest IP: "
+"return the fastest IP, Fastest Response: return the fastest DNS response."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:147
 msgid "Smartdns server name"
 msgstr "SmartDNS 的伺服器名稱，默认為 smartdns，留空為主機名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:440
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Smartdns speed check mode."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1119
 msgid ""
 "Specify an IP address to return for any host in the given domains, Queries "
 "in the domains are never forwarded and always replied to with the specified "
 "IP address which may be IPv4 or IPv6."
 msgstr ""
-"配置特定域名返回特定的 IP 位址，域名查詢将不到上游伺服器請求，直接返回配置的 IP"
-"位址，可用于廣告屏蔽。"
+"配置特定域名返回特定的 IP 位址，域名查詢将不到上游伺服器請求，直接返回配置的 "
+"IP位址，可用于廣告屏蔽。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:150
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:238
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:169
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1016
+msgid "Speed Check Mode"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1050
+msgid "Speed check mode is invalid."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:219
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:384
 msgid "TCP Server"
 msgstr "TCP 伺服器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:376
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:196
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1044
+msgid "TCP port is empty"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:708
 msgid "TLS Hostname Verify"
 msgstr "校驗 TLS 主機名"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:395
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:727
 msgid "TLS SNI name"
 msgstr "TLS SNI 名稱"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:414
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:746
 msgid "TLS SPKI Pinning"
 msgstr "TLS SPKI 指紋"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:202
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:324
 msgid "TTL for all domain result."
 msgstr "設置所有域名的 TTL 值。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:473
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1137
 msgid "Technical Support"
 msgstr "技術支持"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:316
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:539
+msgid "URL"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:548
+msgid "URL format error, format: http:// or https://"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:523
+msgid "Update"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:514
+msgid "Update Files"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:500
+msgid "Upload Config File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:507
+msgid "Upload Domain List File"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:508
+msgid "Upload domain list file to /etc/smartdns/domain-set"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:892
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:992
+msgid ""
+"Upload domain list file, or configure auto download from Download File "
+"Setting page."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:921
+msgid "Upload domain list file."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:501
+msgid "Upload smartdns config file to /etc/smartdns/conf.d"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:631
 msgid "Upstream Servers"
 msgstr "上游伺服器"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:317
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:632
 msgid ""
 "Upstream Servers, support UDP, TCP protocol. Please configure multiple DNS "
 "servers, including multiple foreign DNS servers."
@@ -446,7 +829,15 @@ msgstr ""
 "上游 DNS 伺服器，支持 UDP，TCP 協議。请配置多个上游 DNS 伺服器，包括多个国内"
 "外伺服器。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:415
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:765
+msgid "Use Proxy"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:766
+msgid "Use proxy to connect to upstream DNS server."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:747
 msgid ""
 "Used to verify the validity of the TLS server, The value is Base64 encoded "
 "SPKI fingerprint, leaving blank to indicate that the validity of TLS is not "
@@ -455,41 +846,82 @@ msgstr ""
 "用于校驗 TLS 伺服器的有效性，數值為 Base64 編碼的 SPKI 指紋，留空表示不驗證 "
 "TLS 的合法性。"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:354
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:262
+msgid "Write cache to disk on exit and load on startup."
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1013
+msgid "Yes"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:172
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:213
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:611
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1012
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1020
+msgid "default"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:555
+msgid "domain list (/etc/smartdns/domain-set)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:670
 msgid "https"
 msgstr "https"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:335
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:651
 msgid "ip"
 msgstr "ip"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:479
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:295
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:452
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:858
+msgid "ipset name format error, format: [#[4|6]:]ipsetname"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:1143
 msgid "open website"
 msgstr "打开網站"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:340
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:656
 msgid "port"
 msgstr "通訊埠"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:296
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:556
+msgid "smartdns config (/etc/smartdns/conf.d)"
+msgstr ""
+
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:585
 msgid "smartdns custom settings"
 msgstr "smartdns 自定義設置，具體配置參數參考指導"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:352
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:668
 msgid "tcp"
 msgstr "tcp"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:353
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:669
 msgid "tls"
 msgstr "tls"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:349
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:554
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:665
 msgid "type"
 msgstr "類型"
 
-#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:351
+#: applications/luci-app-smartdns/htdocs/luci-static/resources/view/smartdns/smartdns.js:667
 msgid "udp"
 msgstr "udp"
+
+#~ msgid ""
+#~ "DNS Server group belongs to, used with nameserver, such as office, home."
+#~ msgstr "DNS 伺服器所屬組， 配合 nameserver 使用，例如：office，home。"
+
+#~ msgid "Dnsmasq Forwared To Smartdns Failure"
+#~ msgstr "重定向 dnsmasq 到 smartdns 失敗"
+
+#~ msgid "Sets the server name indication for query."
+#~ msgstr "設置查詢時使用的伺服器 SNI 名稱。"
 
 #~ msgid "IPV4 53 Port Redirect Failure"
 #~ msgstr "IPV4 53 通訊埠重定向失敗"

--- a/applications/luci-app-smartdns/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
+++ b/applications/luci-app-smartdns/root/usr/share/rpcd/acl.d/luci-app-smartdns.json
@@ -13,7 +13,8 @@
 		"write": {
 			"file": {
 				"/etc/smartdns/*": [ "write" ],
-				"/etc/init.d/smartdns restart": [ "exec" ]
+				"/etc/init.d/smartdns restart": [ "exec" ],
+				"/etc/init.d/smartdns updatefiles": [ "exec" ]
 			},
 			"uci": [ "smartdns" ]
 		}


### PR DESCRIPTION
Maintainer: me / @<github-user> (find it by checking history of the package Makefile)
Compile tested: x86_64 openwrt docker image
Run tested: latest docker image, https://github.com/openwrt/packages/commit/21d02e598a0bf209cebc1c5b8f3e433913329107
Depends on https://github.com/openwrt/packages/pull/20939
