### PR TITLE
openvpn-advanced.lua request to add OpenVPN data-ciphers

### DIFF
--- a/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
+++ b/applications/luci-app-openvpn/luasrc/model/cbi/openvpn-advanced.lua
@@ -798,6 +798,10 @@ local knownParams = {
 			"ncp_ciphers",
 			"AES-256-GCM:AES-128-GCM",
 			translate("Restrict the allowed ciphers to be negotiated") },
+		{ Value,
+			"data_ciphers",
+			"CHACHA20-POLY1305:AES-256-GCM:AES-128-GCM:AES-256-CBC",  
+			translate("Restrict the allowed ciphers to be negotiated") },
 	} }
 }
 


### PR DESCRIPTION
Add OpenVPN data-ciphers.
ncp-ciphers are superseded by data-ciphers in OpenVPN 2.5.
Request to add data-ciphers.