### PR TITLE
docs: fix Client side JS API docs link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,5 +2,5 @@
 
 ## API Reference
 
- - [Client side JavaScript APIs](jsapi/index.html)
+ - [Client side JavaScript APIs](jsapi/)
  - [Server side Lua APIs](api/index.html)


### PR DESCRIPTION
Link will work with the generated web documentation site as well as the Github README Markdown renderer.