### PR TITLE
luci-app-unbound: correct default for validator_ntp

### DIFF
--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/configure.lua
@@ -77,6 +77,7 @@ if (valman == "0") then
         translate("DNSSEC NTP Fix"),
         translate("Break the loop where DNSSEC needs NTP and NTP needs DNS"))
     nvd.optional = true
+    nvd.default = true
     nvd:depends("validator", true)
 
     prt = s1:taboption("basic", Value, "listen_port",


### PR DESCRIPTION
I noticed some odd behaviour while setting up Unbound: the [default for `validator_ntp` is `1`](https://github.com/openwrt/packages/blob/master/net/unbound/files/README.md#config-unbound), however luci thought it was `0` and so would clear the uci entry when unchecked, meaning the `validator_ntp` option could never be disabled.

Simply setting the luci default to `true` fixes the issue.