### PR TITLE
luci-app-acme:  rename keylength to key_type 

### DIFF
--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -54,15 +54,15 @@ return view.extend({
 		o.rmempty = false;
 		o.modalonly = true;
 
-		o = s.taboption('general', form.ListValue, "keylength", _("Key size"),
+		o = s.taboption('general', form.ListValue, 'key_type', _("Key size"),
 			_("Key size (and type) for the generated certificate."));
-		o.value("2048", _("RSA 2048 bits"));
-		o.value("3072", _("RSA 3072 bits"));
-		o.value("4096", _("RSA 4096 bits"));
-		o.value("ec-256", _("ECC 256 bits"));
-		o.value("ec-384", _("ECC 384 bits"));
-		o.default = "2048";
+		o.value('rsa2048', _('RSA 2048 bits'));
+		o.value('rsa3072', _('RSA 3072 bits'));
+		o.value('rsa4096', _('RSA 4096 bits'));
+		o.value('ec256', _('ECC 256 bits'));
+		o.value('ec384', _('ECC 384 bits'));
 		o.rmempty = false;
+		o.optional = true;
 		o.modalonly = true;
 
 		o = s.taboption('general', form.DynamicList, "domains", _("Domain names"),

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -36,7 +36,8 @@ return view.extend({
 		s.nodescriptions = true;
 
 		o = s.tab("general", _("General Settings"));
-		o = s.tab("challenge", _("Challenge Validation"));
+		o = s.tab('challenge_webroot', _('Webroot Challenge Validation'));
+		o = s.tab('challenge_dns', _('DNS Challenge Validation'));
 		o = s.tab("advanced", _('Advanced Settings'));
 
 		o = s.taboption('general', form.Flag, "enabled", _("Enabled"));
@@ -48,24 +49,26 @@ return view.extend({
 				"Note that all domain names must point at the router in the global DNS."));
 		o.datatype = "list(string)";
 
-		o = s.taboption('challenge', form.ListValue, "validation_method", _("Validation method"),
+		o = s.taboption('general', form.ListValue, 'validation_method', _('Validation method'),
 			_("Standalone mode will use the built-in webserver of acme.sh to issue a certificate. " +
 			"Webroot mode will use an existing webserver to issue a certificate. " +
 			"DNS mode will allow you to use the DNS API of your DNS provider to issue a certificate."));
 		o.value("standalone", _("Standalone"));
 		o.value("webroot", _("Webroot"));
 		o.value("dns", _("DNS"));
-		o.default = "standalone";
+		o.default = 'webroot';
 
-		o = s.taboption('challenge', form.Value, "webroot", _("Webroot directory"),
+		o = s.taboption('challenge_webroot', form.Value, 'webroot', _('Webroot directory'),
 			_("Webserver root directory. Set this to the webserver " +
 				"document root to run Acme in webroot mode. The web " +
-				"server must be accessible from the internet on port 80."));
+				"server must be accessible from the internet on port 80.") + '<br/>' +
+			_("Default") + " <em>/var/run/acme/challenge/</em>"
+		);
 		o.optional = true;
 		o.depends("validation_method", "webroot");
 		o.modalonly = true;
 
-		o = s.taboption('challenge', form.Value, "dns", _("DNS API"),
+		o = s.taboption('challenge_dns', form.Value, 'dns', _('DNS API'),
 			_("To use DNS mode to issue certificates, set this to the name of a DNS API supported by acme.sh. " +
 				"See https://github.com/acmesh-official/acme.sh/wiki/dnsapi for the list of available APIs. " +
 				"In DNS mode, the domain name does not have to resolve to the router IP. " +
@@ -74,7 +77,7 @@ return view.extend({
 		o.depends("validation_method", "dns");
 		o.modalonly = true;
 
-		o = s.taboption('challenge', form.DynamicList, "credentials", _("DNS API credentials"),
+		o = s.taboption('challenge_dns', form.DynamicList, 'credentials', _('DNS API credentials'),
 			_("The credentials for the DNS API mode selected above. " +
 				"See https://github.com/acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required by each API. " +
 				"Add multiple entries here in KEY=VAL shell variable format to supply multiple credential variables."))
@@ -82,14 +85,14 @@ return view.extend({
 		o.depends("validation_method", "dns");
 		o.modalonly = true;
 
-		o = s.taboption('challenge', form.Value, "calias", _("Challenge Alias"),
+		o = s.taboption('challenge_dns', form.Value, 'calias', _('Challenge Alias'),
 			_("The challenge alias to use for ALL domains. " +
 				"See https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode for the details of this process. " +
 				"LUCI only supports one challenge alias per certificate."));
 		o.depends("validation_method", "dns");
 		o.modalonly = true;
 
-		o = s.taboption('challenge', form.Value, "dalias", _("Domain Alias"),
+		o = s.taboption('challenge_dns', form.Value, 'dalias', _('Domain Alias'),
 			_("The domain alias to use for ALL domains. " +
 				"See https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode for the details of this process. " +
 				"LUCI only supports one challenge domain per certificate."));

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -63,6 +63,7 @@ return view.extend({
 		o.value("ec-384", _("ECC 384 bits"));
 		o.default = "2048";
 		o.rmempty = false;
+		o.modalonly = true;
 
 		o = s.taboption('general', form.DynamicList, "domains", _("Domain names"),
 			_("Domain names to include in the certificate. " +
@@ -154,6 +155,7 @@ return view.extend({
 		o.optional    = true;
 		o.placeholder = 90;
 		o.datatype    = 'uinteger';
+		o.modalonly = true;
 
 		return m.render()
 	}

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -21,7 +21,9 @@ return view.extend({
 				"Note that the domain names in the certificate must already be configured to " +
 				"point at the router's public IP address. " +
 				"Once configured, issuing certificates can take a while. " +
-				"Check the logs for progress and any errors."));
+				"Check the logs for progress and any errors.") + '<br/>' +
+				_("Cert files are stored in") + ' <em>/etc/ssl/acme<em>'
+		);
 
 		s = m.section(form.TypedSection, "acme", _("ACME global config"));
 		s.anonymous = true;

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -6,6 +6,8 @@
 
 return view.extend({
 	render: function (stats) {
+		let wikiUrl = 'https://github.com/acmesh-official/acme.sh/wiki/';
+		var wikiInstructionUrl = wikiUrl + 'dnsapi';
 		var m, s, o;
 
 		m = new form.Map("acme", _("ACME certificates"),
@@ -68,14 +70,362 @@ return view.extend({
 		o.depends("validation_method", "webroot");
 		o.modalonly = true;
 
-		o = s.taboption('challenge_dns', form.Value, 'dns', _('DNS API'),
+		o = s.taboption('challenge_dns', form.ListValue, 'dns', _('DNS API'),
 			_("To use DNS mode to issue certificates, set this to the name of a DNS API supported by acme.sh. " +
 				"See https://github.com/acmesh-official/acme.sh/wiki/dnsapi for the list of available APIs. " +
 				"In DNS mode, the domain name does not have to resolve to the router IP. " +
 				"DNS mode is also the only mode that supports wildcard certificates. " +
 				"Using this mode requires the acme-dnsapi package to be installed."));
 		o.depends("validation_method", "dns");
+		// List of supported DNS API. Names are same as file names in acme.sh for easier search.
+		// May be outdated but not changed too often.
+		o.value('', '')
+		o.value('dns_acmedns', 'ACME DNS API github.com/joohoi/acme-dns');
+		o.value('dns_acmeproxy', 'ACME Proxy github.com/mdbraber/acmeproxy');
+		o.value('dns_1984hosting', '1984.is');
+		o.value('dns_active24', 'Active24.com');
+		o.value('dns_ad', 'Alwaysdata.com');
+		o.value('dns_ali', 'Alibaba Cloud Aliyun.com');
+		o.value('dns_anx', 'Anexia.com');
+		o.value('dns_arvan', 'ArvanCloud.ir');
+		o.value('dns_aurora', 'AuroraDNS.eu');
+		o.value('dns_autodns', 'autoDNS (InternetX)');
+		o.value('dns_aws', 'Amazon AWS Route53');
+		o.value('dns_azion', 'Azion.com');
+		o.value('dns_azure', 'Azure');
+		o.value('dns_bunny', 'Bunny.net');
+		o.value('dns_cf', 'CloudFlare.com');
+		o.value('dns_clouddns', 'CloudDNS vshosting.cz');
+		o.value('dns_cloudns', 'ClouDNS.net');
+		o.value('dns_cn', 'Core-Networks.de');
+		o.value('dns_conoha', 'ConoHa.io');
+		o.value('dns_constellix', 'constellix.com');
+		o.value('dns_cpanel', 'CPanel');
+		o.value('dns_curanet', 'curanet.dk scannet.dk wannafind.dk dandomain.dk');
+		o.value('dns_cyon', 'cayon.ch');
+		o.value('dns_da', 'DirectAdmin Panel');
+		o.value('dns_ddnss', 'DDNSS.de');
+		o.value('dns_desec', 'deSEC.io');
+		o.value('dns_df', 'DynDnsFree.de');
+		o.value('dns_dgon', 'DigitalOcean.com');
+		o.value('dns_dnshome', 'dnsHome.de');
+		o.value('dns_dnsimple', 'DNSimple.com');
+		o.value('dns_dnsservices', 'dns.services');
+		o.value('dns_doapi', 'Domain-Offensive do.de');
+		o.value('dns_domeneshop', 'DomeneShop.no');
+		o.value('dns_dp', 'DNSPod.cn');
+		o.value('dns_dpi', 'DNSPod.com');
+		o.value('dns_dreamhost', 'DreamHost.com');
+		o.value('dns_duckdns', 'DuckDNS.org');
+		o.value('dns_durabledns', 'DurableDNS.com');
+		o.value('dns_dyn', 'Dyn.com');
+		o.value('dns_dynu', 'Dynu.com');
+		o.value('dns_dynv6', 'DynV6.com');
+		o.value('dns_easydns', 'EasyDNS.net');
+		o.value('dns_edgedns', 'Akamai Edge DNS');
+		o.value('dns_euserv', 'euserv.eu');
+		o.value('dns_exoscale', 'Exoscale.com');
+		o.value('dns_fornex', 'fornex.com');
+		o.value('dns_freedns', 'FreeDNS.afraid.org');
+		o.value('dns_gandi_livedns', 'LiveDNS.Gandi.net');
+		// o.value('dns_gcloud', 'Google Cloud gcloud client');
+		o.value('dns_gcore', 'Gcore.com');
+		o.value('dns_gd', 'GoDaddy.com');
+		o.value('dns_geoscaling', 'Geoscaling.com');
+		o.value('dns_googledomains', 'Google Domains');
+		o.value('dns_he', 'he.net');
+		o.value('dns_hetzner', 'Hetzner.com');
+		o.value('dns_hexonet', 'Hexonet.net');
+		o.value('dns_hostingde', 'Hosting.de');
+		o.value('dns_huaweicloud', 'MyHuaweiCloud.com');
+		o.value('dns_infoblox', 'Infoblox');
+		o.value('dns_infomaniak', 'InfoManiak.com');
+		o.value('dns_internetbs', 'InternetBS.net');
+		o.value('dns_inwx', 'inwx.de');
+		o.value('dns_ionos', 'IONOS.com');
+		o.value('dns_ipv64', 'ipv64.net');
+		o.value('dns_ispconfig', 'ISPConfig Server');
+		o.value('dns_jd', 'JDCloud.com');
+		o.value('dns_joker', 'Joker.com');
+		o.value('dns_kappernet', 'kapper.net');
+		o.value('dns_kas', 'kasserver.com');
+		o.value('dns_kinghost', 'KingHost.net');
+		o.value('dns_la', 'dns.la');
+		o.value('dns_leaseweb', 'leaseweb.com');
+		// o.value('dns_lexicon', 'Lexicon client');
+		o.value('dns_linode_v4', 'Linode.com');
+		o.value('dns_loopia', 'Loopia.se');
+		o.value('dns_lua', 'LuaDNS.com');
+		// o.value('dns_maradns', 'MaraDNS Server zone file');
+		o.value('dns_me', 'DNSMadeEasy.com');
+		// o.value('dns_miab', 'Mail-in-a-Box Server API');
+		o.value('dns_misaka', 'misaka.io');
+		o.value('dns_mydevil', 'MyDevil.net');
+		o.value('dns_mydnsjp', 'MyDNS.JP');
+		o.value('dns_mythic_beasts', 'Mythic-Beasts.com');
+		o.value('dns_namecheap', 'NameCheap.com');
+		o.value('dns_namecom', 'Name.com');
+		o.value('dns_namesilo', 'NameSilo.com');
+		o.value('dns_nanelo', 'Nanelo.com');
+		o.value('dns_nederhost', 'NederHost.nl');
+		o.value('dns_neodigit', 'Neodigit.net');
+		o.value('dns_netcup', 'netcup.eu netcup.de');
+		o.value('dns_netlify', 'Netlify.com');
+		o.value('dns_nic', 'nic.ru');
+		o.value('dns_njalla', 'Njalla njal.la');
+		o.value('dns_nm', 'NameMaster.de');
+		// o.value('dns_nsd', 'NSD Server zone file');
+		o.value('dns_nsone', 'NS1 nsone.net');
+		o.value('dns_nsupdate', 'nsupdate (RFC2136) Server');
+		o.value('dns_nw', 'Nexcess.net');
+		o.value('dns_oci', 'Oracle Cloud Infrastructure (OCI)');
+		o.value('dns_one', 'one.com');
+		o.value('dns_online', 'online.net');
+		o.value('dns_openprovider', 'OpenProvider.com');
+		// o.value('dns_openstack', 'OpenStack Client');
+		o.value('dns_opnsense', 'OPNsense Bind API');
+		o.value('dns_ovh', 'OVH ovh.com ovhcloud.com kimsufi.com soyoustart.com');
+		o.value('dns_pdns', 'PowerDNS Server');
+		o.value('dns_pleskxml', 'plesk.com XML API');
+		o.value('dns_pointhq', 'PointDNS pointhq.com');
+		o.value('dns_porkbun', 'Porkbun.com');
+		o.value('dns_rackcorp', 'RackCorp.com');
+		o.value('dns_rackspace', 'RackSpace rackspacecloud.com');
+		o.value('dns_rage4', 'rage4.com');
+		o.value('dns_rcode0', 'Rcode0 rcodezero.at');
+		o.value('dns_regru', 'Reg.ru');
+		o.value('dns_scaleway', 'Scaleway.com');
+		o.value('dns_schlundtech', 'Schlundtech.de');
+		o.value('dns_selectel', 'Selectel.ru');
+		o.value('dns_selfhost', 'selfhost.de');
+		o.value('dns_servercow', 'servercow.de');
+		o.value('dns_simply', 'Simply.com');
+		o.value('dns_tele3', 'tele3.cz');
+		o.value('dns_transip', 'transip.nl');
+		o.value('dns_udr', 'ud-reselling.com');
+		o.value('dns_ultra', 'UltraDNS.com');
+		o.value('dns_variomedia', 'variomedia.de');
+		o.value('dns_veesp', 'veesp.com');
+		o.value('dns_vercel', 'Vercel.com');
+		o.value('dns_vscale', 'vscale.io');
+		o.value('dns_vultr', 'vultr.com');
+		o.value('dns_websupport', 'websupport.sk');
+		o.value('dns_world4you', 'World4You.com');
+		o.value('dns_yandex', 'Yandex DNS dns.yandex.ru');
+		o.value('dns_yc', 'Yandex Cloud cloud.yandex.net');
+		o.value('dns_zilore', 'zilore.com');
+		o.value('dns_zone', 'Zone.ee');
+		o.value('dns_zonomi', 'Zonomi.com');
 		o.modalonly = true;
+		o.onchange = L.bind(_handleCheckService, o, s);
+
+		o = s.taboption('challenge_dns', form.DummyValue, '_wiki_url', _('See instructions'), '');
+		o.rawhtml = true;
+		o.default = '<a id="wikiInstructionUrl" href="%s" target="_blank" rel="noreferrer">Acme Wiki DNS API</a>'
+			.format(wikiInstructionUrl);
+		o.depends('validation_method', 'dns');
+		o.modalonly = true;
+
+		_addDnsProviderField(s, 'dns_1984hosting', 'One984HOSTING_Username', '1984.is Username', '');
+		_addDnsProviderField(s, 'dns_1984hosting', 'One984HOSTING_Password', '1984.is Password', '');
+
+		_addDnsProviderField(s, 'dns_acmedns', 'ACMEDNS_BASE_URL', 'ACMEDNS URL', '');
+		_addDnsProviderField(s, 'dns_acmedns', 'ACMEDNS_USERNAME', 'ACMEDNS User', '');
+		_addDnsProviderField(s, 'dns_acmedns', 'ACMEDNS_PASSWORD', 'ACMEDNS Password', '');
+		_addDnsProviderField(s, 'dns_acmedns', 'ACMEDNS_SUBDOMAIN', 'ACMEDNS Subdomain', '');
+
+		_addDnsProviderField(s, 'dns_ali', 'Ali_Key', 'Ali Key', '');
+		_addDnsProviderField(s, 'dns_ali', 'Ali_Secret', 'Ali Secret', '');
+
+		_addDnsProviderField(s, 'dns_aws', 'AWS_ACCESS_KEY_ID', 'AWS access key id', '');
+		_addDnsProviderField(s, 'dns_aws', 'AWS_SECRET_ACCESS_KEY', 'AWS secret access key', '');
+
+		_addDnsProviderField(s, 'dns_azure', 'AZUREDNS_SUBSCRIPTIONID', 'Azure Subscription ID', '');
+		_addDnsProviderField(s, 'dns_azure', 'AZUREDNS_TENANTID', 'Azure Tenant ID', '');
+		_addDnsProviderField(s, 'dns_azure', 'AZUREDNS_APPID', 'Azure App ID', '');
+		_addDnsProviderField(s, 'dns_azure', 'AZUREDNS_CLIENTSECRET', 'Azure Client Secret', '');
+
+		_addDnsProviderField(s, 'dns_bunny', 'BUNNY_API_KEY', 'Bunny API Key', '');
+
+		_addDnsProviderField(s, 'dns_cf', 'CF_Key', 'CF Key', '');
+		_addDnsProviderField(s, 'dns_cf', 'CF_Email', 'CF Email', '');
+		_addDnsProviderField(s, 'dns_cf', 'CF_Token', 'CF Token', '');
+		_addDnsProviderField(s, 'dns_cf', 'CF_Account_ID', 'CF Account ID', '');
+		_addDnsProviderField(s, 'dns_cf', 'CF_Zone_ID', 'CF Zone ID', '');
+
+		_addDnsProviderField(s, 'dns_ddnss', 'DDNSS_Token', 'DDNSS.de Token', '');
+
+		_addDnsProviderField(s, 'dns_desec', 'DEDYN_TOKEN', 'deSEC.io Token', '');
+
+		_addDnsProviderField(s, 'dns_duckdns', 'DuckDNS_Token', 'DuckDNS Token',
+			_('Open <a href="https://www.duckdns.org/">DuckDNS</a> and copy a token here')
+		);
+
+		_addDnsProviderField(s, 'dns_dynv6', 'DYNV6_TOKEN', 'DynV6 Token', '');
+
+		_addDnsProviderField(s, 'dns_dnsimple', 'DNSimple_OAUTH_TOKEN', 'DNSimple OAuth TOKEN', '');
+
+		_addDnsProviderField(s, 'dns_dgon', 'DO_API_KEY', 'Digital Ocean API Key', '');
+
+		_addDnsProviderField(s, 'dns_dreamhost', 'DH_API_KEY', 'DreamHost.com API Key', '');
+
+		_addDnsProviderField(s, 'dns_df', 'DF_user', 'DynDnsFree.de Username', '');
+		_addDnsProviderField(s, 'dns_df', 'DF_password', 'DynDnsFree.de Password', '');
+
+		_addDnsProviderField(s, 'dns_gandi_livedns', 'GANDI_LIVEDNS_KEY', 'Gandi LiveDNS Key', '');
+
+		_addDnsProviderField(s, 'dns_gcore', 'GCORE_Key', 'GCore Key', '');
+
+		_addDnsProviderField(s, 'dns_gd', 'GD_Key', 'GoDaddy.com Key', '');
+		_addDnsProviderField(s, 'dns_gd', 'GD_Secret', 'GoDaddy.com Secret', '');
+
+		_addDnsProviderField(s, 'dns_geoscaling', 'GEOSCALING_Username', 'Geoscaling.com Username',
+			_('This is usually NOT an email address')
+		);
+		_addDnsProviderField(s, 'dns_geoscaling', 'GEOSCALING_Password', 'Geoscaling.com Password', '');
+
+		_addDnsProviderField(s, 'dns_googledomains', 'GOOGLEDOMAINS_ACCESS_TOKEN', 'Google Domains Access Token', '');
+		_addDnsProviderField(s, 'dns_googledomains', 'GOOGLEDOMAINS_ZONE', 'Google Domains Zone', '');
+
+		_addDnsProviderField(s, 'dns_he', 'HE_Username', 'dns.he.net Username', '');
+		_addDnsProviderField(s, 'dns_he', 'HE_Password', 'dns.he.net Password', '');
+
+		_addDnsProviderField(s, 'dns_hetzner', 'HETZNER_Token', 'Hetzner Token', '');
+
+		_addDnsProviderField(s, 'dns_he', 'dns_hexonet', 'Hexonet.net Login', 'username!roleId');
+		_addDnsProviderField(s, 'dns_he', 'dns_hexonet', 'Hexonet.net Password', '');
+
+		_addDnsProviderField(s, 'dns_huaweicloud', 'HUAWEICLOUD_Username', 'MyHuaweiCloud.com Username', '');
+		_addDnsProviderField(s, 'dns_huaweicloud', 'HUAWEICLOUD_Password', 'MyHuaweiCloud.com Password', '');
+		_addDnsProviderField(s, 'dns_huaweicloud', 'HUAWEICLOUD_DomainName', 'MyHuaweiCloud.com Domain Name', '');
+
+		_addDnsProviderField(s, 'dns_infomaniak', 'INFOMANIAK_API_TOKEN', 'InfoManiak Token', '');
+
+		_addDnsProviderField(s, 'dns_ipv64', 'IPv64_Token', 'ipv64.net Token', '');
+
+		_addDnsProviderField(s, 'dns_jd', 'JD_ACCESS_KEY_ID', 'JDCloud.com Access Key ID', '');
+		_addDnsProviderField(s, 'dns_jd', 'JD_ACCESS_KEY_SECRET', 'JDCloud.com Access Key Secret', '');
+		_addDnsProviderField(s, 'dns_jd', 'JD_REGION', 'JDCloud.com Region', 'cn-north-1');
+
+		_addDnsProviderField(s, 'dns_joker', 'JOKER_USERNAME', 'Joker.com User', '');
+		_addDnsProviderField(s, 'dns_joker', 'JOKER_PASSWORD', 'Joker.com Password', '');
+
+		_addDnsProviderField(s, 'dns_freedns', 'FREEDNS_User', 'FreeDNS User', '');
+		_addDnsProviderField(s, 'dns_freedns', 'FREEDNS_Password', 'FreeDNS Password', '');
+
+		_addDnsProviderField(s, 'dns_la', 'LA_Id', 'dns.la Id', '');
+		_addDnsProviderField(s, 'dns_la', 'LA_Key', 'dns.la Key', '');
+
+		_addDnsProviderField(s, 'dns_linodev4', 'LINODE_V4_API_KEY', 'Linode API Key', '');
+
+		_addDnsProviderField(s, 'dns_loopia', 'LOOPIA_User', 'Loopia User', '');
+		_addDnsProviderField(s, 'dns_loopia', 'LOOPIA_Password', 'Loopia Password', '');
+
+		_addDnsProviderField(s, 'dns_lua', 'LUA_Email', 'luadns.com email', '');
+		_addDnsProviderField(s, 'dns_lua', 'LUA_Key', 'luadns.com Key', '');
+
+		_addDnsProviderField(s, 'dns_mydnsjp', 'MYDNSJP_MasterID', 'MyDNS.jp MasterID', '');
+		_addDnsProviderField(s, 'dns_mydnsjp', 'MYDNSJP_Password', 'MyDNS.jp Password', '');
+
+		_addDnsProviderField(s, 'dns_me', 'ME_Key', 'DNSMadeEasy Key', '');
+		_addDnsProviderField(s, 'dns_me', 'ME_Secret', 'DNSMadeEasy Secret', '');
+
+		_addDnsProviderField(s, 'dns_namecom', 'Namecom_Username', 'Name.com Username', '');
+		_addDnsProviderField(s, 'dns_namecom', 'Namecom_Token', 'Name.com Token', '');
+
+		_addDnsProviderField(s, 'dns_namecheap', 'NAMECHEAP_API_KEY', 'NameCheap API Key', '');
+		_addDnsProviderField(s, 'dns_namecheap', 'NAMECHEAP_USERNAME', 'NameCheap User', '');
+		_addDnsProviderField(s, 'dns_namecheap', 'NAMECHEAP_SOURCEIP', 'NameCheap Source IP', '');
+
+		_addDnsProviderField(s, 'dns_nic', 'NIC_ClientID', 'Nic.ru ClientID', '');
+		_addDnsProviderField(s, 'dns_nic', 'NIC_ClientSecret', 'Nic.ru ClientSecret', '');
+		_addDnsProviderField(s, 'dns_nic', 'NIC_Username', 'Nic.ru Username', '');
+		_addDnsProviderField(s, 'dns_nic', 'NIC_Password', 'Nic.ru Password', '');
+
+		_addDnsProviderField(s, 'dns_netlify', 'NETLIFY_ACCESS_TOKEN', 'Netlify Access Token', '');
+
+		_addDnsProviderField(s, 'dns_nsone', 'NS1_Key', 'nsone.net Key', '');
+
+		_addDnsProviderField(s, 'dns_nsupdate', 'NSUPDATE_SERVER', 'nsupdate server address', '');
+		_addDnsProviderField(s, 'dns_nsupdate', 'NSUPDATE_SERVER_PORT', 'nsupdate server port', '');
+		_addDnsProviderField(s, 'dns_nsupdate', 'NSUPDATE_KEY', 'nsupdate key file path', '');
+		_addDnsProviderField(s, 'dns_nsupdate', 'NSUPDATE_ZONE', 'nsupdate zone', '');
+
+		_addDnsProviderField(s, 'dns_nsupdate', 'OCI_CLI_TENANCY', 'OCI Tenancy',
+			_('OCID of tenancy that contains the target DNS zone')
+		);
+		_addDnsProviderField(s, 'dns_nsupdate', 'OCI_CLI_USER', 'OCI User',
+			_('OCID of user with permission to add/remove records from zones')
+		);
+		_addDnsProviderField(s, 'dns_nsupdate', 'OCI_CLI_REGION', 'OCI Region',
+			_('Should point to the tenancy home region')
+		);
+		_addDnsProviderField(s, 'dns_nsupdate', 'OCI_CLI_KEY_FILE', 'OCI Key file',
+			_('Path to private API signing key file in PEM format')
+		);
+		_addDnsProviderField(s, 'dns_nsupdate', 'OCI_CLI_KEY', 'OCI Key',
+			_('The private API signing key in PEM format')
+		);
+
+		_addDnsProviderField(s, 'dns_ovh', 'OVH_AK', 'OVH Application Key', '');
+		_addDnsProviderField(s, 'dns_ovh', 'OVH_AS', 'OVH Application Secret', '');
+		_addDnsProviderField(s, 'dns_ovh', 'OVH_CK', 'OVH Consumer Key', '');
+		_addDnsProviderField(s, 'dns_ovh', 'OVH_END_POINT', 'OVH Region/Endpoint',
+			'ovh-eu, ovh-us, ovh-ca, kimsufi-eu, kimsufi-ca, soyoustart-eu, soyoustart-ca'
+		);
+
+		_addDnsProviderField(s, 'dns_pdns', 'PDNS_Url', 'PDNS API URL', '');
+		_addDnsProviderField(s, 'dns_pdns', 'PDNS_ServerId', 'PDNS Server ID', '');
+		_addDnsProviderField(s, 'dns_pdns', 'PDNS_Token', 'PDNS Token', '');
+		_addDnsProviderField(s, 'dns_pdns', 'PDNS_Ttl', 'PDNS Default TTL', '60');
+
+		_addDnsProviderField(s, 'dns_porkbun', 'PORKBUN_API_KEY', 'Porkbun API Key', '');
+		_addDnsProviderField(s, 'dns_porkbun', 'PORKBUN_SECRET_API_KEY', 'Porkbun API Secret', '');
+
+		_addDnsProviderField(s, 'dns_rackspace', 'RACKSPACE_Apikey', 'RackSpace API Key', '');
+		_addDnsProviderField(s, 'dns_rackspace', 'RACKSPACE_Username', 'Porkbun Username', '');
+
+		_addDnsProviderField(s, 'dns_regru', 'REGRU_API_Username', 'reg.ru Username', '');
+		_addDnsProviderField(s, 'dns_regru', 'REGRU_API_Password', 'reg.ru Password', '');
+
+		_addDnsProviderField(s, 'dns_selectel', 'SL_Key', 'Selectel API Key', '');
+
+		_addDnsProviderField(s, 'dns_selfhost', 'SELFHOSTDNS_USERNAME', 'SelfHost.de Username', '');
+		_addDnsProviderField(s, 'dns_selfhost', 'SELFHOSTDNS_PASSWORD', 'SelfHost.de Password', '');
+		_addDnsProviderField(s, 'dns_selfhost', 'SELFHOSTDNS_MAP', 'SelfHost.de Domains map',
+			_('E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</code>')
+		);
+
+		_addDnsProviderField(s, 'dns_simply', 'SIMPLY_AccountName', 'Simply.com account name', '');
+		_addDnsProviderField(s, 'dns_simply', 'SIMPLY_ApiKey', 'Simply.com API Key', '');
+
+		_addDnsProviderField(s, 'dns_tele3', 'TELE3_Key', 'tele3.cz API Key', '');
+		_addDnsProviderField(s, 'dns_tele3', 'TELE3_Secret', 'tele3.cz API Secret', '');
+
+		_addDnsProviderField(s, 'dns_vultr', 'VULTR_API_KEY', 'Vultr API Secret', '');
+
+		_addDnsProviderField(s, 'dns_vscale', 'VSCALE_API_KEY', 'vscale.io API Key', '');
+
+		_addDnsProviderField(s, 'dns_yandex', 'PDD_Token', 'Yandex DNS API Token', '');
+
+		_addDnsProviderField(s, 'dns_yandex', 'PDD_Token', 'Yandex DNS API Token', '');
+
+		_addDnsProviderField(s, 'dns_yc', 'YC_Zone_ID', 'Yandex Cloud: DNS Zone ID', '');
+		_addDnsProviderField(s, 'dns_yc', 'YC_Folder_ID', 'Yandex Cloud: YC Folder ID', '');
+		_addDnsProviderField(s, 'dns_yc', 'YC_SA_ID', 'Yandex Cloud: Service Account ID', '');
+		_addDnsProviderField(s, 'dns_yc', 'YC_SA_Key_ID', 'Yandex Cloud: Service Account IAM Key ID', '');
+		_addDnsProviderField(s, 'dns_yc', 'YC_SA_Key_File_Path', 'Yandex Cloud: Path to private key', '');
+		_addDnsProviderField(s, 'dns_yc', 'YC_SA_Key_File_PEM_b64', 'Yandex Cloud: PEM of private key',
+			_('Base64 content of private key. Use instead of YC_SA_Key_File_Path')
+		);
+
+		_addDnsProviderField(s, 'dns_zilore', 'Zilore_Key', 'Zilore API Key', '');
+
+		_addDnsProviderField(s, 'dns_zone', 'ZONE_Username', 'Zone.ee Username', '');
+		_addDnsProviderField(s, 'dns_zone', 'ZONE_Key', 'Zone.ee API Key', '');
+
+		_addDnsProviderField(s, 'dns_zonomi', 'ZM_Key', 'Zonomi.com API Key', '');
+
 
 		o = s.taboption('challenge_dns', form.DynamicList, 'credentials', _('DNS API credentials'),
 			_("The credentials for the DNS API mode selected above. " +
@@ -164,3 +514,47 @@ return view.extend({
 	}
 })
 
+
+function _addDnsProviderField(s, provider, env, title, desc) {
+	let o = s.taboption('challenge_dns', form.Value, '_' + env, _(title),
+		_(desc));
+	o.depends('dns', provider);
+	o.modalonly = true;
+	o.cfgvalue = function (section_id, stored_val) {
+		var creds = this.map.data.get(this.map.config, section_id, 'credentials');
+		return _extractParamValue(creds, env);
+	};
+	o.write = function (section_id, value) {
+		this.map.data.set('acme', section_id, 'credentials', [env + '="' + value + '"']);
+	};
+	return o;
+}
+
+/**
+ * @param {string[]} paramsKeyVals
+ * @param {string} paramName
+ * @returns {string}
+ */
+function _extractParamValue(paramsKeyVals, paramName) {
+	if (!paramsKeyVals) {
+		return '';
+	}
+	for (let i = 0; i < paramsKeyVals.length; i++) {
+		var paramKeyVal = paramsKeyVals[i];
+		var parts = paramKeyVal.split('=');
+		if (parts.lenght < 2) {
+			continue;
+		}
+		var name = parts[0];
+		var val = parts[1];
+		if (name == paramName) {
+			// unquote
+			return val.substring(0, val.length-1).substring(1);
+		}
+	}
+	return '';
+}
+
+function _handleCheckService(c, event, curVal, newVal) {
+	document.getElementById('wikiInstructionUrl').href = 'https://github.com/acmesh-official/acme.sh/wiki/dnsapi#' + newVal;
+}

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -5,13 +5,6 @@
 'require view';
 
 return view.extend({
-	load: function () {
-		return Promise.all([
-			L.resolveDefault(fs.stat('/usr/sbin/nginx'), {}),
-			L.resolveDefault(fs.stat('/usr/sbin/uhttpd'), {})
-		]);
-	},
-
 	render: function (stats) {
 		var m, s, o;
 
@@ -54,25 +47,6 @@ return view.extend({
 				"The first name will be the subject name, subsequent names will be alt names. " +
 				"Note that all domain names must point at the router in the global DNS."));
 		o.datatype = "list(string)";
-
-		if (stats[1].type === 'file') {
-			o = s.taboption('general', form.Flag, "update_uhttpd", _("Use for uhttpd"),
-				_("Update the uhttpd config with this certificate once issued " +
-					"(only select this for one certificate). " +
-					"Is also available luci-app-uhttpd to configure uhttpd form the LuCI interface."));
-			o.rmempty = false;
-			o.modalonly = true;
-		}
-
-		if (stats[0].type === 'file') {
-			o = s.taboption('general', form.Flag, "update_nginx", _("Use for nginx"),
-				_("Update the nginx config with this certificate once issued " +
-					"(only select this for one certificate). " +
-					"Nginx must support ssl, if not it won't start as it needs to be " +
-					"compiled with ssl support to use cert options"));
-			o.rmempty = false;
-			o.modalonly = true;
-		}
 
 		o = s.taboption('challenge', form.ListValue, "validation_method", _("Validation method"),
 			_("Standalone mode will use the built-in webserver of acme.sh to issue a certificate. " +

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -473,7 +473,7 @@ return view.extend({
 		o.rmempty = false;
 		o.modalonly = true;
 
-		o = s.taboption('advanced', form.ListValue, 'key_type', _('Key size'),
+		o = s.taboption('advanced', form.ListValue, 'key_type', _('Key type'),
 			_('Key size (and type) for the generated certificate.')
 		);
 		o.value('rsa2048', _('RSA 2048 bits'));

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -49,43 +49,6 @@ return view.extend({
 		o = s.taboption('general', form.Flag, "enabled", _("Enabled"));
 		o.rmempty = false;
 
-		o = s.taboption('general', form.Flag, "use_staging", _("Use staging server"),
-			_("Get certificate from the Letsencrypt staging server " +
-				"(use for testing; the certificate won't be valid)."));
-		o.rmempty = false;
-		o.modalonly = true;
-
-		o = s.taboption('general', form.ListValue, 'key_type', _("Key size"),
-			_("Key size (and type) for the generated certificate."));
-		o.value('rsa2048', _('RSA 2048 bits'));
-		o.value('rsa3072', _('RSA 3072 bits'));
-		o.value('rsa4096', _('RSA 4096 bits'));
-		o.value('ec256', _('ECC 256 bits'));
-		o.value('ec384', _('ECC 384 bits'));
-		o.rmempty = false;
-		o.optional = true;
-		o.modalonly = true;
-		o.cfgvalue = function(section_id, set_value) {
-			var keylength = uci.get('acme', section_id, 'keylength');
-			if (keylength) {
-				// migrate the old keylength to a new keytype
-				switch (keylength) {
-					case '2048': return 'rsa2048';
-					case '3072': return 'rsa3072';
-					case '4096': return 'rsa4096';
-					case 'ec-256': return 'ec256';
-					case 'ec-384': return 'ec384';
-					default: return ''; // bad value
-				}
-			}
-			return set_value;
-		};
-		o.write = function(section_id, value) {
-			// remove old keylength
-			uci.unset('acme', section_id, 'keylength');
-			uci.set('acme', section_id, 'key_type', value);
-		};
-
 		o = s.taboption('general', form.DynamicList, "domains", _("Domain names"),
 			_("Domain names to include in the certificate. " +
 				"The first name will be the subject name, subsequent names will be alt names. " +
@@ -158,6 +121,48 @@ return view.extend({
 				"LUCI only supports one challenge domain per certificate."));
 		o.depends("validation_method", "dns");
 		o.modalonly = true;
+
+
+		o = s.taboption('advanced', form.Flag, 'use_staging', _('Use staging server'),
+			_(
+				'Get certificate from the Letsencrypt staging server ' +
+				'(use for testing; the certificate won\'t be valid).'
+			)
+		);
+		o.rmempty = false;
+		o.modalonly = true;
+
+		o = s.taboption('advanced', form.ListValue, 'key_type', _('Key size'),
+			_('Key size (and type) for the generated certificate.')
+		);
+		o.value('rsa2048', _('RSA 2048 bits'));
+		o.value('rsa3072', _('RSA 3072 bits'));
+		o.value('rsa4096', _('RSA 4096 bits'));
+		o.value('ec256', _('ECC 256 bits'));
+		o.value('ec384', _('ECC 384 bits'));
+		o.rmempty = false;
+		o.optional = true;
+		o.modalonly = true;
+		o.cfgvalue = function(section_id, set_value) {
+			var keylength = uci.get('acme', section_id, 'keylength');
+			if (keylength) {
+				// migrate the old keylength to a new keytype
+				switch (keylength) {
+					case '2048': return 'rsa2048';
+					case '3072': return 'rsa3072';
+					case '4096': return 'rsa4096';
+					case 'ec-256': return 'ec256';
+					case 'ec-384': return 'ec384';
+					default: return ''; // bad value
+				}
+			}
+			return set_value;
+		};
+		o.write = function(section_id, value) {
+			// remove old keylength
+			uci.unset('acme', section_id, 'keylength');
+			uci.set('acme', section_id, 'key_type', value);
+		};
 
 		o = s.taboption('advanced', form.Flag, "use_acme_server",
 			_("Custom ACME CA"), _("Use a custom CA instead of Let's Encrypt."));

--- a/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
+++ b/applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js
@@ -25,7 +25,9 @@ return view.extend({
 		s.anonymous = true;
 
 		o = s.option(form.Value, "account_email", _("Account email"),
-			_("Email address to associate with account key."))
+			_('Email address to associate with account key.') + '<br/>' +
+			_('If a certificate wasn\'t renewed in time then you\'ll receive a notice at 20 days before expiry.')
+		)
 		o.rmempty = false;
 		o.datatype = "minlength(1)";
 

--- a/applications/luci-app-acme/po/ar/acme.po
+++ b/applications/luci-app-acme/po/ar/acme.po
@@ -12,12 +12,9 @@ msgstr ""
 "X-Generator: Weblate 4.5.1\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "‍ شهادات بيئة إدارة الشهادات التلقائية"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr "شهادات بيئة إدارة الشهادات التلقائية"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
@@ -331,3 +328,6 @@ msgid ""
 msgstr ""
 "الدليل الجذر لخادم الويب. اضبط هذا على جذر وثيقة خادم الويب لتشغيل Acme في "
 "وضع webroot. يجب الوصول إلى خادم الويب من الإنترنت على المنفذ 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "شهادات بيئة إدارة الشهادات التلقائية"

--- a/applications/luci-app-acme/po/ar/acme.po
+++ b/applications/luci-app-acme/po/ar/acme.po
@@ -44,8 +44,11 @@ msgid "Challenge Alias"
 msgstr "الاسم المستعار لاعتراض"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "التحقق من صحة التحدي"
+msgid "DNS Challenge Validation"
+msgstr "DNS التحقق من صحة التحدي"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot التحقق من صحة التحدي"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/ar/acme.po
+++ b/applications/luci-app-acme/po/ar/acme.po
@@ -154,13 +154,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "حجم المفتاح"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "حجم المفتاح (والنوع) للشهادة التي تم إنشاؤها."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "حجم المفتاح"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/ar/acme.po
+++ b/applications/luci-app-acme/po/ar/acme.po
@@ -155,7 +155,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "حجم المفتاح"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/ar/acme.po
+++ b/applications/luci-app-acme/po/ar/acme.po
@@ -278,8 +278,5 @@ msgstr ""
 "الدليل الجذر لخادم الويب. اضبط هذا على جذر وثيقة خادم الويب لتشغيل Acme في "
 "وضع webroot. يجب الوصول إلى خادم الويب من الإنترنت على المنفذ 80."
 
-#~ msgid "State directory"
-#~ msgstr "دليل الدولة"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "حيث يتم حفظ شهادات وملفات الدولة الأخرى."
+msgid "Cert files are stored in"
+msgstr "حيث يتم حفظ شهادات وملفات الدولة الأخرى."

--- a/applications/luci-app-acme/po/ar/acme.po
+++ b/applications/luci-app-acme/po/ar/acme.po
@@ -222,36 +222,9 @@ msgstr ""
 "إلى IP الخاص بالموجه. وضع DNS هو أيضًا الوضع الوحيد الذي يدعم شهادات أحرف "
 "البدل. يتطلب استخدام هذا الوضع تثبيت حزمة acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"قم بتحديث nginx config بهذه الشهادة بمجرد إصدارها (حدد هذا فقط لشهادة "
-"واحدة). يجب أن يدعم nginx SSL ، إذا لم يكن كذلك ، فلن يبدأ لأنه يحتاج إلى "
-"تجميع مع دعم SSL لاستخدام خيارات الشهادة"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"قم بتحديث تكوين uhttpd بهذه الشهادة بمجرد إصدارها (حدد هذا فقط لشهادة "
-"واحدة). كما يتوفر luci-app-uhttpd لتكوين uhttpd من واجهة LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "استخدم مرجع مصدق (CA) مخصصًا بدلاً من Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "استخدم ل nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "استخدم ل uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/ar/acme.po
+++ b/applications/luci-app-acme/po/ar/acme.po
@@ -11,7 +11,7 @@ msgstr ""
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 "X-Generator: Weblate 4.5.1\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "‍ شهادات بيئة إدارة الشهادات التلقائية"
 
@@ -19,70 +19,83 @@ msgstr "‍ شهادات بيئة إدارة الشهادات التلقائية
 msgid "ACME certs"
 msgstr "شهادات بيئة إدارة الشهادات التلقائية"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "التكوين العالمي لبيئة إدارة الشهادات التلقائية"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "عنوان URL لخادم ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "حساب البريد الإلكتروني"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "إعدادات متقدمة"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "حيث يتم حفظ شهادات وملفات الدولة الأخرى."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "تكوين الشهادة"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "الاسم المستعار لاعتراض"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS التحقق من صحة التحدي"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot التحقق من صحة التحدي"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "مخصص ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "عنوان URL مخصص لدليل خادم ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "نظام أسماء النطاقات"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "واجهة برمجة تطبيقات لنظام أسماء النطاقات"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "مؤهلات واجهة برمجة تطبيقات لنظام أسماء النطاقات"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS التحقق من صحة التحدي"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "الأيام حتى التجديد"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "الاسم المستعار للنطاق"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "أسماء النطاقات"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -92,31 +105,37 @@ msgstr ""
 "وستكون الأسماء اللاحقة أسماء بديلة. لاحظ أن جميع أسماء النطاقات يجب أن تشير "
 "إلى جهاز التوجيه في نظام أسماء النطاقات العام."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 بت"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 بت"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "عنوان البريد الإلكتروني لربطه بمفتاح الحساب."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "مكن السجل للتصحيح البرمجي"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "مفعل"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "الاعدادات العامة"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -128,31 +147,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "منح الوصول فريد معرف العميل ل luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "حجم المفتاح"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "حجم المفتاح (والنوع) للشهادة التي تم إنشاؤها."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 بت"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 بت"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 بت"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "مستقل"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "Webroot خادم ويب موجودًا لإصدار شهادة. سيسمح لك وضع DNS باستخدام DNS API "
 "لمزود DNS الخاص بك لإصدار شهادة."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode للاطلاع على تفاصيل "
 "هذه العملية. يدعم LUCI اسمًا مستعارًا واحدًا فقط للاعتراض لكل شهادة."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -185,7 +251,7 @@ msgstr ""
 "الاعتماد التي تتطلبها كل واجهة برمجة تطبيقات. أضف إدخالات متعددة هنا في "
 "تنسيق متغير shell \"KEY = VAL\" لتوفير متغيرات اعتماد متعددة."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -195,7 +261,11 @@ msgstr ""
 "acmesh-official/acme.sh/wiki/DNS-alias-mode عن تفاصيل هذه العملية. لوسي يدعم "
 "فقط واحد التحدي المجال لكل شهادة."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -210,7 +280,11 @@ msgstr ""
 "بروتوكول الإنترنت العام لجهاز التوجيه. بمجرد التكوين ، يمكن أن يستغرق إصدار "
 "الشهادات بعض الوقت. يمكنك التحقق من سجلات التقدم وأية أخطاء."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -225,27 +299,31 @@ msgstr ""
 "إلى IP الخاص بالموجه. وضع DNS هو أيضًا الوضع الوحيد الذي يدعم شهادات أحرف "
 "البدل. يتطلب استخدام هذا الوضع تثبيت حزمة acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "استخدم مرجع مصدق (CA) مخصصًا بدلاً من Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "استخدم خادم الترحيل"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "طريقة التحقق من الصحة"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot التحقق من صحة التحدي"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "دليل Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -253,6 +331,3 @@ msgid ""
 msgstr ""
 "الدليل الجذر لخادم الويب. اضبط هذا على جذر وثيقة خادم الويب لتشغيل Acme في "
 "وضع webroot. يجب الوصول إلى خادم الويب من الإنترنت على المنفذ 80."
-
-msgid "Cert files are stored in"
-msgstr "حيث يتم حفظ شهادات وملفات الدولة الأخرى."

--- a/applications/luci-app-acme/po/bg/acme.po
+++ b/applications/luci-app-acme/po/bg/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.9-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME сертификати"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME сертификати"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -300,3 +297,6 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME сертификати"

--- a/applications/luci-app-acme/po/bg/acme.po
+++ b/applications/luci-app-acme/po/bg/acme.po
@@ -148,12 +148,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/bg/acme.po
+++ b/applications/luci-app-acme/po/bg/acme.po
@@ -193,30 +193,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/bg/acme.po
+++ b/applications/luci-app-acme/po/bg/acme.po
@@ -149,7 +149,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/bg/acme.po
+++ b/applications/luci-app-acme/po/bg/acme.po
@@ -242,6 +242,5 @@ msgid ""
 "port 80."
 msgstr ""
 
-#, fuzzy
-#~ msgid "State directory"
-#~ msgstr "Директория на състоянието"
+msgid "Cert files are stored in"
+msgstr "Директория със сертификати"

--- a/applications/luci-app-acme/po/bg/acme.po
+++ b/applications/luci-app-acme/po/bg/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME сертификати"
 
@@ -18,101 +18,120 @@ msgstr "ACME сертификати"
 msgid "ACME certs"
 msgstr "ACME сертификати"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME глобални настройки"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL на ACME сървър"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Имейл на акаунта"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Разширени настройки"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Директория със сертификати"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Конфигурация на сертификат"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Проверка на предизвикателство"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Проверка на предизвикателство"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Персонализиран ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API креденшъли"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Проверка на предизвикателство"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Дни до подновяване"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Имена на домейни"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Разрешен"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Основни настройки"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -122,31 +141,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -154,14 +220,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -169,14 +235,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -186,7 +256,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -196,32 +270,33 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Проверка на предизвикателство"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
-
-msgid "Cert files are stored in"
-msgstr "Директория със сертификати"

--- a/applications/luci-app-acme/po/bg/acme.po
+++ b/applications/luci-app-acme/po/bg/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Проверка на предизвикателство"
+msgid "DNS Challenge Validation"
+msgstr "DNS Проверка на предизвикателство"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Проверка на предизвикателство"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/bn_BD/acme.po
+++ b/applications/luci-app-acme/po/bn_BD/acme.po
@@ -265,6 +265,3 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
-
-#~ msgid "State directory"
-#~ msgstr "স্টেট ডিরেক্টরি"

--- a/applications/luci-app-acme/po/bn_BD/acme.po
+++ b/applications/luci-app-acme/po/bn_BD/acme.po
@@ -217,30 +217,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/bn_BD/acme.po
+++ b/applications/luci-app-acme/po/bn_BD/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.9-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME সার্টিফিকেট"
 
@@ -18,70 +18,83 @@ msgstr "ACME সার্টিফিকেট"
 msgid "ACME certs"
 msgstr "ACME সার্টিফিকেট"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME গ্লোবাল কনফিগ"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACME সার্ভার URL"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "অ্যাকাউন্ট ইমেইল"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "উন্নত সেটিংস"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "সার্টিফিকেট কনফিগারেশন"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "চ্যালেঞ্জ উপনাম"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS চ্যালেঞ্জ বৈধতা"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot চ্যালেঞ্জ বৈধতা"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "কাস্টম ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "কাস্টম ACME সার্ভার ডিরেক্টরি URL।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "ডিএনএস"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API ক্রিডেনশিয়াল"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS চ্যালেঞ্জ বৈধতা"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "নবায়ন পর্যন্ত দিন"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "ডোমেইন উপনাম"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "ডোমেইন উপনাম"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "হবে বিকল্প নাম। মনে রাখবেন যে সমস্ত ডোমেইন নাম অবশ্যই বৈশ্বিক DNS- এর রাউটারে "
 "নির্দেশ করতে হবে।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 বিট"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 বিট"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "অ্যাকাউন্ট কী এর সাথে যুক্ত করার জন্য ইমেইল ঠিকানা।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "ডিবাগ লগিং সক্রিয় করুন"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "সক্রিয়"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "সাধারণ সেটিংস"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Luci-app-acme এর জন্য UCI অ্যাক্সেস প্রদান করুন"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "কী সাইজ"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "সার্টিফিকেট উৎপন্ন করার জন্য কী সাইজ (এবং প্রকার)।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 বিট"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 বিট"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 বিট"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "স্বতন্ত্র"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "করবে। ডিএনএস মোড আপনার ডিএনএস প্রদানকারীর ডিএনএস এপিআই ব্যবহার করে সার্টিফিকেট "
 "ইস্যু করবে।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode দেখুন। LUCI শুধুমাত্র "
 "একটি সার্টিফিকেট চ্যালেঞ্জ উপনাম সমর্থন করে।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -185,7 +251,7 @@ msgstr ""
 "একাধিক ক্রিডেনশিয়াল ভেরিয়েবল সরবরাহ করতে এখানে KEY = VAL শেল ভেরিয়েবল ফরম্যাটে "
 "একাধিক এন্ট্রি যুক্ত করুন।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -195,7 +261,11 @@ msgstr ""
 "https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode। LUCI শুধুমাত্র "
 "একটি সার্টিফিকেট চ্যালেঞ্জ ডোমেইন সমর্থন করে।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -210,7 +280,11 @@ msgstr ""
 "ঠিকানায় নির্দেশ করার জন্য কনফিগার করা আবশ্যক। একবার কনফিগার হয়ে গেলে, "
 "সার্টিফিকেট ইস্যু করতে কিছু সময় লাগতে পারে। অগ্রগতি এবং কোন ত্রুটির জন্য লগ চেক করুন।"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -220,27 +294,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot চ্যালেঞ্জ বৈধতা"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/bn_BD/acme.po
+++ b/applications/luci-app-acme/po/bn_BD/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.9-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME সার্টিফিকেট"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME সার্টিফিকেট"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -324,3 +321,6 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME সার্টিফিকেট"

--- a/applications/luci-app-acme/po/bn_BD/acme.po
+++ b/applications/luci-app-acme/po/bn_BD/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "কী সাইজ"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "সার্টিফিকেট উৎপন্ন করার জন্য কী সাইজ (এবং প্রকার)।"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "কী সাইজ"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/bn_BD/acme.po
+++ b/applications/luci-app-acme/po/bn_BD/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "চ্যালেঞ্জ উপনাম"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "চ্যালেঞ্জ বৈধতা"
+msgid "DNS Challenge Validation"
+msgstr "DNS চ্যালেঞ্জ বৈধতা"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot চ্যালেঞ্জ বৈধতা"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/bn_BD/acme.po
+++ b/applications/luci-app-acme/po/bn_BD/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "কী সাইজ"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/ca/acme.po
+++ b/applications/luci-app-acme/po/ca/acme.po
@@ -42,8 +42,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/ca/acme.po
+++ b/applications/luci-app-acme/po/ca/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.5.2-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr ""
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36

--- a/applications/luci-app-acme/po/ca/acme.po
+++ b/applications/luci-app-acme/po/ca/acme.po
@@ -148,12 +148,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/ca/acme.po
+++ b/applications/luci-app-acme/po/ca/acme.po
@@ -193,30 +193,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/ca/acme.po
+++ b/applications/luci-app-acme/po/ca/acme.po
@@ -149,7 +149,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/ca/acme.po
+++ b/applications/luci-app-acme/po/ca/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5.2-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr ""
 
@@ -18,100 +18,120 @@ msgstr ""
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Configuració avançada"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Activat"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Paràmetres generals"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -121,31 +141,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -153,14 +220,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -168,14 +235,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -185,7 +256,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -195,27 +270,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/cs/acme.po
+++ b/applications/luci-app-acme/po/cs/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Certifikáty ACME"
 
@@ -18,69 +18,83 @@ msgstr "Certifikáty ACME"
 msgid "ACME certs"
 msgstr "Certifikáty ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Globální konfigurace ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL serveru ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "E-mail k účtu"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Pokročilá nastavení"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Kde jsou uchovávány certifikáty a další stavové soubory."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Konfigurace certifikátu"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Aliasy"
 
-msgid "DNS Challenge Validation"
-msgstr "DNS Validace"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Validace"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Vlastní ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "Adresář URL vlastního serveru ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API pověření"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Validace"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Dny do obnovení"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Alias domény"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Doménové názvy"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -90,31 +104,37 @@ msgstr ""
 "jméno subjektu, další jsou alternativní názvy. Mějte na paměti, že všechny "
 "doménové názvy musejí v globálním DNS ukazovat na router."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bitů"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bitů"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "E-mailová adresa pro přiřazení ke klíči účtu."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Povolit ladicí protokolování"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Zapnuto"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Obecná nastavení"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -126,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Udělit přístup UCI pro luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Velikost klíče"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Velikost (a typ) klíče pro generovaný certifikát."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bitů"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bitů"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bitů"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Samostatný"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -161,7 +228,7 @@ msgstr ""
 "acme.sh. Režim webroot bude používat existující webový server. DNS režim "
 "bude umožňovat použití DNS API vašeho poskytovatele DNS."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -172,20 +239,20 @@ msgstr ""
 "DNS-alias-mode. Rozhraní LUCI podporuje pouze jeden alias výzvy na "
 "certifikát."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
 "by each API. Add multiple entries here in KEY=VAL shell variable format to "
 "supply multiple credential variables."
 msgstr ""
-"Přihlašovací údaje pro zvolený režim DNS API. Podívejte se na adresu "
-"https://github.com/acmesh-official/acme.sh/wiki/dnsapi, jaký formát "
-"přihlašovacích údajů je požadován pro každé API. Přidejte zde více položek v "
-"formátu proměnné shellu KLÍČ=HODNOTA, abyste mohli poskytnout více "
-"přihlašovacích proměnných."
+"Přihlašovací údaje pro zvolený režim DNS API. Podívejte se na adresu https://"
+"github.com/acmesh-official/acme.sh/wiki/dnsapi, jaký formát přihlašovacích "
+"údajů je požadován pro každé API. Přidejte zde více položek v formátu "
+"proměnné shellu KLÍČ=HODNOTA, abyste mohli poskytnout více přihlašovacích "
+"proměnných."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -195,7 +262,11 @@ msgstr ""
 "official/acme.sh/wiki/DNS-alias-mode pro více informací o tomto procesu. "
 "LUCI podporuje jen jednu challenge doménu pro každý certifikát."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -212,7 +283,11 @@ msgstr ""
 "bude chvíli trvat. Kontrolujte protokoly, kde uvidíte průběh a jakékoli "
 "chyby."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -228,27 +303,31 @@ msgstr ""
 "také jediným režimem, který podporuje vydávání wildcard certifikátů. Použití "
 "tohoto režimu vyžaduje instalaci balíčku acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Namísto Let's Encrypt použít vlastní CA."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Použijte pracovní server"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Metoda ověření"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Validace"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Adresář Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -257,6 +336,3 @@ msgstr ""
 "Kořenový adresář webového serveru. Pro spuštění ACME v režimu webroot "
 "nastavte tento adresář jako kořen webu ve webovém serveru. Server musí být "
 "přístupný z Internetu na portu 80."
-
-msgid "Cert files are stored in"
-msgstr "Kde jsou uchovávány certifikáty a další stavové soubory."

--- a/applications/luci-app-acme/po/cs/acme.po
+++ b/applications/luci-app-acme/po/cs/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Velikost klíče"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/cs/acme.po
+++ b/applications/luci-app-acme/po/cs/acme.po
@@ -285,8 +285,5 @@ msgstr ""
 "nastavte tento adresář jako kořen webu ve webovém serveru. Server musí být "
 "přístupný z Internetu na portu 80."
 
-#~ msgid "State directory"
-#~ msgstr "Stavový adresář"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Kde jsou uchovávány certifikáty a další stavové soubory."
+msgid "Cert files are stored in"
+msgstr "Kde jsou uchovávány certifikáty a další stavové soubory."

--- a/applications/luci-app-acme/po/cs/acme.po
+++ b/applications/luci-app-acme/po/cs/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.16.2-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Certifikáty ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Certifikáty ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -336,3 +333,6 @@ msgstr ""
 "Kořenový adresář webového serveru. Pro spuštění ACME v režimu webroot "
 "nastavte tento adresář jako kořen webu ve webovém serveru. Server musí být "
 "přístupný z Internetu na portu 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Certifikáty ACME"

--- a/applications/luci-app-acme/po/cs/acme.po
+++ b/applications/luci-app-acme/po/cs/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Velikost klíče"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Velikost (a typ) klíče pro generovaný certifikát."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Velikost klíče"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/cs/acme.po
+++ b/applications/luci-app-acme/po/cs/acme.po
@@ -42,9 +42,11 @@ msgstr "Konfigurace certifikátu"
 msgid "Challenge Alias"
 msgstr "Aliasy"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Validace"
+msgid "DNS Challenge Validation"
+msgstr "DNS Validace"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Validace"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/cs/acme.po
+++ b/applications/luci-app-acme/po/cs/acme.po
@@ -226,38 +226,9 @@ msgstr ""
 "také jediným režimem, který podporuje vydávání wildcard certifikátů. Použití "
 "tohoto režimu vyžaduje instalaci balíčku acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Aktualizovat konfiguraci nginx s tímto certifikátem po jeho vydání (zvolte "
-"pouze pro jeden certifikát). Nginx musí podporovat SSL, pokud ne, nebude "
-"spuštěn, protože musí být kompilován s podporou SSL pro použití "
-"certifikačních možností"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Aktualizovat konfiguraci uhttpd s tímto certifikátem po jeho vydání (zvolte "
-"pouze pro jeden certifikát). Je také k dispozici luci-app-uhttpd pro "
-"konfiguraci uhttpd z rozhraní LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Namísto Let's Encrypt použít vlastní CA."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Použít pro nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Použít pro uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/da/acme.po
+++ b/applications/luci-app-acme/po/da/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Udfordr Alias"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Udfordringsvalidering"
+msgid "DNS Challenge Validation"
+msgstr "DNS Udfordringsvalidering"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Udfordringsvalidering"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/da/acme.po
+++ b/applications/luci-app-acme/po/da/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Nøglestørrelse"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Nøglestørrelse (og -type) for det genererede certifikat."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Nøglestørrelse"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/da/acme.po
+++ b/applications/luci-app-acme/po/da/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME-certifikater"
 
@@ -18,70 +18,83 @@ msgstr "ACME-certifikater"
 msgid "ACME certs"
 msgstr "ACME certs"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME global konfiguration"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL til ACME-serveren"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Konto e-mail"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Avancerede indstillinger"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Hvor certifikater og andre stat filer opbevares."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Certifikatkonfiguration"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Udfordr Alias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Udfordringsvalidering"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Udfordringsvalidering"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Brugerdefineret ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "Brugerdefineret URL til ACME-serverens mappe."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS-API legitimationsoplysninger"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Udfordringsvalidering"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Antal dage indtil fornyelse"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Domænealias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Domænenavne"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "emnet, de efterfølgende navne vil være alt-navne. Bemærk, at alle "
 "domænenavne skal pege på routeren i den globale DNS."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "E-mail-adresse, der skal knyttes til kontonøglen."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Aktivér debug logning"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Aktiver"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Generelle indstillinger"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Giv UCI-adgang til luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Nøglestørrelse"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Nøglestørrelse (og -type) for det genererede certifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Standalone"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "til at udstede et certifikat. DNS-tilstand giver dig mulighed for at bruge "
 "DNS API'et hos din DNS-udbyder til at udstede et certifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -174,7 +240,7 @@ msgstr ""
 "oplysninger om denne proces. LUCI understøtter kun ét udfordringsalias pr. "
 "certifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -186,7 +252,7 @@ msgstr ""
 "legitimationsoplysninger, der kræves af hvert API. Tilføj flere poster her i "
 "formatet KEY=VAL shellvariabel for at angive flere legitimationsvariabler."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -196,7 +262,11 @@ msgstr ""
 "acmesh-official/acme.sh/wiki/DNS-alias-mode for nærmere oplysninger om denne "
 "proces. LUCI understøtter kun ét udfordringsdomæne pr. certifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -213,7 +283,11 @@ msgstr ""
 "certifikater tage et stykke tid. Kontroller logfilerne for fremskridt og "
 "eventuelle fejl."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -230,27 +304,31 @@ msgstr ""
 "der understøtter wildcard-certifikater. Brug af denne tilstand kræver, at "
 "pakken acme-dnsapi er installeret."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Brug en brugerdefineret CA i stedet for Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Brug staging-server"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Valideringsmetode"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Udfordringsvalidering"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webroot-mappen"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -259,6 +337,3 @@ msgstr ""
 "Webserverens rodmappe. Indstil denne til webserverens dokumentrod for at "
 "køre Acme i webroot-tilstand. Webserveren skal være tilgængelig fra "
 "internettet på port 80."
-
-msgid "Cert files are stored in"
-msgstr "Hvor certifikater og andre stat filer opbevares."

--- a/applications/luci-app-acme/po/da/acme.po
+++ b/applications/luci-app-acme/po/da/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Nøglestørrelse"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/da/acme.po
+++ b/applications/luci-app-acme/po/da/acme.po
@@ -286,8 +286,5 @@ msgstr ""
 "køre Acme i webroot-tilstand. Webserveren skal være tilgængelig fra "
 "internettet på port 80."
 
-#~ msgid "State directory"
-#~ msgstr "State mappe"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Hvor certifikater og andre stat filer opbevares."
+msgid "Cert files are stored in"
+msgstr "Hvor certifikater og andre stat filer opbevares."

--- a/applications/luci-app-acme/po/da/acme.po
+++ b/applications/luci-app-acme/po/da/acme.po
@@ -227,38 +227,9 @@ msgstr ""
 "der understøtter wildcard-certifikater. Brug af denne tilstand kræver, at "
 "pakken acme-dnsapi er installeret."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Opdater nginx-konfigurationen med dette certifikat, når det er udstedt (vælg "
-"kun dette for ét certifikat). Nginx skal understøtte ssl, hvis ikke vil den "
-"ikke starte, da den skal kompileres med ssl-understøttelse for at kunne "
-"bruge cert-indstillinger"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Opdater uhttpd-konfigurationen med dette certifikat, når det er udstedt "
-"(vælg kun dette for ét certifikat). Er også tilgængelig luci-app-uhttpd til "
-"at konfigurere uhttpd fra LuCI-grænsefladen."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Brug en brugerdefineret CA i stedet for Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Brug til nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Brug til uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/da/acme.po
+++ b/applications/luci-app-acme/po/da/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 4.18-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "ACME-certifikater"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr "ACME certs"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
@@ -337,3 +334,6 @@ msgstr ""
 "Webserverens rodmappe. Indstil denne til webserverens dokumentrod for at "
 "køre Acme i webroot-tilstand. Webserveren skal være tilgængelig fra "
 "internettet på port 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME certs"

--- a/applications/luci-app-acme/po/de/acme.po
+++ b/applications/luci-app-acme/po/de/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Schlüsselgröße"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/de/acme.po
+++ b/applications/luci-app-acme/po/de/acme.po
@@ -228,39 +228,9 @@ msgstr ""
 "Platzhalterzertifikate unterstützt. Für die Verwendung dieses Modus muss das "
 "acme-dnsapi-Paket installiert sein."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Aktualisieren Sie die Nginx-Konfiguration mit diesem einmal ausgestellten "
-"Zertifikat (wählen Sie dies nur für ein Zertifikat aus). Nginx muss ssl "
-"unterstützen. Andernfalls wird es nicht gestartet, da es mit ssl-"
-"Unterstützung kompiliert werden muss, um Zertifizierungsoptionen verwenden "
-"zu können"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Aktualisieren Sie die uhttpd-Konfiguration mit diesem einmal ausgestellten "
-"Zertifikat (wählen Sie dies nur für ein Zertifikat aus). Es ist auch luci-"
-"app-uhttpd verfügbar, um uhttpd über die LuCI-Schnittstelle zu konfigurieren."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Nutze individuelles Zertifikat statt Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Für nginx verwenden"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Für uhttpd verwenden"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/de/acme.po
+++ b/applications/luci-app-acme/po/de/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Challenge-Alias"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Challenge-Verifizierung"
+msgid "DNS Challenge Validation"
+msgstr "DNS Challenge-Verifizierung"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Challenge-Verifizierung"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/de/acme.po
+++ b/applications/luci-app-acme/po/de/acme.po
@@ -288,8 +288,5 @@ msgstr ""
 "ein, um Acme im Webroot-Modus auszuführen. Der Webserver muss über Port 80 "
 "über das Internet erreichbar sein."
 
-#~ msgid "State directory"
-#~ msgstr "Statusverzeichnis"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Wo Zertifikate und andere Statusdateien aufbewahrt werden."
+msgid "Cert files are stored in"
+msgstr "Wo Zertifikate und andere Statusdateien aufbewahrt werden."

--- a/applications/luci-app-acme/po/de/acme.po
+++ b/applications/luci-app-acme/po/de/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Schlüsselgröße"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Schlüsselgröße (und Typ) für das generierte Zertifikat."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Schlüsselgröße"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/de/acme.po
+++ b/applications/luci-app-acme/po/de/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME-Zertifikate"
 
@@ -18,70 +18,83 @@ msgstr "ACME-Zertifikate"
 msgid "ACME certs"
 msgstr "ACME-Zertifikate"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Globale ACME-Einstellungen"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACME-Server URL"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Account E-Mail"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Wo Zertifikate und andere Statusdateien aufbewahrt werden."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Zertifikateinstellungen"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Challenge-Alias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Challenge-Verifizierung"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Challenge-Verifizierung"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Individuelles ACME-Zertifikat"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "Benutzerdefinierte ACME-Serververzeichnis URL."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API Zugangsdaten"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Challenge-Verifizierung"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Tage bis zur Erneuerung"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Domain-Alias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Domainnamen"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "Eintrag ist der Betreff, nachfolgende Namen sind Alternativnamen. Beachten "
 "Sie, dass alle Domainamen im globalen DNS auf den Router zeigen müssen."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 Bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 Bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "E-Mail Adresse, welche mit dem Account Key verknüpft wird."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Aktiviere Debug-Protokollierung"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Allgemeine Einstellungen"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "UCI Zugriff auf luci-app-acme erlauben"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Schlüsselgröße"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Schlüsselgröße (und Typ) für das generierte Zertifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 Bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 Bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 Bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Eigenständig"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "Webserver genutzt. Der DNS-Modus erlaubt es, die API deines DNS-Providers "
 "für die Zertifikatausstellung zu verwenden."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "Vorgang finden Sie unter https://github.com/acmesh-official/acme.sh/wiki/DNS-"
 "alias-mode. LUCI unterstützt nur einen Challenge-Alias pro Zertifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -186,7 +252,7 @@ msgstr ""
 "Einträge im Shell-Variablenformat KEY = VAL hinzu, um mehrere "
 "Anmeldeinformationsvariablen bereitzustellen."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -196,7 +262,11 @@ msgstr ""
 "official/acme.sh/wiki/DNS-alias-mode für Details zu diesem Prozess. LUCI "
 "unterstützt nur eine Domänenanforderung pro Zertifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -214,7 +284,11 @@ msgstr ""
 "Zertifikaten eine Weile dauern. Überprüfen Sie die Protokolle auf "
 "Fortschritt und Fehler."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -231,27 +305,31 @@ msgstr ""
 "Platzhalterzertifikate unterstützt. Für die Verwendung dieses Modus muss das "
 "acme-dnsapi-Paket installiert sein."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Nutze individuelles Zertifikat statt Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Staging-Server verwenden"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Überprüfungsmethode"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Challenge-Verifizierung"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webroot-Verzeichnis"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -260,6 +338,3 @@ msgstr ""
 "Webserver-Stammverzeichnis. Stellen Sie dies auf den Webserver-Dokumentstamm "
 "ein, um Acme im Webroot-Modus auszuführen. Der Webserver muss über Port 80 "
 "über das Internet erreichbar sein."
-
-msgid "Cert files are stored in"
-msgstr "Wo Zertifikate und andere Statusdateien aufbewahrt werden."

--- a/applications/luci-app-acme/po/de/acme.po
+++ b/applications/luci-app-acme/po/de/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME-Zertifikate"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME-Zertifikate"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -338,3 +335,6 @@ msgstr ""
 "Webserver-Stammverzeichnis. Stellen Sie dies auf den Webserver-Dokumentstamm "
 "ein, um Acme im Webroot-Modus auszuführen. Der Webserver muss über Port 80 "
 "über das Internet erreichbar sein."
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME-Zertifikate"

--- a/applications/luci-app-acme/po/el/acme.po
+++ b/applications/luci-app-acme/po/el/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 4.5-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "ACME πιστοποιητικά"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"

--- a/applications/luci-app-acme/po/el/acme.po
+++ b/applications/luci-app-acme/po/el/acme.po
@@ -42,8 +42,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/el/acme.po
+++ b/applications/luci-app-acme/po/el/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.5-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME πιστοποιητικά"
 
@@ -18,100 +18,120 @@ msgstr "ACME πιστοποιητικά"
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Λογαριασμός email"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Ρυθμίσεις για προχωρημένους"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Μέρες μέχρι την ανανέωση"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Ενεργοποιήθηκε"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Γενικές ρυθμίσεις"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -121,31 +141,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -153,14 +220,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -168,14 +235,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -185,7 +256,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -195,27 +270,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Μέθοδος επιβεβαίωσης"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/el/acme.po
+++ b/applications/luci-app-acme/po/el/acme.po
@@ -148,12 +148,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/el/acme.po
+++ b/applications/luci-app-acme/po/el/acme.po
@@ -193,30 +193,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/el/acme.po
+++ b/applications/luci-app-acme/po/el/acme.po
@@ -149,7 +149,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/en/acme.po
+++ b/applications/luci-app-acme/po/en/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/en/acme.po
+++ b/applications/luci-app-acme/po/en/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.4.1-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME certificates"
 
@@ -18,69 +18,83 @@ msgstr "ACME certificates"
 msgid "ACME certs"
 msgstr "ACME certs"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME global config"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Account email"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Advanced Settings"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Certificate config"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Challenge Alias"
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API credentials"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Domain Alias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Domain names"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -90,31 +104,37 @@ msgstr ""
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Email address to associate with account key."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Enable debug logging"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Enabled"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -126,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -158,14 +225,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -173,14 +240,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -190,7 +261,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -200,27 +275,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/en/acme.po
+++ b/applications/luci-app-acme/po/en/acme.po
@@ -153,12 +153,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/en/acme.po
+++ b/applications/luci-app-acme/po/en/acme.po
@@ -198,30 +198,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/en/acme.po
+++ b/applications/luci-app-acme/po/en/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 4.4.1-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "ACME certificates"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr "ACME certs"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
@@ -305,3 +302,6 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME certs"

--- a/applications/luci-app-acme/po/en/acme.po
+++ b/applications/luci-app-acme/po/en/acme.po
@@ -42,8 +42,10 @@ msgstr "Certificate config"
 msgid "Challenge Alias"
 msgstr "Challenge Alias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/es/acme.po
+++ b/applications/luci-app-acme/po/es/acme.po
@@ -156,7 +156,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Tamaño de clave"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/es/acme.po
+++ b/applications/luci-app-acme/po/es/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Alias de desafío"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Validación de desafío"
+msgid "DNS Challenge Validation"
+msgstr "DNS Validación de desafío"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Validación de desafío"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/es/acme.po
+++ b/applications/luci-app-acme/po/es/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.15.1-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Certificados ACME"
 
@@ -18,70 +18,83 @@ msgstr "Certificados ACME"
 msgid "ACME certs"
 msgstr "Certificados ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Configuración global de ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL del servidor ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Cuenta de email"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Configuración avanzada"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Donde se mantienen los certificados y otros archivos de estado."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Configuración de certificado"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Alias de desafío"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Validación de desafío"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Validación de desafío"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "CA ACME personalizado"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL del directorio del servidor ACME personalizado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "API de DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Credenciales de API de DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Validación de desafío"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Días hasta la renovación"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Alias de dominio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Nombres de dominio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -92,32 +105,38 @@ msgstr ""
 "en cuenta que todos los nombres de dominio deben apuntar al enrutador en el "
 "DNS global."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC de 256 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC de 384 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 "Dirección de correo electrónico para asociar con la clave de la cuenta."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Activar el registro de depuración"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Activado"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Configuración general"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -129,31 +148,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Conceder acceso UCI para luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Tamaño de clave"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Tamaño de clave (y tipo) para el certificado generado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA de 2048 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA de 3072 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA de 4096 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Ser único"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -165,7 +231,7 @@ msgstr ""
 "emitir un certificado. El modo DNS le permitirá utilizar la API de DNS de su "
 "proveedor de DNS para emitir un certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -175,7 +241,7 @@ msgstr ""
 "com/acmesh-official/acme.sh/wiki/DNS-alias-mode para obtener detalles sobre "
 "este proceso. LUCI solo admite un alias de desafío por certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -188,7 +254,7 @@ msgstr ""
 "en formato de variable de shell KEY=VAL para proporcionar múltiples "
 "variables de credenciales."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -198,7 +264,11 @@ msgstr ""
 "github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode para obtener detalles "
 "sobre este proceso. LUCI solo admite un dominio de desafío por certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -215,7 +285,11 @@ msgstr ""
 "emisión de certificados puede demorar un tiempo. Verifique los registros de "
 "progreso y cualquier error."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -231,27 +305,31 @@ msgstr ""
 "enrutador. El modo DNS también es el único modo que admite certificados "
 "comodín. El uso de este modo requiere que se instale el paquete acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Utilice una CA personalizada en lugar de Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Usar servidor de ensayo"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Método de validación"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Validación de desafío"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Directorio Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -260,9 +338,6 @@ msgstr ""
 "Directorio raíz del servidor web. Configure esto en la raíz del documento "
 "del servidor web para ejecutar Acme en modo webroot. El servidor web debe "
 "ser accesible desde internet en el puerto 80."
-
-msgid "Cert files are stored in"
-msgstr "Donde se mantienen los certificados y otros archivos de estado."
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/es/acme.po
+++ b/applications/luci-app-acme/po/es/acme.po
@@ -155,13 +155,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Tamaño de clave"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Tamaño de clave (y tipo) para el certificado generado."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Tamaño de clave"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/es/acme.po
+++ b/applications/luci-app-acme/po/es/acme.po
@@ -228,38 +228,9 @@ msgstr ""
 "enrutador. El modo DNS también es el único modo que admite certificados "
 "comodín. El uso de este modo requiere que se instale el paquete acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Actualice la configuración de nginx con este certificado una vez emitido "
-"(solo seleccione esto para un certificado). Nginx debe ser compatible con "
-"SSL, de lo contrario no se iniciará, ya que debe compilarse con soporte SSL "
-"para usar opciones de certificado"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Actualice la configuración de uhttpd con este certificado una vez emitido "
-"(solo seleccione esto para un certificado). También está disponible luci-app-"
-"uhttpd para configurar uhttpd desde la interfaz LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Utilice una CA personalizada en lugar de Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Usar para nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Usar para uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/es/acme.po
+++ b/applications/luci-app-acme/po/es/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.15.1-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Certificados ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Certificados ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -338,6 +335,9 @@ msgstr ""
 "Directorio raíz del servidor web. Configure esto en la raíz del documento "
 "del servidor web para ejecutar Acme en modo webroot. El servidor web debe "
 "ser accesible desde internet en el puerto 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Certificados ACME"
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/es/acme.po
+++ b/applications/luci-app-acme/po/es/acme.po
@@ -287,11 +287,8 @@ msgstr ""
 "del servidor web para ejecutar Acme en modo webroot. El servidor web debe "
 "ser accesible desde internet en el puerto 80."
 
-#~ msgid "State directory"
-#~ msgstr "Directorio del estado"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Donde se mantienen los certificados y otros archivos de estado."
+msgid "Cert files are stored in"
+msgstr "Donde se mantienen los certificados y otros archivos de estado."
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/fi/acme.po
+++ b/applications/luci-app-acme/po/fi/acme.po
@@ -245,6 +245,3 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
-
-#~ msgid "State directory"
-#~ msgstr "Tilahakemisto"

--- a/applications/luci-app-acme/po/fi/acme.po
+++ b/applications/luci-app-acme/po/fi/acme.po
@@ -42,8 +42,10 @@ msgstr "Sertifikaatin asetukset"
 msgid "Challenge Alias"
 msgstr "Haaste - alias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/fi/acme.po
+++ b/applications/luci-app-acme/po/fi/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME-sertifikaatit"
 
@@ -18,69 +18,83 @@ msgstr "ACME-sertifikaatit"
 msgid "ACME certs"
 msgstr "ACME-sertifikaatit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME-yleisasetukset"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACME-palvelimen URL-osoite"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Sähköpostitili"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Lisäasetukset"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Sertifikaatin asetukset"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Haaste - alias"
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API:n kirjautumistiedot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Päiviä uusimiseen"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Verkkonimen alias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Verkkonimet"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +105,37 @@ msgstr ""
 "kaikkien verkkotunnusten pitää osoittaa reitittimeen globaalissa DNS-"
 "järjestelmässä."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bittiä"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bittiä"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Avaimeen liitettävä sähköpostiosoite."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Ota vieanetsintälokkaus käyttöön"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Käytössä"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Yleiset asetukset"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -125,31 +145,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Salli pääsy acme-asetuksiin"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Avaimen koko"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Avaimen koko (ja tyyppi) luotavassa sertifikaatissa."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bittiä"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bittiä"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bittiä"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -157,14 +224,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -172,14 +239,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -189,7 +260,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -199,27 +274,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Käytä staging-palvelimeen"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Validointitapa"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/fi/acme.po
+++ b/applications/luci-app-acme/po/fi/acme.po
@@ -153,7 +153,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Avaimen koko"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/fi/acme.po
+++ b/applications/luci-app-acme/po/fi/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME-sertifikaatit"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME-sertifikaatit"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -304,3 +301,6 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME-sertifikaatit"

--- a/applications/luci-app-acme/po/fi/acme.po
+++ b/applications/luci-app-acme/po/fi/acme.po
@@ -152,13 +152,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Avaimen koko"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Avaimen koko (ja tyyppi) luotavassa sertifikaatissa."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Avaimen koko"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/fi/acme.po
+++ b/applications/luci-app-acme/po/fi/acme.po
@@ -197,31 +197,9 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Käytä nginx:ään"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Käytä uhttpd:hen"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/fr/acme.po
+++ b/applications/luci-app-acme/po/fr/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.18-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Certificats ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Certificats ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -336,3 +333,6 @@ msgstr ""
 "Répertoire racine du serveur web. Définir ce champ avec l'emplacement de la "
 "racine du serveur Web pour utiliser ACME en mode Racine (webroot). Le "
 "serveur web doit être accessible depuis internet sur le port 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Certificats ACME"

--- a/applications/luci-app-acme/po/fr/acme.po
+++ b/applications/luci-app-acme/po/fr/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Certificats ACME"
 
@@ -18,70 +18,83 @@ msgstr "Certificats ACME"
 msgid "ACME certs"
 msgstr "Certificats ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Configuration globale ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL du serveur ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Compte email"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Paramètres avancés"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Emplacement de sauvegarde des certificats et des fichiers états."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Configuration du certificat"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Alias du challenge"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Validation du challenge"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Validation du challenge"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "CA ACME personnalisé"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL du répertoire du serveur ACME personnalisé."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "API du DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Identités de API du DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Validation du challenge"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Nombre de jour avant renouvellement"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Alias du Domaine"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Noms de domaine"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "principal, les noms suivants seront les noms alternatifs. Notez que tous les "
 "noms de domaine doivent pointer sur le router dans le DNS global."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Adresse email à associer avec la clé du compte."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Activer les logs de type debug"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Activé"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Paramètres généraux"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Autoriser les accès UCI pour luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Longueur de clé"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Longueur de clé (et type) du certificat généré."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Autonome"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "pour le générer. Le mode DNS vous permet d'utiliser l 'API DNS de votre "
 "fournisseur de DNS pour générer le certificat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "com/acmesh-official/acme.sh/wiki/DNS-alias-mode pour les détails de ce "
 "processus. LUCI supporte un seul alias par certificat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -185,7 +251,7 @@ msgstr ""
 "pour chaque API. Ajouter toutes vos variables d'identification ici sous le "
 "format CLÉ=VALEUR."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -195,7 +261,11 @@ msgstr ""
 "acmesh-official/acme.sh/wiki/DNS-alias-mode pour plus de détail. LUCI ne "
 "supporte qu'un seul domaine par certificat pour le challenge."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -212,7 +282,11 @@ msgstr ""
 "certificats peut prendre un certain temps. Vérifiez les journaux pour la "
 "progression et les erreurs."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -229,27 +303,31 @@ msgstr ""
 "certificats génériques (wildcard). L'utilisation de ce mode requiert "
 "l'installation du paquet acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Utiliser un CA personnalisé à la place de celui de Let's Encryt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Utiliser le serveur de qualification"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Méthode de validation"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Racine web"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Validation du challenge"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Répertoire racine web"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -258,6 +336,3 @@ msgstr ""
 "Répertoire racine du serveur web. Définir ce champ avec l'emplacement de la "
 "racine du serveur Web pour utiliser ACME en mode Racine (webroot). Le "
 "serveur web doit être accessible depuis internet sur le port 80."
-
-msgid "Cert files are stored in"
-msgstr "Emplacement de sauvegarde des certificats et des fichiers états."

--- a/applications/luci-app-acme/po/fr/acme.po
+++ b/applications/luci-app-acme/po/fr/acme.po
@@ -226,38 +226,9 @@ msgstr ""
 "certificats génériques (wildcard). L'utilisation de ce mode requiert "
 "l'installation du paquet acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Actualise la configuration nginx à l'aide de ce certificat une fois émis (à "
-"ne choisir que pour un seul certificat). Nginx requiert le support SSL pour "
-"pouvoir démarrer et avoir accès aux options de certificat et doit avoir été "
-"compilé avec le support SSL."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Actualise la configuration uhttpd à l'aide de ce certificat une fois émis (à "
-"ne choisir que pour un seul certificat). luci-app-uhttpd permet également de "
-"configurer uhttpd à partir de l'interface LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Utiliser un CA personnalisé à la place de celui de Let's Encryt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Utiliser pour nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Utiliser pour uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/fr/acme.po
+++ b/applications/luci-app-acme/po/fr/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Longueur de clé"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Longueur de clé (et type) du certificat généré."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Longueur de clé"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/fr/acme.po
+++ b/applications/luci-app-acme/po/fr/acme.po
@@ -285,8 +285,5 @@ msgstr ""
 "racine du serveur Web pour utiliser ACME en mode Racine (webroot). Le "
 "serveur web doit être accessible depuis internet sur le port 80."
 
-#~ msgid "State directory"
-#~ msgstr "Répertoire pour les contextes"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Emplacement de sauvegarde des certificats et des fichiers états."
+msgid "Cert files are stored in"
+msgstr "Emplacement de sauvegarde des certificats et des fichiers états."

--- a/applications/luci-app-acme/po/fr/acme.po
+++ b/applications/luci-app-acme/po/fr/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Alias du challenge"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Validation du challenge"
+msgid "DNS Challenge Validation"
+msgstr "DNS Validation du challenge"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Validation du challenge"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/fr/acme.po
+++ b/applications/luci-app-acme/po/fr/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Longueur de clé"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/he/acme.po
+++ b/applications/luci-app-acme/po/he/acme.po
@@ -11,7 +11,7 @@ msgstr ""
 "n % 10 == 0) ? 2 : 3));\n"
 "X-Generator: Weblate 4.4.1-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr ""
 
@@ -19,100 +19,120 @@ msgstr ""
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "הגדרות מתקדמות"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -122,31 +142,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -154,14 +221,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -169,14 +236,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -186,7 +257,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -196,27 +271,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/he/acme.po
+++ b/applications/luci-app-acme/po/he/acme.po
@@ -43,8 +43,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/he/acme.po
+++ b/applications/luci-app-acme/po/he/acme.po
@@ -12,11 +12,8 @@ msgstr ""
 "X-Generator: Weblate 4.4.1-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr ""
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36

--- a/applications/luci-app-acme/po/he/acme.po
+++ b/applications/luci-app-acme/po/he/acme.po
@@ -150,7 +150,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/he/acme.po
+++ b/applications/luci-app-acme/po/he/acme.po
@@ -149,12 +149,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/he/acme.po
+++ b/applications/luci-app-acme/po/he/acme.po
@@ -194,30 +194,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/hi/acme.po
+++ b/applications/luci-app-acme/po/hi/acme.po
@@ -4,7 +4,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr ""
 
@@ -12,100 +12,120 @@ msgstr ""
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -115,31 +135,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -147,14 +214,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -162,14 +229,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -179,7 +250,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -189,27 +264,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/hi/acme.po
+++ b/applications/luci-app-acme/po/hi/acme.po
@@ -187,30 +187,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/hi/acme.po
+++ b/applications/luci-app-acme/po/hi/acme.po
@@ -143,7 +143,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/hi/acme.po
+++ b/applications/luci-app-acme/po/hi/acme.po
@@ -5,11 +5,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr ""
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36

--- a/applications/luci-app-acme/po/hi/acme.po
+++ b/applications/luci-app-acme/po/hi/acme.po
@@ -36,8 +36,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/hi/acme.po
+++ b/applications/luci-app-acme/po/hi/acme.po
@@ -142,12 +142,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/hu/acme.po
+++ b/applications/luci-app-acme/po/hu/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Kihívás álneve"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Kihívás érvényesítése"
+msgid "DNS Challenge Validation"
+msgstr "DNS Kihívás érvényesítése"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Kihívás érvényesítése"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/hu/acme.po
+++ b/applications/luci-app-acme/po/hu/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.13-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME tanúsítványok"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME tanúsítványok"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -337,3 +334,6 @@ msgstr ""
 "A webkiszolgáló gyökérkönyvtára. Állítsa be ezt a webkiszolgáló "
 "dokumentumgyökerére az ACME webgyökér módban történő futtatásához. A "
 "webkiszolgálónak elérhetőnek kell lennie az internetről a 80-as porton."
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME tanúsítványok"

--- a/applications/luci-app-acme/po/hu/acme.po
+++ b/applications/luci-app-acme/po/hu/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Kulcsméret"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/hu/acme.po
+++ b/applications/luci-app-acme/po/hu/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.13-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME tanúsítványok"
 
@@ -18,70 +18,83 @@ msgstr "ACME tanúsítványok"
 msgid "ACME certs"
 msgstr "ACME tanúsítványok"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME globális beállítás"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACME szerver URL"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Fiók e-mail"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Haladó Beállítások"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Ahol a tanúsítványok és egyéb állapotfájlok tárolva vannak."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Tanúsítvány beállítása"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Kihívás álneve"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Kihívás érvényesítése"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Kihívás érvényesítése"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Egyéni ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "Testreszabott ACME szerver könyvtár URL."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API hitelesítési adatok"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Kihívás érvényesítése"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Napok megújításig"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Tartományálnév"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Tartománynevek"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "neve, az azt követő nevek lesznek az alternatív nevek. Ne feledje, hogy az "
 "összes tartománynévnek az útválasztóra kell mutatnia a globális DNS-ben."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "256 bites ECC"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "384 bites ECC"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "A fiók kulcsához rendelendő e-mail cím."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Hibakeresési naplózás engedélyezése"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Általános Beállítások"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "UCI hozzáférés megadása a luci-app-acme alkalmazásnak"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Kulcsméret"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Kulcsméret (és típus) az előállított tanúsítványhoz."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "2048 bites RSA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "3072 bites RSA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "4096 bites RSA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Önálló"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "használni, hogy kiállítson egy tanusítványt. A DNS üzemmód megengedélyezi a "
 "DNS szolgáltatód DNS API-ja használatát, hogy kiállítson egy tanusítványt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode oldalt a folyamat "
 "részleteiért. A LuCI csak egy kihívási álnevet támogat tanúsítványonként."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -186,7 +252,7 @@ msgstr ""
 "KULCS=ÉRTÉK parancsértelmező változóformátumban a több hitelesítési adat "
 "változójának támogatásához."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -196,7 +262,11 @@ msgstr ""
 "github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode oldalt a folyamat "
 "részleteiért. A LuCI csak egy tartományálnevet támogat tanúsítványonként."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -213,7 +283,11 @@ msgstr ""
 "a tanúsítványok kibocsátása eltarthat egy ideig. Nézze meg a naplókat a "
 "folyamat előrehaladásához és a hibákhoz."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -230,27 +304,31 @@ msgstr ""
 "tanúsítványokat. Ezen mód használatához az szükséges, hogy az acme-dnsapi "
 "csomag telepítve legyen."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Előkészítő kiszolgáló használata"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Kihívás érvényesítése"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webgyökér könyvtár"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -259,6 +337,3 @@ msgstr ""
 "A webkiszolgáló gyökérkönyvtára. Állítsa be ezt a webkiszolgáló "
 "dokumentumgyökerére az ACME webgyökér módban történő futtatásához. A "
 "webkiszolgálónak elérhetőnek kell lennie az internetről a 80-as porton."
-
-msgid "Cert files are stored in"
-msgstr "Ahol a tanúsítványok és egyéb állapotfájlok tárolva vannak."

--- a/applications/luci-app-acme/po/hu/acme.po
+++ b/applications/luci-app-acme/po/hu/acme.po
@@ -286,8 +286,5 @@ msgstr ""
 "dokumentumgyökerére az ACME webgyökér módban történő futtatásához. A "
 "webkiszolgálónak elérhetőnek kell lennie az internetről a 80-as porton."
 
-#~ msgid "State directory"
-#~ msgstr "Állapotkönyvtár"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Ahol a tanúsítványok és egyéb állapotfájlok tárolva vannak."
+msgid "Cert files are stored in"
+msgstr "Ahol a tanúsítványok és egyéb állapotfájlok tárolva vannak."

--- a/applications/luci-app-acme/po/hu/acme.po
+++ b/applications/luci-app-acme/po/hu/acme.po
@@ -227,38 +227,9 @@ msgstr ""
 "tanúsítványokat. Ezen mód használatához az szükséges, hogy az acme-dnsapi "
 "csomag telepítve legyen."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Az nginx beállítás frissítése ezzel a tanúsítvánnyal, miután kibocsátották "
-"(csak egy tanúsítványnál válassza ki ezt). Az nginx programnak támogatnia "
-"kell az SSL-t. Ha nem támogatja, akkor nem fog elindulni, mivel SSL "
-"támogatással kell lefordítani a tanúsítvány lehetőségeinek használatához"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Az uhttpd beállítás frissítése ezzel a tanúsítvánnyal, miután kibocsátották "
-"(csak egyetlen tanúsítványnál válassza ki). Elérhető a luci-app-uhttpd is a "
-"LuCI felületéről történő uhttpd beállításhoz."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Nginx-hez történő használat"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Uhttpd-hez történő használat"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/hu/acme.po
+++ b/applications/luci-app-acme/po/hu/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Kulcsméret"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Kulcsméret (és típus) az előállított tanúsítványhoz."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Kulcsméret"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/id/acme.po
+++ b/applications/luci-app-acme/po/id/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Ukuran kunci"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Ukuran kunci (dan jenis) untuk sertifikat yang dihasilkan."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Ukuran kunci"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/id/acme.po
+++ b/applications/luci-app-acme/po/id/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Ukuran kunci"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/id/acme.po
+++ b/applications/luci-app-acme/po/id/acme.po
@@ -224,27 +224,6 @@ msgstr ""
 "satunya mode yang mendukung sertifikat wildcard. Menggunakan mode ini "
 "memerlukan paket acme-dnsapi untuk diinstal."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Perbarui konfigurasi nginx dengan sertifikat ini setelah dikeluarkan (hanya "
-"pilih ini untuk satu sertifikat). Nginx harus mendukung ssl, jika tidak, itu "
-"tidak akan dimulai karena perlu dikompilasi dengan dukungan ssl untuk "
-"menggunakan opsi sertifikat"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Perbarui konfigurasi uhttpd dengan sertifikat ini setelah diterbitkan (hanya "
-"pilih ini untuk satu sertifikat). Juga tersedia luci-app-uhttpd untuk "
-"mengkonfigurasi uhttpd dari antarmuka LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Gunakan CA khusus sebagai ganti Let's Encrypt."
@@ -252,14 +231,6 @@ msgstr "Gunakan CA khusus sebagai ganti Let's Encrypt."
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
 msgid "Use for nginx"
 msgstr "Gunakan untuk nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Gunakan untuk uhttpd"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
-msgid "Use staging server"
-msgstr "Gunakan server pementasan"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
 msgid "Validation method"

--- a/applications/luci-app-acme/po/id/acme.po
+++ b/applications/luci-app-acme/po/id/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.12.1-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Sertifikat ACME"
 
@@ -18,70 +18,83 @@ msgstr "Sertifikat ACME"
 msgid "ACME certs"
 msgstr "Sertifikat ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Konfigurasi global ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL server ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Akun e-mail"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Pengaturan Lanjutan"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Di mana sertifikat dan file status lainnya disimpan."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Konfigurasi sertifikat"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Tantangan Alias"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Validasi Tantangan"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Validasi Tantangan"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "CA ACME khusus"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL direktori server ACME khusus."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Kredensial API DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Validasi Tantangan"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Hari sampai perpanjangan"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Alias Domain"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Nama domain"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "subjek, nama berikutnya akan menjadi nama alternatif. Perhatikan bahwa semua "
 "nama domain harus mengarah ke router di DNS global."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Alamat email untuk dikaitkan dengan kunci akun."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Aktifkan pencatatan debug"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Diaktifkan"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Pengaturan Umum"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Berikan akses UCI untuk luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Ukuran kunci"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Ukuran kunci (dan jenis) untuk sertifikat yang dihasilkan."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Mandiri"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "mengeluarkan sertifikat. Mode DNS akan memungkinkan Anda untuk menggunakan "
 "API DNS dari penyedia DNS Anda untuk mengeluarkan sertifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "acmesh-official/acme.sh/wiki/DNS-alias-mode untuk detail proses ini. LUCI "
 "hanya mendukung satu alias tantangan per sertifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -185,7 +251,7 @@ msgstr ""
 "oleh setiap API. Tambahkan beberapa entri di sini dalam format variabel "
 "shell KEY=VAL untuk memasok beberapa variabel kredensial."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -195,7 +261,11 @@ msgstr ""
 "com/acmesh-official/acme.sh/wiki/DNS-alias-mode untuk detail proses ini. "
 "LUCI hanya mendukung satu domain tantangan per sertifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -211,7 +281,11 @@ msgstr ""
 "router. Setelah dikonfigurasi, penerbitan sertifikat dapat memakan waktu "
 "cukup lama. Periksa log untuk kemajuan dan kesalahan apa pun."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -227,27 +301,31 @@ msgstr ""
 "satunya mode yang mendukung sertifikat wildcard. Menggunakan mode ini "
 "memerlukan paket acme-dnsapi untuk diinstal."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Gunakan CA khusus sebagai ganti Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Gunakan untuk nginx"
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
+msgid "Use staging server"
+msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Metode validasi"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Validasi Tantangan"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Direktori webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -257,5 +335,5 @@ msgstr ""
 "menjalankan Acme dalam mode webroot. Server web harus dapat diakses dari "
 "internet pada port 80."
 
-msgid "Cert files are stored in"
-msgstr "Di mana sertifikat dan file status lainnya disimpan."
+#~ msgid "Use for nginx"
+#~ msgstr "Gunakan untuk nginx"

--- a/applications/luci-app-acme/po/id/acme.po
+++ b/applications/luci-app-acme/po/id/acme.po
@@ -283,8 +283,5 @@ msgstr ""
 "menjalankan Acme dalam mode webroot. Server web harus dapat diakses dari "
 "internet pada port 80."
 
-#~ msgid "State directory"
-#~ msgstr "Direktori negara"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Di mana sertifikat dan file status lainnya disimpan."
+msgid "Cert files are stored in"
+msgstr "Di mana sertifikat dan file status lainnya disimpan."

--- a/applications/luci-app-acme/po/id/acme.po
+++ b/applications/luci-app-acme/po/id/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Tantangan Alias"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Validasi Tantangan"
+msgid "DNS Challenge Validation"
+msgstr "DNS Validasi Tantangan"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Validasi Tantangan"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/id/acme.po
+++ b/applications/luci-app-acme/po/id/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.12.1-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Sertifikat ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Sertifikat ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -334,6 +331,9 @@ msgstr ""
 "Direktori root server web. Setel ini ke root dokumen server web untuk "
 "menjalankan Acme dalam mode webroot. Server web harus dapat diakses dari "
 "internet pada port 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Sertifikat ACME"
 
 #~ msgid "Use for nginx"
 #~ msgstr "Gunakan untuk nginx"

--- a/applications/luci-app-acme/po/it/acme.po
+++ b/applications/luci-app-acme/po/it/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Alias challenge"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Validazione challenge"
+msgid "DNS Challenge Validation"
+msgstr "DNS Validazione challenge"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Validazione challenge"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/it/acme.po
+++ b/applications/luci-app-acme/po/it/acme.po
@@ -225,38 +225,9 @@ msgstr ""
 "è anche l'unica modalità che supporta i certificati con caratteri jolly. "
 "L'uso di questa modalità richiede l'installazione del pacchetto acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Aggiorna la configurazione di nginx con questo certificato una volta emesso "
-"(selezionalo solo per un certificato). Nginx deve supportare SSL, altrimenti "
-"non si avvia poiché deve essere compilato con il supporto SSL per usare le "
-"opzioni cert"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Aggiorna la configurazione uhttpd con questo certificato una volta emesso "
-"(selezionalo solo per un certificato). È disponibile anche luci-app-uhttpd "
-"per configurare uhttpd nell'interfaccia LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Usa una CA personalizzata invece di Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Usa per nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Usa per uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/it/acme.po
+++ b/applications/luci-app-acme/po/it/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Dimensione chiave"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Dimensione chiave (e tipo) per il certificato generato."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Dimensione chiave"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/it/acme.po
+++ b/applications/luci-app-acme/po/it/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Certificati ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Certificati ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -335,3 +332,6 @@ msgstr ""
 "Cartella principale del server web. Impostala sulla root del documento del "
 "server web per eseguire Acme in modalità webroot. Il server web deve essere "
 "accessibile da internet sulla porta 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Certificati ACME"

--- a/applications/luci-app-acme/po/it/acme.po
+++ b/applications/luci-app-acme/po/it/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Certificati ACME"
 
@@ -18,70 +18,83 @@ msgstr "Certificati ACME"
 msgid "ACME certs"
 msgstr "Certificati ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Configurazione globale ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL server ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "E-mail dell'account"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Impostazioni avanzate"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Dove vengono conservati i certificati e altri file di stato."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Configurazione certificato"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Alias challenge"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Validazione challenge"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Validazione challenge"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "CA ACME personalizzato"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL personalizzata cartella server ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "API DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Credenziali API DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Validazione challenge"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "giorni al rinnovo"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Alias di dominio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Nomi di dominio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "soggetto, i successivi saranno nomi alternativi. Nota che tutti i nomi di "
 "dominio devono puntare al router nel DNS globale."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Indirizzo e-mail da associare alla chiave dell'account."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Attiva i log di debug"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Attivato"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Impostazioni generali"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Concedi l'accesso UCI a luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Dimensione chiave"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Dimensione chiave (e tipo) per il certificato generato."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Autonoma"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "emettere un certificato. La modalità DNS ti consentirà di usare l'API DNS "
 "del tuo provider DNS per emettere un certificato."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "processo vedi https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-"
 "mode . LUCI supporta solo un alias challenge per certificato."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -185,7 +251,7 @@ msgstr ""
 "official/acme.sh/wiki/dnsapi . Aggiungi più voci qui nel formato variabile "
 "shell CHIAVE=VALORE per fornire variabili credenziali multiple."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -195,7 +261,11 @@ msgstr ""
 "processo vedi https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-"
 "mode . LUCI supporta solo un dominio challenge per certificato."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -212,7 +282,11 @@ msgstr ""
 "certificati può richiedere del tempo. Controlla i registri eventi per "
 "verificare lo stato di avanzamento e gli eventuali errori."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -228,27 +302,31 @@ msgstr ""
 "è anche l'unica modalità che supporta i certificati con caratteri jolly. "
 "L'uso di questa modalità richiede l'installazione del pacchetto acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Usa una CA personalizzata invece di Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Usa server di prova"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Metodo validazione"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Validazione challenge"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Cartella webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -257,6 +335,3 @@ msgstr ""
 "Cartella principale del server web. Impostala sulla root del documento del "
 "server web per eseguire Acme in modalità webroot. Il server web deve essere "
 "accessibile da internet sulla porta 80."
-
-msgid "Cert files are stored in"
-msgstr "Dove vengono conservati i certificati e altri file di stato."

--- a/applications/luci-app-acme/po/it/acme.po
+++ b/applications/luci-app-acme/po/it/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Dimensione chiave"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/it/acme.po
+++ b/applications/luci-app-acme/po/it/acme.po
@@ -284,8 +284,5 @@ msgstr ""
 "server web per eseguire Acme in modalità webroot. Il server web deve essere "
 "accessibile da internet sulla porta 80."
 
-#~ msgid "State directory"
-#~ msgstr "Cartella stato"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Dove vengono conservati i certificati e altri file di stato."
+msgid "Cert files are stored in"
+msgstr "Dove vengono conservati i certificati e altri file di stato."

--- a/applications/luci-app-acme/po/ja/acme.po
+++ b/applications/luci-app-acme/po/ja/acme.po
@@ -152,13 +152,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "鍵の大きさ"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "生成された証明書の鍵の大きさ(およびタイプ)。"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "鍵の大きさ"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/ja/acme.po
+++ b/applications/luci-app-acme/po/ja/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.7.1-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME証明書"
 
@@ -18,69 +18,83 @@ msgstr "ACME証明書"
 msgid "ACME certs"
 msgstr "ACME証明書"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACMEグローバル設定"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACMEサーバーのURL"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "アカウントのメールアドレス"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "詳細設定"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "証明書設定"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "カスタムACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "カスタムACMEサーバーディレクトリのURL。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API資格情報"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "更新までの日数"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "ドメインエイリアス"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "ドメイン名"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -89,31 +103,37 @@ msgstr ""
 "証明書に含めるドメイン名です。最初の名前はサブジェクト名、その次は代替名で"
 "す。すべてのドメイン名はグローバルDNSのルーターを指す必要があります。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC256ビット"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC384ビット"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "アカウントに関連付けるメールアドレスです。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "デバッグロギングを有効化"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "有効"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -125,31 +145,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "luci-app-acmeにUCIアクセスを許可"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "鍵の大きさ"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "生成された証明書の鍵の大きさ(およびタイプ)。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA2048ビット"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA3072ビット"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA4096ビット"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "スタンドアロン"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -160,14 +227,14 @@ msgstr ""
 "します。 Webrootモードでは、既存のWebサーバーを使用して証明書を発行します。 "
 "DNSモードでは、DNSプロバイダーのDNSAPIを使用して証明書を発行できます。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -175,14 +242,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -192,7 +263,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -202,27 +277,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Let'sEncryptの代わりにカスタムCAを使用する。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "ステージングサーバーを使用"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webrootディレクトリ"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/ja/acme.po
+++ b/applications/luci-app-acme/po/ja/acme.po
@@ -153,7 +153,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "鍵の大きさ"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/ja/acme.po
+++ b/applications/luci-app-acme/po/ja/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.7.1-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME証明書"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME証明書"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -307,3 +304,6 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME証明書"

--- a/applications/luci-app-acme/po/ja/acme.po
+++ b/applications/luci-app-acme/po/ja/acme.po
@@ -42,8 +42,10 @@ msgstr "証明書設定"
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/ja/acme.po
+++ b/applications/luci-app-acme/po/ja/acme.po
@@ -200,31 +200,9 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Let'sEncryptの代わりにカスタムCAを使用する。"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "nginxを使用"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "uhttpdを使用"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/ko/acme.po
+++ b/applications/luci-app-acme/po/ko/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "키 크기"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/ko/acme.po
+++ b/applications/luci-app-acme/po/ko/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.15.1-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME 인증서"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME 인증서"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -331,3 +328,6 @@ msgid ""
 msgstr ""
 "ACME를 웹루트(Webroot) 모드로 실행하기 위해선 웹 서버 문서 루트 디렉터리를 설"
 "정하세요. 웹 서버는 80번 포트에서 인터넷 접근이 가능해야 합니다."
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME 인증서"

--- a/applications/luci-app-acme/po/ko/acme.po
+++ b/applications/luci-app-acme/po/ko/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.15.1-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME 인증서"
 
@@ -18,70 +18,83 @@ msgstr "ACME 인증서"
 msgid "ACME certs"
 msgstr "ACME 인증서"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME 전역 구성"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACME 서버 URL"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "계정 이메일"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "고급 설정"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "인증서와 기타 상태 파일이 저장되는 경로입니다."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "인증서 구성"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "챌린지 별칭"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS 챌린지 확인"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot 챌린지 확인"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "사용자 지정 ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "사용자 지정 ACME 서버 디렉터리 URL."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API 자격 증명"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS 챌린지 확인"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "갱신일"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "도메인 별칭"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "도메인 네임"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "도메인이 부 도메인이 됩니다. 주의할 점은 모든 도메인 네임들이 반드시 글로벌 "
 "DNS의 라우터를 가리키도록 하셔야 합니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256비트"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384비트"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "계정 키에 연결할 이메일 주소입니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "디버그 로깅 사용"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "활성화"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "기본 설정"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "luci-app-acme에 UCI 액세스 허용"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "키 크기"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "생성된 인증서의 키 크기(및 유형)."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048비트"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072비트"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096비트"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "독립형"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "합니다. DNS 모드는 인증서 발행에 DNS 를 제공하는 업체의 DNS API를 사용하게 됩"
 "니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "official/acme.sh/wiki/DNS-alias-mode 에서 자세한 내용을 확인하세요. LuCI에서"
 "는 개별 인증서마다 하나의 챌린지 별칭만 지원합니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -185,7 +251,7 @@ msgstr ""
 "참고해주세요. KEY=VAL 쉘 변수 포맷에 따라 여러 개의 자격 증명을 추가할 수 있"
 "습니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -195,7 +261,11 @@ msgstr ""
 "official/acme.sh/wiki/DNS-alias-mode 에서 자세한 내용을 확인하세요. LuCI에서"
 "는 개별 인증서마다 하나의 챌린지 도메인만 지원합니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -210,7 +280,11 @@ msgstr ""
 "구성하는 경우, 인증서 발급에 시간이 걸릴 수 있습니다. 진행 상황 및 오류는 로"
 "그에서 확인할 수 있습니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -225,27 +299,31 @@ msgstr ""
 "카드 인증서를 지원합니다. DNS 모드를 사용하기 위해선 acme-dnsapi 패키지가 설"
 "치되어 있어야 합니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Let's Encrypt 대신 사용자 지정 CA를 사용합니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "테스트 서버 사용"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "유효성 검증 방법"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot 챌린지 확인"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webroot 디렉터리"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -253,6 +331,3 @@ msgid ""
 msgstr ""
 "ACME를 웹루트(Webroot) 모드로 실행하기 위해선 웹 서버 문서 루트 디렉터리를 설"
 "정하세요. 웹 서버는 80번 포트에서 인터넷 접근이 가능해야 합니다."
-
-msgid "Cert files are stored in"
-msgstr "인증서와 기타 상태 파일이 저장되는 경로입니다."

--- a/applications/luci-app-acme/po/ko/acme.po
+++ b/applications/luci-app-acme/po/ko/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "키 크기"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "생성된 인증서의 키 크기(및 유형)."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "키 크기"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/ko/acme.po
+++ b/applications/luci-app-acme/po/ko/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "챌린지 별칭"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "챌린지 확인"
+msgid "DNS Challenge Validation"
+msgstr "DNS 챌린지 확인"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot 챌린지 확인"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/ko/acme.po
+++ b/applications/luci-app-acme/po/ko/acme.po
@@ -279,8 +279,5 @@ msgstr ""
 "ACME를 웹루트(Webroot) 모드로 실행하기 위해선 웹 서버 문서 루트 디렉터리를 설"
 "정하세요. 웹 서버는 80번 포트에서 인터넷 접근이 가능해야 합니다."
 
-#~ msgid "State directory"
-#~ msgstr "상태 디렉터리"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "인증서와 기타 상태 파일이 저장되는 경로입니다."
+msgid "Cert files are stored in"
+msgstr "인증서와 기타 상태 파일이 저장되는 경로입니다."

--- a/applications/luci-app-acme/po/ko/acme.po
+++ b/applications/luci-app-acme/po/ko/acme.po
@@ -222,37 +222,9 @@ msgstr ""
 "카드 인증서를 지원합니다. DNS 모드를 사용하기 위해선 acme-dnsapi 패키지가 설"
 "치되어 있어야 합니다."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"인증서가 발급되었을 때 nginx 설정을 업데이트합니다 (1개의 인증서에서만 이 옵"
-"션을 선택하세요). SSL 지원을 사용하도록 컴파일된 nginx를 사용해야 하며, 그렇"
-"지 않은 경우 nginx가 시작되지 않습니다."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"인증서가 발급되었을 때 uhttpd 설정을 업데이트합니다 (1개의 인증서에서만 이 옵"
-"션을 선택하세요). luci-app-uhttpd 패키지를 통해 LuCI 인터페이스에서 uhttpd의 "
-"설정을 수정할 수도 있습니다."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Let's Encrypt 대신 사용자 지정 CA를 사용합니다."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "nginx에 적용"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "uhttpd에 적용"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/lt/acme.po
+++ b/applications/luci-app-acme/po/lt/acme.po
@@ -197,30 +197,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/lt/acme.po
+++ b/applications/luci-app-acme/po/lt/acme.po
@@ -152,12 +152,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/lt/acme.po
+++ b/applications/luci-app-acme/po/lt/acme.po
@@ -14,7 +14,7 @@ msgstr ""
 "1 : 2);\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr ""
 
@@ -22,100 +22,120 @@ msgstr ""
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Įjungta"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -125,31 +145,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -157,14 +224,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -172,14 +239,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -189,7 +260,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -199,27 +274,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/lt/acme.po
+++ b/applications/luci-app-acme/po/lt/acme.po
@@ -15,11 +15,8 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr ""
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36

--- a/applications/luci-app-acme/po/lt/acme.po
+++ b/applications/luci-app-acme/po/lt/acme.po
@@ -153,7 +153,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/lt/acme.po
+++ b/applications/luci-app-acme/po/lt/acme.po
@@ -46,8 +46,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/mr/acme.po
+++ b/applications/luci-app-acme/po/mr/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 4.3-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "ACME प्रमाणपत्रे"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr "ACME प्रमाणपत्र"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
@@ -300,3 +297,6 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME प्रमाणपत्र"

--- a/applications/luci-app-acme/po/mr/acme.po
+++ b/applications/luci-app-acme/po/mr/acme.po
@@ -148,12 +148,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/mr/acme.po
+++ b/applications/luci-app-acme/po/mr/acme.po
@@ -42,8 +42,10 @@ msgstr "प्रमाणपत्र कॉन्फिगरेशन"
 msgid "Challenge Alias"
 msgstr "आव्हान उपनाम"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/mr/acme.po
+++ b/applications/luci-app-acme/po/mr/acme.po
@@ -193,30 +193,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/mr/acme.po
+++ b/applications/luci-app-acme/po/mr/acme.po
@@ -149,7 +149,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/mr/acme.po
+++ b/applications/luci-app-acme/po/mr/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.3-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME प्रमाणपत्रे"
 
@@ -18,100 +18,120 @@ msgstr "ACME प्रमाणपत्रे"
 msgid "ACME certs"
 msgstr "ACME प्रमाणपत्र"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME ग्लोबल कॉन्फिगरेशन"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "खाते ईमेल"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "प्रमाणपत्र कॉन्फिगरेशन"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "आव्हान उपनाम"
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "डीएनएस एपीआय"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "खाते किल्लीशी संलग्न करण्यासाठी ईमेल पत्ता."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "डीबग लॉगिंग सक्षम करा"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "सक्षम केले"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -121,31 +141,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -153,14 +220,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -168,14 +235,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -185,7 +256,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -195,27 +270,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/ms/acme.po
+++ b/applications/luci-app-acme/po/ms/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.6-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr ""
 
@@ -18,100 +18,120 @@ msgstr ""
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Tetapan Lanjutan"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -121,31 +141,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -153,14 +220,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -168,14 +235,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -185,7 +256,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -195,27 +270,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/ms/acme.po
+++ b/applications/luci-app-acme/po/ms/acme.po
@@ -42,8 +42,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/ms/acme.po
+++ b/applications/luci-app-acme/po/ms/acme.po
@@ -148,12 +148,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/ms/acme.po
+++ b/applications/luci-app-acme/po/ms/acme.po
@@ -193,30 +193,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/ms/acme.po
+++ b/applications/luci-app-acme/po/ms/acme.po
@@ -149,7 +149,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/ms/acme.po
+++ b/applications/luci-app-acme/po/ms/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.6-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr ""
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36

--- a/applications/luci-app-acme/po/nb_NO/acme.po
+++ b/applications/luci-app-acme/po/nb_NO/acme.po
@@ -42,8 +42,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/nb_NO/acme.po
+++ b/applications/luci-app-acme/po/nb_NO/acme.po
@@ -148,13 +148,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Nøkkelstørrelse"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Nøkkelstørrelse"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/nb_NO/acme.po
+++ b/applications/luci-app-acme/po/nb_NO/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 5.0-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "ACME-sertifikater"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"

--- a/applications/luci-app-acme/po/nb_NO/acme.po
+++ b/applications/luci-app-acme/po/nb_NO/acme.po
@@ -149,7 +149,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Nøkkelstørrelse"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/nb_NO/acme.po
+++ b/applications/luci-app-acme/po/nb_NO/acme.po
@@ -193,30 +193,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/nb_NO/acme.po
+++ b/applications/luci-app-acme/po/nb_NO/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.0-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME-sertifikater"
 
@@ -18,100 +18,120 @@ msgstr "ACME-sertifikater"
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Avanserte innstillinger"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Domenenavn"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Aktivert"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Generelle innstillinger"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -121,31 +141,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Nøkkelstørrelse"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -153,14 +220,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -168,14 +235,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -185,7 +256,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -195,27 +270,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/pl/acme.po
+++ b/applications/luci-app-acme/po/pl/acme.po
@@ -44,8 +44,11 @@ msgid "Challenge Alias"
 msgstr "Alias wyzwania"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Weryfikacja wyzwań"
+msgid "DNS Challenge Validation"
+msgstr "DNS Weryfikacja wyzwań"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Weryfikacja wyzwań"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/pl/acme.po
+++ b/applications/luci-app-acme/po/pl/acme.po
@@ -226,38 +226,9 @@ msgstr ""
 "DNS jest także jedynym trybem obsługującym certyfikaty wieloznaczne. "
 "Korzystanie z tego trybu wymaga zainstalowania pakietu acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Zaktualizuj konfigurację nginx za pomocą tego certyfikatu po jego wydaniu "
-"(wybierz to tylko dla jednego certyfikatu). Nginx musi obsługiwać ssl, jeśli "
-"nie, to nie uruchomi się, ponieważ musi być skompilowany z obsługą ssl, aby "
-"użyć opcji cert"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Zaktualizuj konfigurację uhttpd z tym certyfikatem po wystawieniu (wybierz "
-"to tylko dla jednego certyfikatu). Jest również dostępna luci-app-uhttpd do "
-"konfiguracji uhttpd z interfejsu LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Użyj niestandardowego CA zamiast Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Użyj dla nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Użyj dla uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/pl/acme.po
+++ b/applications/luci-app-acme/po/pl/acme.po
@@ -11,7 +11,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.4-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Certyfikaty ACME"
 
@@ -19,70 +19,83 @@ msgstr "Certyfikaty ACME"
 msgid "ACME certs"
 msgstr "Certyfikaty ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Konfiguracja globalna ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "Adres URL serwera ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Konto e-mail"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Ustawienia zaawansowane"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Gdzie przechowywane są certyfikaty i inne pliki stanu."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Konfiguracja certyfikatu"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Alias wyzwania"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Weryfikacja wyzwań"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Weryfikacja wyzwań"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Niestandardowy ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "Niestandardowy adres URL katalogu serwera ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Poświadczenia interfejsu API DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Weryfikacja wyzwań"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Dni do czasu odnowienia"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Alias Domeny"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Nazwy domen"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -92,31 +105,37 @@ msgstr ""
 "podmiotu, kolejne imiona będą imionami alternatywnymi. Pamiętaj, że "
 "wszystkie nazwy domen muszą wskazywać na router w globalnym DNS."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bitów"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bity"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Adres e-mail do powiązania z kluczem konta."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Włącz rejestrowanie debugowania"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Włączone"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Ustawienia główne"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -128,31 +147,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Udziel dostępu UCI dla luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Rozmiar klucza"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Rozmiar klucza (i typ) dla wygenerowanego certyfikatu."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bitów"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bity"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bitów"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Autonomiczny"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -164,7 +230,7 @@ msgstr ""
 "wystawienia certyfikatu. Tryb DNS pozwala na użycie DNS API dostawcy DNS do "
 "wystawienia certyfikatu."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -175,7 +241,7 @@ msgstr ""
 "informacje na temat tego procesu. LUCI obsługuje tylko jeden alias wyzwania "
 "na certyfikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -187,7 +253,7 @@ msgstr ""
 "poświadczeń wymaganych przez każdy interfejs API. Dodaj tutaj wiele wpisów w "
 "formacie zmiennej powłoki KEY=VAL, aby podać wiele zmiennych referencji."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -197,7 +263,11 @@ msgstr ""
 "official/acme.sh/wiki/DNS-alias-mode, aby uzyskać szczegółowe informacje na "
 "temat tego procesu. LUCI obsługuje tylko jedną domenę wyzwania na certyfikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -213,7 +283,11 @@ msgstr ""
 "adres IP routera. Po skonfigurowaniu wydawanie certyfikatów może chwilę "
 "potrwać. Sprawdź dzienniki pod kątem postępu i ewentualnych błędów."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -229,27 +303,31 @@ msgstr ""
 "DNS jest także jedynym trybem obsługującym certyfikaty wieloznaczne. "
 "Korzystanie z tego trybu wymaga zainstalowania pakietu acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Użyj niestandardowego CA zamiast Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Użyj serwera pomostowego"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Metoda walidacji"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Weryfikacja wyzwań"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Katalog Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -258,6 +336,3 @@ msgstr ""
 "Katalog główny serwera WWW. Ustaw to na katalog główny serwera WWW, aby "
 "uruchomić Acme w trybie webroot. Serwer WWW musi być dostępny z Internetu na "
 "porcie 80."
-
-msgid "Cert files are stored in"
-msgstr "Gdzie przechowywane są certyfikaty i inne pliki stanu."

--- a/applications/luci-app-acme/po/pl/acme.po
+++ b/applications/luci-app-acme/po/pl/acme.po
@@ -154,13 +154,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Rozmiar klucza"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Rozmiar klucza (i typ) dla wygenerowanego certyfikatu."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Rozmiar klucza"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/pl/acme.po
+++ b/applications/luci-app-acme/po/pl/acme.po
@@ -12,11 +12,8 @@ msgstr ""
 "X-Generator: Weblate 4.4-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Certyfikaty ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Certyfikaty ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -336,3 +333,6 @@ msgstr ""
 "Katalog główny serwera WWW. Ustaw to na katalog główny serwera WWW, aby "
 "uruchomić Acme w trybie webroot. Serwer WWW musi być dostępny z Internetu na "
 "porcie 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Certyfikaty ACME"

--- a/applications/luci-app-acme/po/pl/acme.po
+++ b/applications/luci-app-acme/po/pl/acme.po
@@ -155,7 +155,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Rozmiar klucza"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/pl/acme.po
+++ b/applications/luci-app-acme/po/pl/acme.po
@@ -285,8 +285,5 @@ msgstr ""
 "uruchomić Acme w trybie webroot. Serwer WWW musi być dostępny z Internetu na "
 "porcie 80."
 
-#~ msgid "State directory"
-#~ msgstr "Katalog stanu"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Gdzie przechowywane są certyfikaty i inne pliki stanu."
+msgid "Cert files are stored in"
+msgstr "Gdzie przechowywane są certyfikaty i inne pliki stanu."

--- a/applications/luci-app-acme/po/pt/acme.po
+++ b/applications/luci-app-acme/po/pt/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.17-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Certificados ACME"
 
@@ -18,70 +18,83 @@ msgstr "Certificados ACME"
 msgid "ACME certs"
 msgstr "Certificados ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Configuração global de ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL do servidor ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Conta de e-mail"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Onde os certificados e outros ficheiros de estado são mantidos."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Configuração do certificado"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Aliás do Desafio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Validação do desafio"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Validação do desafio"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "AC de ACME personalizada"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL personalizada do diretório do servidor ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "API do DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Credenciais do API do DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Validação do desafio"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Dias até à renovação"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Aliás do Domínio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Nomes de domínio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "assunto, os nomes subsequentes serão nomes alternativos. Note que todos os "
 "nomes de domínio devem apontar para o roteador no DNS global."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "O endereço de email para associar à chave da conta."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Ativar o registo de depuração"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Conceder acesso UCI ao luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Tamanho da chave"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Tamanho (e tipo) da chave para o certificado gerado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Autónomo"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "certificado. O modo DNS permitirá que use a API DNS do seu provedor de DNS "
 "para emitir um certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -174,7 +240,7 @@ msgstr ""
 "este processo. O LUCI é compatível apenas com um desafio aliás por "
 "certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -187,7 +253,7 @@ msgstr ""
 "como variável da shell KEY=VAL suprindo múltiplas variáveis para as "
 "credenciais."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -198,7 +264,11 @@ msgstr ""
 "este processo. O LUCI é compatível apenas com um desafio aliás por "
 "certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -215,7 +285,11 @@ msgstr ""
 "demorar um pouco. Verifique os registos log para ver o progresso e quaisquer "
 "erros."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -231,27 +305,31 @@ msgstr ""
 "DNS é também o único modo que suporta certificados curinga. A utilização "
 "deste modo requer a instalação do pacote acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Use uma AC personalizada em vez de Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Use o servidor de estágio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Método de validação"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Validação do desafio"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Diretório webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -260,6 +338,3 @@ msgstr ""
 "Diretório raiz do Webserver. Defina isto para o documento raiz do webserver "
 "para executar o Acme em modo webroot. O servidor web deve estar acessível da "
 "Internet na porta 80."
-
-msgid "Cert files are stored in"
-msgstr "Onde os certificados e outros ficheiros de estado são mantidos."

--- a/applications/luci-app-acme/po/pt/acme.po
+++ b/applications/luci-app-acme/po/pt/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Aliás do Desafio"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Validação do desafio"
+msgid "DNS Challenge Validation"
+msgstr "DNS Validação do desafio"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Validação do desafio"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/pt/acme.po
+++ b/applications/luci-app-acme/po/pt/acme.po
@@ -228,38 +228,9 @@ msgstr ""
 "DNS é também o único modo que suporta certificados curinga. A utilização "
 "deste modo requer a instalação do pacote acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Atualize a configuração nginx com este certificado depois de ser emitido "
-"(selecione isto apenas para um certificado). Nginx deve suportar ssl, caso "
-"contrário não será iniciado precisa ser compilado com o suporte ssl para "
-"usar as opções do cert"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Atualize a configuração uhttpd com este certificado depouis de ser emitido "
-"(selecione isto apenas para um certificado). Também está disponível o luci-"
-"app-uhttpd para configurar uhttpd a partir da interface LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Use uma AC personalizada em vez de Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Uso para nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Use para uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/pt/acme.po
+++ b/applications/luci-app-acme/po/pt/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Tamanho da chave"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Tamanho (e tipo) da chave para o certificado gerado."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Tamanho da chave"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/pt/acme.po
+++ b/applications/luci-app-acme/po/pt/acme.po
@@ -287,8 +287,5 @@ msgstr ""
 "para executar o Acme em modo webroot. O servidor web deve estar acessível da "
 "Internet na porta 80."
 
-#~ msgid "State directory"
-#~ msgstr "Diretório do estado"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Onde os certificados e outros ficheiros de estado são mantidos."
+msgid "Cert files are stored in"
+msgstr "Onde os certificados e outros ficheiros de estado são mantidos."

--- a/applications/luci-app-acme/po/pt/acme.po
+++ b/applications/luci-app-acme/po/pt/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.17-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Certificados ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Certificados ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -338,3 +335,6 @@ msgstr ""
 "Diretório raiz do Webserver. Defina isto para o documento raiz do webserver "
 "para executar o Acme em modo webroot. O servidor web deve estar acessível da "
 "Internet na porta 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Certificados ACME"

--- a/applications/luci-app-acme/po/pt/acme.po
+++ b/applications/luci-app-acme/po/pt/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Tamanho da chave"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/pt_BR/acme.po
+++ b/applications/luci-app-acme/po/pt_BR/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Aliás do Desafio"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Validação do Desafio"
+msgid "DNS Challenge Validation"
+msgstr "DNS Validação do Desafio"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Validação do Desafio"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/pt_BR/acme.po
+++ b/applications/luci-app-acme/po/pt_BR/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.16.2-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Certificados ACME"
 
@@ -18,70 +18,83 @@ msgstr "Certificados ACME"
 msgid "ACME certs"
 msgstr "certificados ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Configuração global ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL do Servidor ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "E-mail da conta"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Configurações avançadas"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Onde os certificados e os outros arquivos de estado são mantidos."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Configuração do certificado"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Aliás do Desafio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Validação do Desafio"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Validação do Desafio"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "CA ACME Customizado"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL do Servidor ACME Customizado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "API do DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Credenciais do API DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Validação do Desafio"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Dias até a renovação"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Aliás do Domínio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Nomes de domínio"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "do assunto, os nomes subsequentes serão nomes alternativos. Observe que "
 "todos os nomes de domínio devem apontar para o roteador no DNS global."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "O endereço de email para associar à chave da conta."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Ativar o registro de depuração"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Ativado"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Configurações gerais"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Conceda acesso UCI para o luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Tamanho da chave"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Tamanho (e tipo) da chave para o certificado gerado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Independente"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "solicitar um certificado. O modo DNS permitirá vocÊ a usar a API de DNS do "
 "seu provedor DNS para solicitar um certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -174,7 +240,7 @@ msgstr ""
 "este processo. O LUCI é compatível apenas com um desafio aliás por "
 "certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -187,7 +253,7 @@ msgstr ""
 "como variável da shell KEY=VAL suprindo múltiplas variáveis para as "
 "credenciais."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -198,7 +264,11 @@ msgstr ""
 "este processo. O LUCI é compatível apenas com um desafio aliás por "
 "certificado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -215,7 +285,11 @@ msgstr ""
 "demorar um pouco. Verifique os registros log para ver os progressos e "
 "quaisquer outros erros."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -231,27 +305,31 @@ msgstr ""
 "O modo DNS também é o único modo que é compatível com certificados curinga. "
 "O uso desse modo requer que o pacote acme-dnsapi esteja instalado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Use uma CA customizada em vez do Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Use o servidor de encenação"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Método de Validação"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Validação do Desafio"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Diretório Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -260,9 +338,6 @@ msgstr ""
 "Diretório raiz do servidor web. Defina isso como raiz do documento do "
 "servidor da web para executar o Acme em modo webroot. O servidor web deve "
 "estar acessível na internet na porta 80."
-
-msgid "Cert files are stored in"
-msgstr "Onde os certificados e os outros arquivos de estado são mantidos."
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/pt_BR/acme.po
+++ b/applications/luci-app-acme/po/pt_BR/acme.po
@@ -228,38 +228,9 @@ msgstr ""
 "O modo DNS também é o único modo que é compatível com certificados curinga. "
 "O uso desse modo requer que o pacote acme-dnsapi esteja instalado."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Uma vez emitido, atualize a configuração nginx com este certificado "
-"(selecione-o apenas para um certificado). O nginx deve ser compatível com "
-"ssl, caso contrário ele não vai iniciar pois para usar as opções cert ele "
-"precisa ser compilado com ssl"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Uma vez emitido, atualize a configuração uhttpd com este certificado "
-"(selecione-o apenas para um certificado). Também está disponível o luci-app-"
-"uhttpd para configurar o uhttpd através da interface LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Use uma CA customizada em vez do Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Uso para o nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Use para o uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/pt_BR/acme.po
+++ b/applications/luci-app-acme/po/pt_BR/acme.po
@@ -287,11 +287,8 @@ msgstr ""
 "servidor da web para executar o Acme em modo webroot. O servidor web deve "
 "estar acessível na internet na porta 80."
 
-#~ msgid "State directory"
-#~ msgstr "Condição do diretório"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Onde os certificados e os outros arquivos de estado são mantidos."
+msgid "Cert files are stored in"
+msgstr "Onde os certificados e os outros arquivos de estado são mantidos."
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/pt_BR/acme.po
+++ b/applications/luci-app-acme/po/pt_BR/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 4.16.2-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "Certificados ACME"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr "certificados ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
@@ -338,6 +335,9 @@ msgstr ""
 "Diretório raiz do servidor web. Defina isso como raiz do documento do "
 "servidor da web para executar o Acme em modo webroot. O servidor web deve "
 "estar acessível na internet na porta 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "certificados ACME"
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/pt_BR/acme.po
+++ b/applications/luci-app-acme/po/pt_BR/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Tamanho da chave"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Tamanho (e tipo) da chave para o certificado gerado."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Tamanho da chave"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/pt_BR/acme.po
+++ b/applications/luci-app-acme/po/pt_BR/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Tamanho da chave"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/ro/acme.po
+++ b/applications/luci-app-acme/po/ro/acme.po
@@ -11,7 +11,7 @@ msgstr ""
 "20)) ? 1 : 2;\n"
 "X-Generator: Weblate 4.18-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Certificate ACME"
 
@@ -19,70 +19,83 @@ msgstr "Certificate ACME"
 msgid "ACME certs"
 msgstr "Certificate ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Configurare globală ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "Adresa URL a server-ului ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Adresa de e-mail a contului"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Setări avansate"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Unde se păstrează certificatele și alte dosare de stat."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Configurarea certificatului"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Alias de provocare"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Validarea provocării"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Validarea provocării"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Certificat ACME personalizat"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL-ul personalizat al directorului serverului ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "credențiale DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Validarea provocării"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Zile până la reînnoire"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Aliasul domeniului"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Numele domeniului"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -92,31 +105,37 @@ msgstr ""
 "subiectului, următoarele nume vor fi alternative. Ține minte că toate numele "
 "domeniului trebuie să ducă la router în DNS-ul global."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 biți"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 biți"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Adresa de email ce va fi asociată cu cheia contului."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Activați jurnalizarea de depanare"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "activat"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Setări generale"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -128,31 +147,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Acordă acces la UCI pentru luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Dimensiunea cheii"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Dimensiunea (și tipul) cheii pentru certificatul generat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 biți"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 biți"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 biți"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "De sine stătător"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -164,7 +230,7 @@ msgstr ""
 "emite un certificat. Modul DNS îți va permite să folosești API-ul DNS al "
 "provider-ului DNS pentru a emite un certificat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -175,7 +241,7 @@ msgstr ""
 "pentru detalii despre acest proces. LUCI acceptă doar un singur alias de "
 "provocare pentru fiecare certificat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -188,7 +254,7 @@ msgstr ""
 "formatul variabilei de shell KEY=VAL pentru a furniza mai multe variabile de "
 "acreditare."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -199,7 +265,11 @@ msgstr ""
 "detalii despre acest proces. LUCI acceptă doar un singur domeniu de "
 "provocare pentru fiecare certificat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -216,7 +286,11 @@ msgstr ""
 "certificatelor poate dura ceva timp. Verificați jurnalele pentru a vedea "
 "progresul și eventualele erori."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -232,27 +306,31 @@ msgstr ""
 "DNS este, de asemenea, singurul mod care acceptă certificate wildcard. "
 "Utilizarea acestui mod necesită instalarea pachetului acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Utilizați un CA personalizat în loc de Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Utilizați serverul staging"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Metoda de validare"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Validarea provocării"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Directorul webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -261,6 +339,3 @@ msgstr ""
 "Directorul rădăcină al serverului web. Setați acest lucru la rădăcina "
 "documentului serverului web pentru a rula Acme în modul webroot. Serverul "
 "web trebuie să fie accesibil de pe internet pe portul 80."
-
-msgid "Cert files are stored in"
-msgstr "Unde se păstrează certificatele și alte dosare de stat."

--- a/applications/luci-app-acme/po/ro/acme.po
+++ b/applications/luci-app-acme/po/ro/acme.po
@@ -44,8 +44,11 @@ msgid "Challenge Alias"
 msgstr "Alias de provocare"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Validarea provocării"
+msgid "DNS Challenge Validation"
+msgstr "DNS Validarea provocării"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Validarea provocării"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/ro/acme.po
+++ b/applications/luci-app-acme/po/ro/acme.po
@@ -229,38 +229,9 @@ msgstr ""
 "DNS este, de asemenea, singurul mod care acceptă certificate wildcard. "
 "Utilizarea acestui mod necesită instalarea pachetului acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Actualizați configurația nginx cu acest certificat odată emis (selectați-l "
-"doar pentru un certificat). Nginx trebuie să accepte ssl, în caz contrar nu "
-"va porni, deoarece trebuie să fie compilat cu suport ssl pentru a utiliza "
-"opțiunile de certificare"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Actualizați configurația uhttpd cu acest certificat odată ce a fost emis "
-"(selectați acest lucru doar pentru un certificat). Este disponibil și luci-"
-"app-uhttpd pentru a configura uhttpd din interfața LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Utilizați un CA personalizat în loc de Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Utilizați pentru nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Utilizați pentru uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/ro/acme.po
+++ b/applications/luci-app-acme/po/ro/acme.po
@@ -12,11 +12,8 @@ msgstr ""
 "X-Generator: Weblate 4.18-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Certificate ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Certificate ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -339,3 +336,6 @@ msgstr ""
 "Directorul rădăcină al serverului web. Setați acest lucru la rădăcina "
 "documentului serverului web pentru a rula Acme în modul webroot. Serverul "
 "web trebuie să fie accesibil de pe internet pe portul 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Certificate ACME"

--- a/applications/luci-app-acme/po/ro/acme.po
+++ b/applications/luci-app-acme/po/ro/acme.po
@@ -288,8 +288,5 @@ msgstr ""
 "documentului serverului web pentru a rula Acme în modul webroot. Serverul "
 "web trebuie să fie accesibil de pe internet pe portul 80."
 
-#~ msgid "State directory"
-#~ msgstr "Directorul de stat"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Unde se păstrează certificatele și alte dosare de stat."
+msgid "Cert files are stored in"
+msgstr "Unde se păstrează certificatele și alte dosare de stat."

--- a/applications/luci-app-acme/po/ro/acme.po
+++ b/applications/luci-app-acme/po/ro/acme.po
@@ -154,13 +154,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Dimensiunea cheii"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Dimensiunea (și tipul) cheii pentru certificatul generat."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Dimensiunea cheii"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/ro/acme.po
+++ b/applications/luci-app-acme/po/ro/acme.po
@@ -155,7 +155,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Dimensiunea cheii"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -12,11 +12,8 @@ msgstr ""
 "X-Generator: Weblate 4.17-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "Сертификаты ACME"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "Сертификаты ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -37,7 +34,8 @@ msgstr "Расширенные настройки"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
 msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
-msgstr "Base64 содержимое приватного ключа. Используйте вместо YC_SA_Key_File_Path"
+msgstr ""
+"Base64 содержимое приватного ключа. Используйте вместо YC_SA_Key_File_Path"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
 msgid "Cert files are stored in"
@@ -182,7 +180,9 @@ msgstr ""
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
 msgid ""
 "Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
-msgstr "Зайдите на <a href=\"https://www.duckdns.org/\">DuckDNS</a> и скопируйте токен сюда"
+msgstr ""
+"Зайдите на <a href=\"https://www.duckdns.org/\">DuckDNS</a> и скопируйте "
+"токен сюда"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
 msgid "Path to private API signing key file in PEM format"
@@ -227,10 +227,11 @@ msgid ""
 "certificate. DNS mode will allow you to use the DNS API of your DNS provider "
 "to issue a certificate."
 msgstr ""
-"В Самостоятельном режиме для выдачи сертификата будет использоваться встроенный "
-"веб-сервер acme.sh. Подтверждение через Webroot будет использовать существующий веб-сервер "
-"для выдачи сертификата. Подтверждение через DNS позволит вам использовать API DNS вашего "
-"провайдера DNS для выпуска сертификата."
+"В Самостоятельном режиме для выдачи сертификата будет использоваться "
+"встроенный веб-сервер acme.sh. Подтверждение через Webroot будет "
+"использовать существующий веб-сервер для выдачи сертификата. Подтверждение "
+"через DNS позволит вам использовать API DNS вашего провайдера DNS для "
+"выпуска сертификата."
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
@@ -338,3 +339,6 @@ msgid ""
 msgstr ""
 "Укажите здесь корневой каталог веб-сервера, чтобы запустить Acme в режиме "
 "webroot. Веб-сервер должен быть доступен из интернета на 80 порту."
+
+#~ msgid "ACME certs"
+#~ msgstr "Сертификаты ACME"

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -157,13 +157,13 @@ msgstr ""
 msgid "Issued on"
 msgstr "Выпущен"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Размер ключа"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Размер (и тип) ключа для сгенерированного сертификата."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Размер ключа"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -44,8 +44,11 @@ msgid "Challenge Alias"
 msgstr "Псевдонимы вызова"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Проверка вызовов"
+msgid "DNS Challenge Validation"
+msgstr "DNS подтверждение"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot подтверждение"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -11,7 +11,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.17-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Сертификаты ACME"
 
@@ -19,107 +19,123 @@ msgstr "Сертификаты ACME"
 msgid "ACME certs"
 msgstr "Сертификаты ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Глобальная конфигурация ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL сервера ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Электронная почта учётной записи"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Расширенные настройки"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Сертификаты сохраняются в папку"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Конфигурация сертификата"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Псевдонимы вызова"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS подтверждение"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot подтверждение"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Персонализированный ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL-адрес пользовательского каталога сервера ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Данные для доступа к DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS подтверждение"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Дней до продления"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Псевдоним домена"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Доменные имена"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
-"Доменные имена для включения в сертификат. Первое имя — имя субъекта ("
-"subject name), следующие имена — дополнительные (alt names). Все доменные "
+"Доменные имена для включения в сертификат. Первое имя — имя субъекта "
+"(subject name), следующие имена — дополнительные (alt names). Все доменные "
 "имена должны указывать на маршрутизатор в глобальной DNS."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 бит"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 бита"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "E-mail адрес для привязки ключа аккаунта."
 
-msgid "If a certificate wasn't renewed in time then you'll receive a notice at 20 days before expiry."
-msgstr "Если сертификат не был перевыпущен вовремя то вы получите уведомление за 20 дней до истечения срока действия."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Записывать в журнал данные для отладки"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Включен"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Общие настройки"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -131,31 +147,80 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Предоставить UCI доступ для luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+"Если сертификат не был перевыпущен вовремя то вы получите уведомление за 20 "
+"дней до истечения срока действия."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Размер ключа"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Размер (и тип) ключа для сгенерированного сертификата."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 бит"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 бита"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 бит"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Автономный"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -167,7 +232,7 @@ msgstr ""
 "для выдачи сертификата. Режим DNS позволит вам использовать API DNS вашего "
 "провайдера DNS для выпуска сертификата."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -178,7 +243,7 @@ msgstr ""
 "DNS-alias-mode. LUCI поддерживает только один псевдоним вызова для каждого "
 "сертификата."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -190,17 +255,21 @@ msgstr ""
 "acme.sh/wiki/dnsapi. Добавьте сюда несколько записей в формате переменной "
 "оболочки KEY=VAL, чтобы предоставить несколько переменных учетных данных."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
-"Псевдоним домена для ВСЕХ доменов. Подробнее об этом процессе см. "
-"https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode. LUCI "
-"поддерживает только один контрольный домен для каждого сертификата."
+"Псевдоним домена для ВСЕХ доменов. Подробнее об этом процессе см. https://"
+"github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode. LUCI поддерживает "
+"только один контрольный домен для каждого сертификата."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -217,7 +286,11 @@ msgstr ""
 "выдача сертификатов может занять некоторое время. Проверьте журналы на "
 "наличие прогресса и ошибок."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -233,27 +306,31 @@ msgstr ""
 "является единственным режимом, поддерживающий подстановочные сертификаты. "
 "Для использования этого режима необходимо установить пакет acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Использовать сторонний центр сертификации вместо Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Использовать тестовый сервер"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Метод проверки"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot подтверждение"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Каталог Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -261,6 +338,3 @@ msgid ""
 msgstr ""
 "Укажите здесь корневой каталог веб-сервера, чтобы запустить Acme в режиме "
 "webroot. Веб-сервер должен быть доступен из интернета на 80 порту."
-
-msgid "Cert files are stored in"
-msgstr "Сертификаты сохраняются в папку"

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -227,38 +227,9 @@ msgstr ""
 "является единственным режимом, поддерживающий подстановочные сертификаты. "
 "Для использования этого режима необходимо установить пакет acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Дополнить конфигурацию nginx этим сертификатом как только он будет выдан ("
-"используйте эту функцию только для одного сертификата). Nginx должен "
-"поддерживать SSL, или же его нужно будет перекомпилировать с поддержкой SSL "
-"чтобы использовать настройки сертификата"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Обновить конфигурацию uhttpd этим сертификатом после его выпуска (выберите "
-"этот параметр только для одного сертификата). Также доступен luci-app-uhttpd "
-"для настройки uhttpd из интерфейса LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Использовать сторонний центр сертификации вместо Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Использовать для nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Использовать для uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -285,8 +285,5 @@ msgstr ""
 "Укажите здесь корневой каталог веб-сервера, чтобы запустить Acme в режиме "
 "webroot. Веб-сервер должен быть доступен из интернета на 80 порту."
 
-#~ msgid "State directory"
-#~ msgstr "Директория хранения данных"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Где хранятся сертификаты и другие файлы состояния."
+msgid "Cert files are stored in"
+msgstr "Сертификаты сохраняются в папку"

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -104,6 +104,9 @@ msgstr "ECC 384 бита"
 msgid "Email address to associate with account key."
 msgstr "E-mail адрес для привязки ключа аккаунта."
 
+msgid "If a certificate wasn't renewed in time then you'll receive a notice at 20 days before expiry."
+msgstr "Если сертификат не был перевыпущен вовремя то вы получите уведомление за 20 дней до истечения срока действия."
+
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
 msgid "Enable debug logging"
 msgstr "Записывать в журнал данные для отладки"

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -37,7 +37,7 @@ msgstr "Расширенные настройки"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
 msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
-msgstr ""
+msgstr "Base64 содержимое приватного ключа. Используйте вместо YC_SA_Key_File_Path"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
 msgid "Cert files are stored in"
@@ -49,7 +49,7 @@ msgstr "Конфигурация сертификата"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
 msgid "Certificates"
-msgstr ""
+msgstr "Сертификаты"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
@@ -85,7 +85,7 @@ msgstr "Дней до продления"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
 msgid "Default"
-msgstr ""
+msgstr "По умолчанию"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
@@ -157,7 +157,7 @@ msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
 msgid "Issued on"
-msgstr ""
+msgstr "Выпущен"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
@@ -169,7 +169,7 @@ msgstr "Размер (и тип) ключа для сгенерированно�
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"
-msgstr ""
+msgstr "Главный домен"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
 msgid "OCID of tenancy that contains the target DNS zone"
@@ -182,19 +182,19 @@ msgstr ""
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
 msgid ""
 "Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
-msgstr ""
+msgstr "Зайдите на <a href=\"https://www.duckdns.org/\">DuckDNS</a> и скопируйте токен сюда"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
 msgid "Path to private API signing key file in PEM format"
-msgstr ""
+msgstr "Путь к ключу приватного API в PEM формате"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
 msgid "Private Key"
-msgstr ""
+msgstr "Приватный ключ"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
 msgid "Public Certificate"
-msgstr ""
+msgstr "Публичный сертификат"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
@@ -210,7 +210,7 @@ msgstr "RSA 4096 бит"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
 msgid "See instructions"
-msgstr ""
+msgstr "Смотрите инструкции"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
 msgid "Should point to the tenancy home region"
@@ -218,7 +218,7 @@ msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
-msgstr "Автономный"
+msgstr "Самостоятельно"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
@@ -227,9 +227,9 @@ msgid ""
 "certificate. DNS mode will allow you to use the DNS API of your DNS provider "
 "to issue a certificate."
 msgstr ""
-"В автономном режиме для выдачи сертификата будет использоваться встроенный "
-"веб-сервер acme.sh. Режим Webroot будет использовать существующий веб-сервер "
-"для выдачи сертификата. Режим DNS позволит вам использовать API DNS вашего "
+"В Самостоятельном режиме для выдачи сертификата будет использоваться встроенный "
+"веб-сервер acme.sh. Подтверждение через Webroot будет использовать существующий веб-сервер "
+"для выдачи сертификата. Подтверждение через DNS позволит вам использовать API DNS вашего "
 "провайдера DNS для выпуска сертификата."
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
@@ -267,7 +267,7 @@ msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
 msgid "The private API signing key in PEM format"
-msgstr ""
+msgstr "Приватный ключ подписи API в PEM формате"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""

--- a/applications/luci-app-acme/po/ru/acme.po
+++ b/applications/luci-app-acme/po/ru/acme.po
@@ -158,7 +158,7 @@ msgid "Issued on"
 msgstr "Выпущен"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Размер ключа"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/si/acme.po
+++ b/applications/luci-app-acme/po/si/acme.po
@@ -42,8 +42,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/si/acme.po
+++ b/applications/luci-app-acme/po/si/acme.po
@@ -148,12 +148,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/si/acme.po
+++ b/applications/luci-app-acme/po/si/acme.po
@@ -193,30 +193,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/si/acme.po
+++ b/applications/luci-app-acme/po/si/acme.po
@@ -149,7 +149,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/si/acme.po
+++ b/applications/luci-app-acme/po/si/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.5\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr ""
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36

--- a/applications/luci-app-acme/po/si/acme.po
+++ b/applications/luci-app-acme/po/si/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 4.5\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr ""
 
@@ -18,100 +18,120 @@ msgstr ""
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "ව.නා.ප."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "වසම් නාම"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -121,31 +141,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -153,14 +220,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -168,14 +235,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -185,7 +256,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -195,27 +270,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/sk/acme.po
+++ b/applications/luci-app-acme/po/sk/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Dĺžka kľúča"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Dĺžka (a typ) kľúča pre generovaný certifikát."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Dĺžka kľúča"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/sk/acme.po
+++ b/applications/luci-app-acme/po/sk/acme.po
@@ -42,8 +42,10 @@ msgstr "Konfigurácia certifikátov"
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/sk/acme.po
+++ b/applications/luci-app-acme/po/sk/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.14.1\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME certifikáty"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME certifikáty"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -309,3 +306,6 @@ msgid ""
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME certifikáty"

--- a/applications/luci-app-acme/po/sk/acme.po
+++ b/applications/luci-app-acme/po/sk/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 4.14.1\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME certifikáty"
 
@@ -18,69 +18,83 @@ msgstr "ACME certifikáty"
 msgid "ACME certs"
 msgstr "ACME certifikáty"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME globálna konfigurácia"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "E-mail účtu"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Konfigurácia certifikátov"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Prihlasovacie údaje DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Alias domény"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Domény"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -89,31 +103,37 @@ msgstr ""
 "Domény v certifikáte. Prvá bude názov subjektu, ďalšie budú alternatívne "
 "názvy. Všetky domény musia smerovať na router v globálnom DNS."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "E-mailová adresa k účtu."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Povoliť detailné záznamy"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Zapnuté"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 #, fuzzy
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
@@ -126,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Povoliť luci-app-acme prístup k UCI"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Dĺžka kľúča"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Dĺžka (a typ) kľúča pre generovaný certifikát."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -158,14 +225,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 #, fuzzy
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
@@ -177,14 +244,18 @@ msgstr ""
 "acmesh-official/acme.sh/wiki/dnsapi pre formát údajov požadovaný každým API. "
 "Pre zadanie viacerých údajov tu pridaj hodnoty v tvare KĽÚČ=HODNOTA."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -194,7 +265,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -204,27 +279,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/sk/acme.po
+++ b/applications/luci-app-acme/po/sk/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Dĺžka kľúča"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/sk/acme.po
+++ b/applications/luci-app-acme/po/sk/acme.po
@@ -202,30 +202,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/sv/acme.po
+++ b/applications/luci-app-acme/po/sv/acme.po
@@ -42,8 +42,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/sv/acme.po
+++ b/applications/luci-app-acme/po/sv/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 4.10-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "ACME-certifikat"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"

--- a/applications/luci-app-acme/po/sv/acme.po
+++ b/applications/luci-app-acme/po/sv/acme.po
@@ -251,8 +251,5 @@ msgid ""
 "port 80."
 msgstr ""
 
-#~ msgid "State directory"
-#~ msgstr "Tillståndskatalog"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Där certifikat och andra tillståndsfiler sparas."
+msgid "Cert files are stored in"
+msgstr "Där certifikat och andra tillståndsfiler sparas."

--- a/applications/luci-app-acme/po/sv/acme.po
+++ b/applications/luci-app-acme/po/sv/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Nyckelstorlek"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/sv/acme.po
+++ b/applications/luci-app-acme/po/sv/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.10-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME-certifikat"
 
@@ -18,69 +18,83 @@ msgstr "ACME-certifikat"
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "E-postkonto"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Avancerade inställningar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Där certifikat och andra tillståndsfiler sparas."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Domännamn"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -90,31 +104,37 @@ msgstr ""
 "Efterföljande namn blir alternativa namn. Notera att alla domännamn måste "
 "peka på routern i den globala DNS:en."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bitar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bitar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "E-postadress att koppla till kontonyckeln."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Aktivera avlunsingsloggning"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Generella inställningar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -126,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Bevilja UCI-tillgång till luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Nyckelstorlek"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Nyckelstorlek (och typ) för det genererade certifikatet."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bitar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bitar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bitar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Fristående"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -162,14 +229,14 @@ msgstr ""
 "att utfärda ett. DNS-lägen tillåter dig att använde din DNS-tjänsts DNS API "
 "för att utfärda ett certifikat."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -177,14 +244,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -194,7 +265,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -204,32 +279,33 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Använd iscensättningsserver"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webbrot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webbrotskatalog"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
 "port 80."
 msgstr ""
-
-msgid "Cert files are stored in"
-msgstr "Där certifikat och andra tillståndsfiler sparas."

--- a/applications/luci-app-acme/po/sv/acme.po
+++ b/applications/luci-app-acme/po/sv/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Nyckelstorlek"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Nyckelstorlek (och typ) för det genererade certifikatet."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Nyckelstorlek"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/sv/acme.po
+++ b/applications/luci-app-acme/po/sv/acme.po
@@ -202,30 +202,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/templates/acme.pot
+++ b/applications/luci-app-acme/po/templates/acme.pot
@@ -139,12 +139,12 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584

--- a/applications/luci-app-acme/po/templates/acme.pot
+++ b/applications/luci-app-acme/po/templates/acme.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr ""
 
@@ -9,100 +9,120 @@ msgstr ""
 msgid "ACME certs"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr ""
 
-msgid "DNS Challenge Validation"
-msgstr ""
-
-msgid "Webroot Challenge Validation"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
 "must point at the router in the global DNS."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -112,31 +132,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -144,14 +211,14 @@ msgid ""
 "to issue a certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge alias per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -159,14 +226,18 @@ msgid ""
 "supply multiple credential variables."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
 "only supports one challenge domain per certificate."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -176,7 +247,11 @@ msgid ""
 "logs for progress and any errors."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -186,27 +261,31 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/templates/acme.pot
+++ b/applications/luci-app-acme/po/templates/acme.pot
@@ -184,30 +184,8 @@ msgid ""
 "package to be installed."
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr ""
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49

--- a/applications/luci-app-acme/po/templates/acme.pot
+++ b/applications/luci-app-acme/po/templates/acme.pot
@@ -140,7 +140,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/templates/acme.pot
+++ b/applications/luci-app-acme/po/templates/acme.pot
@@ -2,11 +2,8 @@ msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr ""
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36

--- a/applications/luci-app-acme/po/templates/acme.pot
+++ b/applications/luci-app-acme/po/templates/acme.pot
@@ -33,8 +33,10 @@ msgstr ""
 msgid "Challenge Alias"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
+msgid "DNS Challenge Validation"
+msgstr ""
+
+msgid "Webroot Challenge Validation"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139

--- a/applications/luci-app-acme/po/tr/acme.po
+++ b/applications/luci-app-acme/po/tr/acme.po
@@ -225,38 +225,9 @@ msgstr ""
 "çözümlemesi gerekmez. DNS modu, joker karakter sertifikalarını destekleyen "
 "tek moddur. Bu modu kullanmak, acme-dnsapi paketinin yüklenmesini gerektirir."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Nginx yapılandırmasını bu sertifika verildikten sonra güncelleyin (bunu "
-"yalnızca bir sertifika için seçin). Nginx, ssl'yi desteklemelidir, değilse, "
-"sertifika seçeneklerini kullanmak için ssl desteği ile derlenmesi "
-"gerektiğinden başlamaz"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Bu sertifika verildikten sonra uhttpd yapılandırmasını güncelleyin (bunu "
-"yalnızca bir sertifika için seçin). LuCI arayüzünden uhttpd'yi yapılandırmak "
-"için luci-app-uhttpd de mevcuttur."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Let's Encrypt yerine özel bir CA kullanın."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Nginx için kullanın"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Uhttpd için kullanın"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/tr/acme.po
+++ b/applications/luci-app-acme/po/tr/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Anahtar boyutu"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/tr/acme.po
+++ b/applications/luci-app-acme/po/tr/acme.po
@@ -284,8 +284,5 @@ msgstr ""
 "sunucusu belge köküne ayarlayın. Web sunucusuna 80 numaralı bağlantı "
 "noktasından internetten erişilebilmelidir."
 
-#~ msgid "State directory"
-#~ msgstr "Dizin belirt"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Sertifikaların ve diğer dosyaların tutulduğu yer."
+msgid "Cert files are stored in"
+msgstr "Sertifikaların ve diğer dosyaların tutulduğu yer."

--- a/applications/luci-app-acme/po/tr/acme.po
+++ b/applications/luci-app-acme/po/tr/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Challenge Takma Adı"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Zorluk Doğrulaması"
+msgid "DNS Challenge Validation"
+msgstr "DNS Zorluk Doğrulaması"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Zorluk Doğrulaması"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/tr/acme.po
+++ b/applications/luci-app-acme/po/tr/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.7-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME sertifikaları"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME sertifikaları"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -335,3 +332,6 @@ msgstr ""
 "Web sunucusu kök dizini. Acme'yi webroot modunda çalıştırmak için bunu web "
 "sunucusu belge köküne ayarlayın. Web sunucusuna 80 numaralı bağlantı "
 "noktasından internetten erişilebilmelidir."
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME sertifikaları"

--- a/applications/luci-app-acme/po/tr/acme.po
+++ b/applications/luci-app-acme/po/tr/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 4.7-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME sertifikaları"
 
@@ -18,70 +18,83 @@ msgstr "ACME sertifikaları"
 msgid "ACME certs"
 msgstr "ACME sertifikaları"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME evrensel yapılandırma"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACME sunucu URL'si"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Hesap e-postası"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Gelişmiş Ayarlar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Sertifikaların ve diğer dosyaların tutulduğu yer."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Sertifika yapılandırması"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Challenge Takma Adı"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Zorluk Doğrulaması"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Zorluk Doğrulaması"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Özel ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "Özel ACME sunucu dizini URL'si."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API bilgileri"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Zorluk Doğrulaması"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Yenilemeye kalan gün sayısı"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Alan Takma Adı"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Alan adları"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -91,31 +104,37 @@ msgstr ""
 "alternatif adlar olacak. Domain adlarının evrensel DNS'de router'ı "
 "göstermesi gerektiğini unutmayın."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Hesap anahtarına bağlanacak e-posta adresi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Hata ayıklama günlüğünü etkinleştir"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Etkin"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Genel Ayarlar"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -127,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "luci-app-acme için UCI erişimi verin"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Anahtar boyutu"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Oluşturulmuş sertifika için anahtar boyutu (ve türü)."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Bağımsız"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -163,7 +229,7 @@ msgstr ""
 "kullanır. DNS modu, bir sertifika vermek için DNS sağlayıcınızın DNS "
 "API'sini kullanmanıza izin verir."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -173,7 +239,7 @@ msgstr ""
 "https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode adresine göz "
 "atın. LUCI sertifika başına sadece bir tane challenge takma adını destekler."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -185,7 +251,7 @@ msgstr ""
 "dnsapi adresine bakın. Birden çok kimlik bilgisi değişkeni sağlamak için "
 "buraya birden çok KEY = VAL olarak shell değişkeni ekleyin."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -195,7 +261,11 @@ msgstr ""
 "için https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode adresine "
 "göz atın. LUCI, sertifika başına yalnızca bir challenge alanını destekler."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -212,7 +282,11 @@ msgstr ""
 "sertifikaların verilmesi biraz zaman alabilir. İlerleme ve herhangi bir hata "
 "için günlük kayıtlarına bakın."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -228,27 +302,31 @@ msgstr ""
 "çözümlemesi gerekmez. DNS modu, joker karakter sertifikalarını destekleyen "
 "tek moddur. Bu modu kullanmak, acme-dnsapi paketinin yüklenmesini gerektirir."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Let's Encrypt yerine özel bir CA kullanın."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Aşama sunucusu kullan"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Doğrulama yöntemi"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Zorluk Doğrulaması"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webroot dizini"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -257,6 +335,3 @@ msgstr ""
 "Web sunucusu kök dizini. Acme'yi webroot modunda çalıştırmak için bunu web "
 "sunucusu belge köküne ayarlayın. Web sunucusuna 80 numaralı bağlantı "
 "noktasından internetten erişilebilmelidir."
-
-msgid "Cert files are stored in"
-msgstr "Sertifikaların ve diğer dosyaların tutulduğu yer."

--- a/applications/luci-app-acme/po/tr/acme.po
+++ b/applications/luci-app-acme/po/tr/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Anahtar boyutu"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Oluşturulmuş sertifika için anahtar boyutu (ve türü)."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Anahtar boyutu"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/uk/acme.po
+++ b/applications/luci-app-acme/po/uk/acme.po
@@ -12,11 +12,8 @@ msgstr ""
 "X-Generator: Weblate 4.15.1-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME сертифікати"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME сертифікати"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -338,3 +335,6 @@ msgstr ""
 "Коренева тека веб-сервера. Встановіть для цього параметра кореневу теку "
 "документа веб-сервера, щоб запустити Acme в режимі webroot. Веб-сервер "
 "повинен бути доступний з Інтернету через порт 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME сертифікати"

--- a/applications/luci-app-acme/po/uk/acme.po
+++ b/applications/luci-app-acme/po/uk/acme.po
@@ -287,8 +287,5 @@ msgstr ""
 "документа веб-сервера, щоб запустити Acme в режимі webroot. Веб-сервер "
 "повинен бути доступний з Інтернету через порт 80."
 
-#~ msgid "State directory"
-#~ msgstr "Каталог стану"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "Де зберігаються сертифікати та інші файли стану."
+msgid "Cert files are stored in"
+msgstr "Сертифікати зберігаються у каталог "

--- a/applications/luci-app-acme/po/uk/acme.po
+++ b/applications/luci-app-acme/po/uk/acme.po
@@ -156,13 +156,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Розмір ключа"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Розмір (і тип) ключа для згенерованого сертифіката."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Розмір ключа"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/uk/acme.po
+++ b/applications/luci-app-acme/po/uk/acme.po
@@ -228,38 +228,9 @@ msgstr ""
 "єдиним режимом, який підтримує підстановочні сертифікати. Для використання "
 "цього режиму потрібно встановити пакет acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Оновити конфігурацію nginx цим сертифікатом після його видачі "
-"(використовуйте цю функцію лише для одного сертифіката). Nginx повинен "
-"підтримувати ssl, якщо ні, він не запуститься, оскільки його потрібно "
-"скомпілювати з підтримкою ssl, щоб використовувати параметри сертифікатів"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Оновіть конфігурацію uhttpd цим сертифіката після його видачі "
-"(використовуйте цю функцію лише для одного сертифіката). Також доступний "
-"luci-app-uhttpd для налаштування uhttpd з інтерфейсу LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Використовувати інший ЦС замість Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Використовувати для nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Використовувати для uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/uk/acme.po
+++ b/applications/luci-app-acme/po/uk/acme.po
@@ -157,7 +157,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Розмір ключа"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/uk/acme.po
+++ b/applications/luci-app-acme/po/uk/acme.po
@@ -44,8 +44,11 @@ msgid "Challenge Alias"
 msgstr "Псевдоніми виклику"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Перевірка викликів"
+msgid "DNS Challenge Validation"
+msgstr "DNS Перевірка викликів"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Перевірка викликів"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/uk/acme.po
+++ b/applications/luci-app-acme/po/uk/acme.po
@@ -11,7 +11,7 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.15.1-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME сертифікати"
 
@@ -19,70 +19,83 @@ msgstr "ACME сертифікати"
 msgid "ACME certs"
 msgstr "ACME сертифікати"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Глобальні налаштування ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "URL-адреса сервера ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Електронна адреса пошти облікового запису"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Додаткові налаштування"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "Сертифікати зберігаються у каталог "
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Параметри сертифіката"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Псевдоніми виклику"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Перевірка викликів"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Перевірка викликів"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Користувацький ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "URL-адреса каталогу користувацького сервера ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Облікові дані DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Перевірка викликів"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Днів до поновлення"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Псевдонім домену"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Імена домену"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -93,32 +106,38 @@ msgstr ""
 "Запримітьте, що всі доменні імена повинні вказувати на маршрутизатор у "
 "глобальному DNS."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 біт"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 біт"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 "Адреса електронної пошти, яку потрібно зв’язати з ключем облікового запису."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Увімкнути системний журнал"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Загальні налаштування"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -130,31 +149,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Надати UCI доступ для luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Розмір ключа"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Розмір (і тип) ключа для згенерованого сертифіката."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 біт"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 біт"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 біт"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Автономний"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -166,7 +232,7 @@ msgstr ""
 "видачі сертифіката. Режим DNS дозволить вам використовувати API DNS вашого "
 "постачальника DNS для видачі сертифіката."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -176,7 +242,7 @@ msgstr ""
 "official/acme.sh/wiki/DNS-alias-mode, щоб дізнатися більше про цей процес. "
 "LUCI підтримує лише один псевдонім виклику на сертифікат."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -188,7 +254,7 @@ msgstr ""
 "для кожного API. Додайте тут кілька записів у форматі змінної оболонки "
 "KEY=VAL, щоб надати декілька змінних облікових даних."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -198,7 +264,11 @@ msgstr ""
 "official/acme.sh/wiki/DNS-alias-mode, щоб дізнатися більше про цей процес. "
 "LUCI підтримує лише один псевдонім виклику на сертифікат."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -215,7 +285,11 @@ msgstr ""
 "зайняти деякий час. Перевірте журнали на наявність прогресу та будь-яких "
 "помилок."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -231,27 +305,31 @@ msgstr ""
 "єдиним режимом, який підтримує підстановочні сертифікати. Для використання "
 "цього режиму потрібно встановити пакет acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Використовувати інший ЦС замість Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Використовувати проміжний сервер"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Метод перевірки"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Перевірка викликів"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Тека Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -260,6 +338,3 @@ msgstr ""
 "Коренева тека веб-сервера. Встановіть для цього параметра кореневу теку "
 "документа веб-сервера, щоб запустити Acme в режимі webroot. Веб-сервер "
 "повинен бути доступний з Інтернету через порт 80."
-
-msgid "Cert files are stored in"
-msgstr "Сертифікати зберігаються у каталог "

--- a/applications/luci-app-acme/po/vi/acme.po
+++ b/applications/luci-app-acme/po/vi/acme.po
@@ -224,38 +224,9 @@ msgstr ""
 "nhất hỗ trợ chứng chỉ ký tự đại diện. Sử dụng chế độ này yêu cầu phải cài "
 "đặt gói acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"Cập nhật cấu hình nginx với chứng chỉ này sau khi được cấp (chỉ chọn chứng "
-"chỉ này cho một chứng chỉ). Nginx phải hỗ trợ ssl, nếu không nó sẽ không "
-"khởi động vì nó cần được biên dịch với hỗ trợ ssl để sử dụng các tùy chọn "
-"chứng chỉ"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"Cập nhật cấu hình uhttpd với chứng chỉ này sau khi được cấp (chỉ chọn tùy "
-"chọn này cho một chứng chỉ). Cũng có sẵn luci-app-uhttpd để định cấu hình "
-"uhttpd từ giao diện LuCI."
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Sử dụng tùy chỉnh nhà cung cấp chứng chỉ thay cho Let's Encrypt."
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "Sử dụng cho nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "Sử dụng cho uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/vi/acme.po
+++ b/applications/luci-app-acme/po/vi/acme.po
@@ -154,7 +154,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "Kích thước khóa"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/vi/acme.po
+++ b/applications/luci-app-acme/po/vi/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 4.18.1\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "Chứng chỉ ACME"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr "Các chứng chỉ ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
@@ -334,3 +331,6 @@ msgstr ""
 "Thư mục gốc của máy chủ web. Đặt cái này thành gốc tài liệu máy chủ web để "
 "chạy Acme ở chế độ gốc web. Máy chủ web phải có thể truy cập được từ "
 "internet trên cổng 80."
+
+#~ msgid "ACME certs"
+#~ msgstr "Các chứng chỉ ACME"

--- a/applications/luci-app-acme/po/vi/acme.po
+++ b/applications/luci-app-acme/po/vi/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 4.18.1\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "Chứng chỉ ACME"
 
@@ -18,69 +18,83 @@ msgstr "Chứng chỉ ACME"
 msgid "ACME certs"
 msgstr "Các chứng chỉ ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "Cấu hình ACME toàn cầu"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "Đường dẫn máy chủ ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "Tài khoản email"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "Cài đặt nâng cao"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "Cấu hình chứng chỉ"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Bí danh"
 
-msgid "DNS Challenge Validation"
-msgstr "DNS Thẩm định"
-
-msgid "Webroot Challenge Validation"
-msgstr "Webroot Thẩm định"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "Tùy chỉnh ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "Tùy chỉnh đường dẫn máy chủ ACME."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "Thông tin đăng nhập DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Thẩm định"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "Cho đến ngày được làm mới"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "Tên miền bí danh"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "Tên miền"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -90,31 +104,37 @@ msgstr ""
 "tiếp theo sẽ là tên thay thế. Lưu ý rằng tất cả các tên miền phải trỏ đến bộ "
 "định tuyến trong DNS."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 bit"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "Tài khoản email phải được kết hợp với chìa khóa của tài khoản."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "Kích hoạt nhật ký bug"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "Kích Hoạt"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "Các cài đặt chung"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -126,31 +146,78 @@ msgstr ""
 msgid "Grant UCI access for luci-app-acme"
 msgstr "Cấp quyền truy cập cho luci-app-acme"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "Kích thước khóa"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Kích thước khóa cho chứng chỉ được tạo."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA kích thước 2048 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA kích thước 3072 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA kích thước 4096 bits"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "Biệt lập"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -162,7 +229,7 @@ msgstr ""
 "sẽ cho phép bạn sử dụng API DNS của nhà cung cấp DNS của bạn để cấp chứng "
 "chỉ."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -172,7 +239,7 @@ msgstr ""
 "acmesh-official/acme.sh/wiki/DNS-alias-mode để biết chi tiết về quy trình "
 "này. LUCI chỉ hỗ trợ một bí danh thách thức cho mỗi chứng chỉ."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -184,7 +251,7 @@ msgstr ""
 "mà mỗi API yêu cầu. Thêm nhiều mục vào đây ở định dạng biến hệ vỏ KEY=VAL để "
 "cung cấp nhiều biến thông tin xác thực."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -194,7 +261,11 @@ msgstr ""
 "acmesh-official/acme.sh/wiki/DNS-alias-mode để biết chi tiết về quy trình "
 "này. LUCI chỉ hỗ trợ một miền thử thách cho mỗi chứng chỉ."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -210,7 +281,11 @@ msgstr ""
 "Sau khi được định cấu hình, việc cấp chứng chỉ có thể mất một lúc. Kiểm tra "
 "nhật ký để biết tiến độ và bất kỳ lỗi nào."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -226,27 +301,31 @@ msgstr ""
 "nhất hỗ trợ chứng chỉ ký tự đại diện. Sử dụng chế độ này yêu cầu phải cài "
 "đặt gói acme-dnsapi."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "Sử dụng tùy chỉnh nhà cung cấp chứng chỉ thay cho Let's Encrypt."
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "Sử dụng máy chủ tạm"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "Phương thức thẩm định"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Thẩm định"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Đường dẫn Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "

--- a/applications/luci-app-acme/po/vi/acme.po
+++ b/applications/luci-app-acme/po/vi/acme.po
@@ -153,13 +153,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "Kích thước khóa"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "Kích thước khóa cho chứng chỉ được tạo."
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "Kích thước khóa"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/vi/acme.po
+++ b/applications/luci-app-acme/po/vi/acme.po
@@ -42,9 +42,11 @@ msgstr "Cấu hình chứng chỉ"
 msgid "Challenge Alias"
 msgstr "Bí danh"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Thẩm định"
+msgid "DNS Challenge Validation"
+msgstr "DNS Thẩm định"
+
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Thẩm định"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/zh_Hans/acme.po
+++ b/applications/luci-app-acme/po/zh_Hans/acme.po
@@ -151,7 +151,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "密钥长度"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/zh_Hans/acme.po
+++ b/applications/luci-app-acme/po/zh_Hans/acme.po
@@ -11,11 +11,8 @@ msgstr ""
 "X-Generator: Weblate 4.10-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
-msgid "ACME certificates"
-msgstr "ACME 证书"
-
 #: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
+msgid "ACME certificates"
 msgstr "ACME 证书"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
@@ -323,6 +320,9 @@ msgid ""
 msgstr ""
 "Webserver 根目录。设置为 Web 服务器文档根目录，在 webroot 模式下运行 Acme。"
 "Web 服务器必须允许从互联网上使用80端口访问。"
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME 证书"
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/zh_Hans/acme.po
+++ b/applications/luci-app-acme/po/zh_Hans/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "质询别名"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "质询验证"
+msgid "DNS Challenge Validation"
+msgstr "DNS 质询验证"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot 质询验证"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/zh_Hans/acme.po
+++ b/applications/luci-app-acme/po/zh_Hans/acme.po
@@ -150,13 +150,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "密钥长度"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "生成的证书的密钥长度(和类型)。"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "密钥长度"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/zh_Hans/acme.po
+++ b/applications/luci-app-acme/po/zh_Hans/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 4.10-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME 证书"
 
@@ -18,70 +18,83 @@ msgstr "ACME 证书"
 msgid "ACME certs"
 msgstr "ACME 证书"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME 全局配置"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACME 服务器 URL"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "电子邮件帐户"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "高级设置"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "存放证书和其他状态文件的位置。"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "证书配置"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "质询别名"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS 质询验证"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot 质询验证"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "自定义 ACME 证书颁发机构"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "自定义 ACME 服务器目录 URL。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API 凭证"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS 质询验证"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "续约前天数"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "域名别名"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "域名"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -90,31 +103,37 @@ msgstr ""
 "证书中要包含的域名。第一个名字将是主题名，后面的名字将是主题备用名称。请注"
 "意，所有域名都必须在路由中指向全局 DNS。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC 256 位"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC 384 位"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr "与帐户密钥关联的电子邮件地址。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "启用调试日志记录"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "已启用"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "常规设置"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -124,31 +143,78 @@ msgstr "从 Letsencrypt 临时服务器获取证书(用于测试;证书无效)�
 msgid "Grant UCI access for luci-app-acme"
 msgstr "为 luci-app-acme 授予 UCI 的访问权限"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "密钥长度"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "生成的证书的密钥长度(和类型)。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA 2048 位"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA 3072 位"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA 4096 位"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "独立"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -158,7 +224,7 @@ msgstr ""
 "独立模式将使用 acme.sh 的内置 Web 服务器来颁发证书。Webroot 模式将使用现有的 "
 "Web 服务器来颁发证书。DNS 模式将允许您使用 DNS 提供商的 DNS API 颁发证书。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -168,7 +234,7 @@ msgstr ""
 "https://github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode。LUCI 每个证书"
 "只支持一个质询别名。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -179,7 +245,7 @@ msgstr ""
 "acme.sh/wiki/dnsapi 以了解每个 API 所需的凭据格式。在此处以 KEY=VAL shell 变"
 "量格式添加多个条目，以提供多个凭据变量。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -189,7 +255,11 @@ msgstr ""
 "github.com/acmesh-official/acme.sh/wiki/DNS-alias-mode。LUCI 每个证书只支持一"
 "个质询别名。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -203,7 +273,11 @@ msgstr ""
 "的公网 IP 地址。配置完成后，颁发证书可能需要一段时间。从日志中查看签署进度和"
 "错误。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -217,27 +291,31 @@ msgstr ""
 "dnsapi。在 DNS 模式下，域名不必解析为路由器IP。DNS 模式也是唯一支持通配符证书"
 "的模式。使用此模式需要安装 acme-dnsapi 包。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "使用自定义证书颁发机构代替 Let's Encrypt。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "使用临时服务器"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "验证方式"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot 质询验证"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webroot 文件夹"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -245,9 +323,6 @@ msgid ""
 msgstr ""
 "Webserver 根目录。设置为 Web 服务器文档根目录，在 webroot 模式下运行 Acme。"
 "Web 服务器必须允许从互联网上使用80端口访问。"
-
-msgid "Cert files are stored in"
-msgstr "存放证书和其他状态文件的位置。"
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/zh_Hans/acme.po
+++ b/applications/luci-app-acme/po/zh_Hans/acme.po
@@ -214,35 +214,9 @@ msgstr ""
 "dnsapi。在 DNS 模式下，域名不必解析为路由器IP。DNS 模式也是唯一支持通配符证书"
 "的模式。使用此模式需要安装 acme-dnsapi 包。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"颁发此证书后，用该证书更新 nginx 配置（只能有一个证书配置选中该选项）。Nginx "
-"必须支持 ssl，如果无法启动，则必须使用ssl支持进行编译才能使用证书选项"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"签发此证书后，使用此证书更新 uhttpd 配置（只能有一个证书配置选中该选项）。也"
-"可通过 LuCI 界面的 luci-app-uhttpd 来配置 uhttpd。"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "使用自定义证书颁发机构代替 Let's Encrypt。"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "用于 Nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "用于 uhttpd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/zh_Hans/acme.po
+++ b/applications/luci-app-acme/po/zh_Hans/acme.po
@@ -269,11 +269,8 @@ msgstr ""
 "Webserver 根目录。设置为 Web 服务器文档根目录，在 webroot 模式下运行 Acme。"
 "Web 服务器必须允许从互联网上使用80端口访问。"
 
-#~ msgid "State directory"
-#~ msgstr "状态文件夹"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "存放证书和其他状态文件的位置。"
+msgid "Cert files are stored in"
+msgstr "存放证书和其他状态文件的位置。"
 
 #~ msgid ""
 #~ "The credentials for the DNS API mode selected above. See https://github."

--- a/applications/luci-app-acme/po/zh_Hant/acme.po
+++ b/applications/luci-app-acme/po/zh_Hant/acme.po
@@ -153,7 +153,7 @@ msgid "Issued on"
 msgstr ""
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key size"
+msgid "Key type"
 msgstr "金鑰大小"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477

--- a/applications/luci-app-acme/po/zh_Hant/acme.po
+++ b/applications/luci-app-acme/po/zh_Hant/acme.po
@@ -152,13 +152,13 @@ msgstr ""
 msgid "Issued on"
 msgstr ""
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
-msgid "Key type"
-msgstr "金鑰大小"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "產生憑證的金鑰大小（和型別）。"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
+msgid "Key type"
+msgstr "金鑰大小"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
 msgid "Main Domain"

--- a/applications/luci-app-acme/po/zh_Hant/acme.po
+++ b/applications/luci-app-acme/po/zh_Hant/acme.po
@@ -217,36 +217,9 @@ msgstr ""
 "單。在DNS 模式下域名不必解析為路由器 IP 位址，該模式也是支援「萬用字元憑證」"
 "的唯一模式。請注意：必須安裝 acme-dnsapi 套件後才能使用該模式。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:82
-msgid ""
-"Update the nginx config with this certificate once issued (only select this "
-"for one certificate). Nginx must support ssl, if not it won't start as it "
-"needs to be compiled with ssl support to use cert options"
-msgstr ""
-"頒發後使用該憑證來更新 Nginx 組態（申請多個憑證時，只能選擇其中一個啟用此選"
-"項）；Nginx 必須支援 SSL，因為它需要編譯的 SSL 支援才能使用憑證，否則將無法啟"
-"動"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
-msgid ""
-"Update the uhttpd config with this certificate once issued (only select this "
-"for one certificate). Is also available luci-app-uhttpd to configure uhttpd "
-"form the LuCI interface."
-msgstr ""
-"頒發後使用該憑證來更新 uHTTPd 組態（申請多個憑證時，只能選擇其中一個啟用此選"
-"項）；您也可以使用 luci-app-uhttpd 的 LuCI 介面來配置 uHTTPd。"
-
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "使用自訂 CA 代替 Let's Encrypt。"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
-msgid "Use for nginx"
-msgstr "用於 Nginx"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
-msgid "Use for uhttpd"
-msgstr "用於 uHTTPd"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Use staging server"

--- a/applications/luci-app-acme/po/zh_Hant/acme.po
+++ b/applications/luci-app-acme/po/zh_Hant/acme.po
@@ -43,8 +43,11 @@ msgid "Challenge Alias"
 msgstr "Challenge 別名"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "Challenge Validation"
-msgstr "Challenge 驗證"
+msgid "DNS Challenge Validation"
+msgstr "DNS Challenge 驗證"
+
+msgid  "Webroot Challenge Validation"
+msgstr "Webroot Challenge 驗證"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
 msgid "Custom ACME CA"

--- a/applications/luci-app-acme/po/zh_Hant/acme.po
+++ b/applications/luci-app-acme/po/zh_Hant/acme.po
@@ -273,8 +273,5 @@ msgstr ""
 "Web 伺服器根目錄；設定 Web 伺服器文件的根目錄以在「Webroot 模式」下執行 "
 "ACME。Web 伺服器的 80 埠必須允許從 Internet 存取。"
 
-#~ msgid "State directory"
-#~ msgstr "狀態目錄"
-
-#~ msgid "Where certs and other state files are kept."
-#~ msgstr "儲存憑證和其他狀態檔的位置。"
+msgid "Cert files are stored in"
+msgstr "儲存憑證和其他狀態檔的位置。"

--- a/applications/luci-app-acme/po/zh_Hant/acme.po
+++ b/applications/luci-app-acme/po/zh_Hant/acme.po
@@ -10,7 +10,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 4.12-dev\n"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:17
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
 msgid "ACME certificates"
 msgstr "ACME證書"
 
@@ -18,70 +18,83 @@ msgstr "ACME證書"
 msgid "ACME certs"
 msgstr "ACME"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
 msgstr "ACME 全域組態"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:144
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:514
 msgid "ACME server URL"
 msgstr "ACME 伺服器 URL"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:29
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:39
 msgid "Account email"
 msgstr "電子郵件帳號"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:44
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
 msgid "Advanced Settings"
 msgstr "進階設定"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:37
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:433
+msgid "Base64 content of private key. Use instead of YC_SA_Key_File_Path"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:33
+msgid "Cert files are stored in"
+msgstr "儲存憑證和其他狀態檔的位置。"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
 msgid "Certificate config"
 msgstr "憑證組態"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:124
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:605
+msgid "Certificates"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:452
 msgid "Challenge Alias"
 msgstr "Challenge 別名"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:43
-msgid "DNS Challenge Validation"
-msgstr "DNS Challenge 驗證"
-
-msgid  "Webroot Challenge Validation"
-msgstr "Webroot Challenge 驗證"
-
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Custom ACME CA"
 msgstr "自訂 ACME CA"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:145
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:515
 msgid "Custom ACME server directory URL."
 msgstr "自訂 ACME 伺服器的 URL。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:96
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:74
 msgid "DNS"
 msgstr "DNS"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:107
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:87
 msgid "DNS API"
 msgstr "DNS API"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:116
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:444
 msgid "DNS API credentials"
 msgstr "DNS API 憑證"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:151
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+msgid "DNS Challenge Validation"
+msgstr "DNS Challenge 驗證"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:521
 msgid "Days until renewal"
 msgstr "更新前的天數"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:131
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:81
+msgid "Default"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:459
 msgid "Domain Alias"
 msgstr "網域別名"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:65
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:62
 msgid "Domain names"
 msgstr "網域名稱"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:66
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:63
 msgid ""
 "Domain names to include in the certificate. The first name will be the "
 "subject name, subsequent names will be alt names. Note that all domain names "
@@ -90,33 +103,39 @@ msgstr ""
 "憑證包含的網域名稱；第一個域名將作為「主體名稱」，其他則為「主體備用名稱」。"
 "請注意：所有域名都必須在全域 DNS 中解析為路由器的 IP 位址。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:60
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:410
+msgid ""
+"E.g. <code>_acme-challenge.example.com:12345:98765 alias.example.com:11111</"
+"code>"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:482
 msgid "ECC 256 bits"
 msgstr "ECC（256 位元）"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:61
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:483
 msgid "ECC 384 bits"
 msgstr "ECC（384 位元）"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:30
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:40
 msgid "Email address to associate with account key."
 msgstr ""
 "與「ACME 帳號金鑰」關聯的電子郵件位址；其用於接收 ACME CA 寄送的憑證過期通知"
 "電子郵件。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:34
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
 msgid "Enable debug logging"
 msgstr "啟用除錯日誌記錄"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:46
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
 msgid "Enabled"
 msgstr "啟用"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:42
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:54
 msgid "General Settings"
 msgstr "一般設定"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:50
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:469
 msgid ""
 "Get certificate from the Letsencrypt staging server (use for testing; the "
 "certificate won't be valid)."
@@ -126,31 +145,78 @@ msgstr "從 Let's Encrypt 臨時伺服器取得憑證（僅供測試用途，憑
 msgid "Grant UCI access for luci-app-acme"
 msgstr "授予 luci-app-acme 擁有 UCI 存取的權限"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:41
+msgid ""
+"If a certificate wasn't renewed in time then you'll receive a notice at 20 "
+"days before expiry."
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:587
+msgid "Issued on"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:476
 msgid "Key size"
 msgstr "金鑰大小"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:56
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:477
 msgid "Key size (and type) for the generated certificate."
 msgstr "產生憑證的金鑰大小（和型別）。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:57
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:584
+msgid "Main Domain"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:369
+msgid "OCID of tenancy that contains the target DNS zone"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:372
+msgid "OCID of user with permission to add/remove records from zones"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:275
+msgid ""
+"Open <a href=\"https://www.duckdns.org/\">DuckDNS</a> and copy a token here"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:378
+msgid "Path to private API signing key file in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:585
+msgid "Private Key"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:586
+msgid "Public Certificate"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:479
 msgid "RSA 2048 bits"
 msgstr "RSA（2048 位元）"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:58
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:480
 msgid "RSA 3072 bits"
 msgstr "RSA（3072 位元）"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:59
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:481
 msgid "RSA 4096 bits"
 msgstr "RSA（4096 位元）"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:94
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:236
+msgid "See instructions"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:375
+msgid "Should point to the tenancy home region"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:72
 msgid "Standalone"
 msgstr "獨立"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:91
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:69
 msgid ""
 "Standalone mode will use the built-in webserver of acme.sh to issue a "
 "certificate. Webroot mode will use an existing webserver to issue a "
@@ -161,7 +227,7 @@ msgstr ""
 "用現存的 Web 伺服器，「DNS 模式」允許您使用 DNS 服務提供者的 DNS API 來頒發憑"
 "證。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:125
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:453
 msgid ""
 "The challenge alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -171,7 +237,7 @@ msgstr ""
 "acme.sh/wiki/DNS-alias-mode 以獲得行程的詳細資訊。LuCI 僅支援每個憑證擁有唯"
 "一 Challenge 別名。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:117
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:445
 msgid ""
 "The credentials for the DNS API mode selected above. See https://github.com/"
 "acmesh-official/acme.sh/wiki/dnsapi for the format of credentials required "
@@ -182,7 +248,7 @@ msgstr ""
 "wiki/dnsapi 以獲得每個 API 所需的憑證格式。要提供多個憑證變數，請輸入格式為 "
 "KEY=VAL 的多個項目。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:132
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:460
 msgid ""
 "The domain alias to use for ALL domains. See https://github.com/acmesh-"
 "official/acme.sh/wiki/DNS-alias-mode for the details of this process. LUCI "
@@ -192,7 +258,11 @@ msgstr ""
 "wiki/DNS-alias-mode 以獲得該行程的詳細資訊。LuCI 僅支援每個憑證擁有唯一網域別"
 "名。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:18
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:381
+msgid "The private API signing key in PEM format"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:26
 msgid ""
 "This configures ACME (Letsencrypt) automatic certificate installation. "
 "Simply fill out this to have the router configured with Letsencrypt-issued "
@@ -206,7 +276,11 @@ msgstr ""
 "Let's Encrypt 頒發的憑證。請注意：憑證中的域名必須指向路由器公共 IP 位址。配"
 "置完成後憑證的頒發需要一段時間，請檢視日誌來取得其進展和任何錯誤。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:108
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:297
+msgid "This is usually NOT an email address"
+msgstr ""
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:88
 msgid ""
 "To use DNS mode to issue certificates, set this to the name of a DNS API "
 "supported by acme.sh. See https://github.com/acmesh-official/acme.sh/wiki/"
@@ -220,27 +294,31 @@ msgstr ""
 "單。在DNS 模式下域名不必解析為路由器 IP 位址，該模式也是支援「萬用字元憑證」"
 "的唯一模式。請注意：必須安裝 acme-dnsapi 套件後才能使用該模式。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:139
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:509
 msgid "Use a custom CA instead of Let's Encrypt."
 msgstr "使用自訂 CA 代替 Let's Encrypt。"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:49
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:467
 msgid "Use staging server"
 msgstr "使用臨時伺服器"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:90
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:68
 msgid "Validation method"
 msgstr "驗證方法"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:95
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:73
 msgid "Webroot"
 msgstr "Webroot"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:99
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:55
+msgid "Webroot Challenge Validation"
+msgstr "Webroot Challenge 驗證"
+
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:77
 msgid "Webroot directory"
 msgstr "Webroot 目錄"
 
-#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:100
+#: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:78
 msgid ""
 "Webserver root directory. Set this to the webserver document root to run "
 "Acme in webroot mode. The web server must be accessible from the internet on "
@@ -248,6 +326,3 @@ msgid ""
 msgstr ""
 "Web 伺服器根目錄；設定 Web 伺服器文件的根目錄以在「Webroot 模式」下執行 "
 "ACME。Web 伺服器的 80 埠必須允許從 Internet 存取。"
-
-msgid "Cert files are stored in"
-msgstr "儲存憑證和其他狀態檔的位置。"

--- a/applications/luci-app-acme/po/zh_Hant/acme.po
+++ b/applications/luci-app-acme/po/zh_Hant/acme.po
@@ -11,12 +11,9 @@ msgstr ""
 "X-Generator: Weblate 4.12-dev\n"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:25
+#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
 msgid "ACME certificates"
 msgstr "ACME證書"
-
-#: applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json:3
-msgid "ACME certs"
-msgstr "ACME"
 
 #: applications/luci-app-acme/htdocs/luci-static/resources/view/acme.js:36
 msgid "ACME global config"
@@ -326,3 +323,6 @@ msgid ""
 msgstr ""
 "Web 伺服器根目錄；設定 Web 伺服器文件的根目錄以在「Webroot 模式」下執行 "
 "ACME。Web 伺服器的 80 埠必須允許從 Internet 存取。"
+
+#~ msgid "ACME certs"
+#~ msgstr "ACME"

--- a/applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json
+++ b/applications/luci-app-acme/root/usr/share/luci/menu.d/luci-app-acme.json
@@ -1,6 +1,6 @@
 {
 	"admin/services/acme": {
-		"title": "ACME certs",
+		"title": "ACME certificates",
 		"order": 50,
 		"action": {
 			"type": "view",

--- a/applications/luci-app-acme/root/usr/share/rpcd/acl.d/luci-app-acme.json
+++ b/applications/luci-app-acme/root/usr/share/rpcd/acl.d/luci-app-acme.json
@@ -3,8 +3,7 @@
                 "description": "Grant UCI access for luci-app-acme",
                 "read": {
                         "file": {
-                                "/usr/sbin/nginx": [ "read" ],
-                                "/usr/sbin/uhttpd": [ "read" ]
+                                "/etc/ssl/acme": [ "list" ]
                         },
                         "uci": [ "acme" ]
                 },


### PR DESCRIPTION
The acme.sh package was changed recently:
* key_size option were renamed to key_type
* the webroot option is now should be a fixed path /var/run/acme/challenge to simplify configuration as part of https://github.com/openwrt/packages/pull/17721

@tohojo @hgl Please explain how to specify that I do really want to use a webroot but with the new `/var/run/acme/challenge` folder. The entire webroot option was deprecated so how the acme can distinguish webroot with a custom path like `/var/www/acme/` and the new folder?
For now I made the `/var/run/acme/challenge` as a default value. So in the script you can just check if it's not the default value or empty and only then write a deprecation notice.

The current validation method is standalone, maybe we should change it to a webroot?


@jow- Please give an advice. We have a DNS API and for example for the DuckDNS:

    config cert 'duckdns_wildcard'
      option validation_method 'dns'
      option dns 'dns_duckdns'
      list credentials 'DuckDNS_Token="6b52e9da-5229-4304-b846-187355f9q91e"'
      list domains 'example.duckdns.org'
      list domains '*.example.duckdns.org'

The problem is that the credentials is list of properties but I wish to turn it into a plain form. So when selecting a provider it's specific fields will be shown.
E.g. for the DuckDNS just show a field "Token" but on the form save it will be added to the `list credentials 'DuckDNS_Token`. How to make this saving?

For each provider we need a separate fields but it should be enough to just support a few main (Gandi, Cloudflare) and some standard like acmedns and nsupdate.


CC @jannispinter @zhanhb 
