### PR TITLE
[22.03] luci-app-https-dns-proxy: fix curl-related error in logs

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2022-10-15-11
+PKG_VERSION:=2022-10-15-14
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy

--- a/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
+++ b/applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua
@@ -103,7 +103,7 @@ else
 	end
 end
 
-if sys.call("curl --version | grep -q HTTP2") == 0 then
+if sys.call("grep -q 'Provides: libnghttp2' /usr/lib/opkg/status") == 0 then
 	http2Supported = true
 end
 

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -13,15 +13,11 @@ msgstr ""
 msgid "360 Secure DNS - CN"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.adguard-dns.dns-family.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns-family.lua:3
 msgid "AdGuard (Family Protection)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.adguard-dns.dns-nonfiltering.lua:3
-msgid "AdGuard (Non-filtering)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/io.adguard-dns.dns.lua:3
+#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.adguard.dns.lua:3
 msgid "AdGuard (Standard)"
 msgstr ""
 
@@ -169,17 +165,14 @@ msgstr ""
 msgid "Configuration"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware-ads-social.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p3.lua:3
 msgid "ControlD (Block Malware + Ads + Social)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware-ads.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p2.lua:3
 msgid "ControlD (Block Malware + Ads)"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.malware.lua:3
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p1.lua:3
 msgid "ControlD (Block Malware)"
 msgstr ""
@@ -189,7 +182,6 @@ msgid "ControlD (Family)"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.p0.lua:3
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/com.controld.freedns.unfiltered.lua:3
 msgid "ControlD (Unfiltered)"
 msgstr ""
 
@@ -456,10 +448,6 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/app.tiar.doh.lua:3
 msgid "Tiarap Public DNS - SG"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/luasrc/https-dns-proxy/providers/cn.edu.tsinghua.tuna.dns.lua:3
-msgid "Tsinghua University Secure DNS - CN"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/luasrc/model/cbi/https-dns-proxy.lua:65


### PR DESCRIPTION
* if curl is not installed, there used to be an error in logs from uhttpd that curl is not found, this commit addresses it

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 5553a66903a1889b52aeb2d36e3d9de455e45c2e)