### PR TITLE
luci-app-shadowsocks-libev: don't repeat fields

### DIFF
--- a/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/shadowsocks-libev.js
+++ b/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/shadowsocks-libev.js
@@ -12,6 +12,7 @@ var names_options_server = [
 	'password',
 	'plugin',
 	'plugin_opts',
+	'local_address',
 ];
 
 var names_options_client = [
@@ -21,7 +22,6 @@ var names_options_client = [
 ];
 
 var names_options_common = [
-	'local_address',
 	'verbose',
 	'ipv6_first',
 	'fast_open',


### PR DESCRIPTION
The field `local_address` shows twice on column `Overview` for client components