### PR TITLE
luci-proto-qmi: allow v6apn and (v6)profile configuration

### DIFF
--- a/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
+++ b/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
@@ -65,8 +65,7 @@ return network.registerProtocol('qmi', {
 			}, this));
 		};
 
-		o = s.taboption('general', form.Value, 'apn', _('APN'));
-		o.validate = function(section_id, value) {
+		var validate_apn = function(section_id, value) {
 			if (value == null || value == '')
 				return true;
 
@@ -74,6 +73,14 @@ return network.registerProtocol('qmi', {
 				return _('Invalid APN provided');
 
 			return true;
+		};
+		o = s.taboption('general', form.Value, 'apn', _('APN'));
+		o.validate = validate_apn;
+
+		if (L.hasSystemFeature('ipv6')) {
+			o = s.taboption('general', form.Value, 'v6apn', _('IPv6 APN'));
+			o.validate = validate_apn;
+			o.depends('pdptype', 'ipv4v6')
 		};
 
 		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
@@ -133,5 +140,17 @@ return network.registerProtocol('qmi', {
 			_('If unchecked, the advertised DNS server addresses are ignored'));
 		o.default = o.enabled;
 
+		o = s.taboption('advanced', form.Value, 'profile',
+			_('APN profile index'));
+		o.placeholder = '1';
+		o.datatype = 'uinteger';
+
+		if (L.hasSystemFeature('ipv6')) {
+			o = s.taboption('advanced', form.Value, 'v6profile',
+				_('IPv6 APN profile index'));
+			o.placeholder = '1';
+			o.datatype = 'uinteger';
+			o.depends('pdptype', 'ipv4v6');
+		};
 	}
 });


### PR DESCRIPTION
To support split-APN dual-stack connections over QMI, add new parameters supported in UCI to LuCI as well. Previously, connection profile wasn't configurable from LuCI at all, so add options to set which APN profile to match for each protocol.

Setting to draft until https://github.com/openwrt/openwrt/pull/10913 is merged, but this is ready for review and testing.