### PR TITLE
luci-app-attendedsysupgrade: handle image names for Arm EFI (armsr)

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -89,7 +89,9 @@ return view.extend({
 		for (image of images) {
 			if (this.firmware.filesystem == image.filesystem) {
 				if (this.data.efi) {
-					if (image.type == 'combined-efi') {
+					if (this.firmware.target.indexOf("armsr") == 0 && image.type == 'combined') {
+						return image;
+					} else if (image.type == 'combined-efi') {
 						return image;
 					}
 				} else {


### PR DESCRIPTION
This fixes an issue where luci-app-attendedsysupgrade failed to present an image to download, after the asu server had built the image.

The cause was `selectImage` returning null, because it was looking for a `combined-efi` image.

`armsr` has no legacy image types (e.g x86 'BIOS'), so all images are named `combined` only.

There is also a fix to the asu server so it will select the `generic` profile rather than by board_name, as it does for x86.
(asu pr will be linked here)