### PR TITLE
luci-app-firewall: add missing ICMPv6 MLD types

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/rules.js
@@ -325,6 +325,9 @@ return view.extend({
 		o.value('mobile-prefix-advertisement'); /* icmpv6 147 */
 		o.value('mobile-prefix-solicitation'); /* icmpv6 146 */
 		o.value('mpl-control-message'); /* icmpv6 159 */
+		o.value('multicast-listener-query'); /* icmpv6 130 */
+		o.value('multicast-listener-report'); /* icmpv6 131 */
+		o.value('multicast-listener-done'); /* icmpv6 132 */
 		o.value('multicast-router-advertisement'); /* icmpv6 151 */
 		o.value('multicast-router-solicitation'); /* icmpv6 152 */
 		o.value('multicast-router-termination'); /* icmpv6 153 */


### PR DESCRIPTION
This adds entries for ICMPv6 MLD types. This fixes the ICMPv6 MLD types to be consistent with fw4. These types were added to fw4 in this [commit](https://github.com/openwrt/firewall4/commit/e6e82a55206cf7017f26b92f7097f779161b5cac) but were omitted from the corresponding luci-app-firewall [commit](https://github.com/openwrt/luci/commit/88a016cbff7eacf3a8248bc4949904abacef6685).
    

