### PR TITLE
luci-app-adblock: drop luci-lib-jsonc dependency

### DIFF
--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -4,7 +4,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for Adblock
-LUCI_DEPENDS:=+adblock +luci-lib-jsonc
+LUCI_DEPENDS:=+adblock
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
Those are the lua bindings, which isn't used by this package anymore.

Fixes: 0f18b873 "luci-app-adblock: release 4.0.0"