### PR TITLE
luci-base: force menu to regenerate after uci change

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/uci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/uci.js
@@ -919,6 +919,8 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 							window.setTimeout(try_confirm, 250);
 						else
 							return Promise.reject(rv);
+					} else {
+						document.dispatchEvent(new CustomEvent('uci-applied'));
 					}
 
 					return rv;

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -3474,6 +3474,10 @@ var UITable = baseclass.extend(/** @lends LuCI.ui.table.prototype */ {
 	}
 });
 
+// Because the menu can depend on uci values, we need to flush the cache
+// after uci mutations.
+document.addEventListener('uci-applied', () => UIMenu.flushCache());
+
 /**
  * @class ui
  * @memberof LuCI

--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -358,7 +358,7 @@ function build_pagetree() {
 		firstchild_ineligible: 'bool'
 	};
 
-	let files = glob('/usr/share/luci/menu.d/*.json', '/usr/lib/lua/luci/controller/*.lua', '/usr/lib/lua/luci/controller/*/*.lua');
+	let files = glob('/usr/share/luci/menu.d/*.json', '/etc/config/*', '/usr/lib/lua/luci/controller/*.lua', '/usr/lib/lua/luci/controller/*/*.lua');
 	let cachefile;
 
 	if (indexcache) {


### PR DESCRIPTION
Because the menu JSON can have 'depends' in them, uci changes should force the menu to regenerate.

See #6422 

WARNING: I haven't tested this exact patch, since on 22.03.5 I had to modify the file glob in dispatcher.lua rather than in dispatcher.uc.