### PR TITLE
docs: fix Client side JS API docs link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,5 +2,5 @@
 
 ## API Reference
 
- - [Client side JavaScript APIs](jsapi/index.html)
+ - [Client side JavaScript APIs](jsapi)
  - [Server side Lua APIs](api/index.html)


### PR DESCRIPTION
Previous link to index.html went to the 404 page. This links to the correct README.md file.