### PR TITLE
luci-app-nft-qos: Remove the redundant MAC address of the static IP speed limit

### DIFF
--- a/applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua
+++ b/applications/luci-app-nft-qos/luasrc/model/cbi/nft-qos/nft-qos.lua
@@ -174,10 +174,6 @@ if limit_enable == "1" and limit_type == "static" then
 		o.titleref = luci.dispatcher.build_url("admin", "status", "overview")
 	end
 
-	o = y:option(Value, "macaddr", translate("MAC (optional)"))
-	o.rmempty = true
-	o.datatype = "macaddr"
-
 	o = y:option(Value, "rate", translate("Rate"))
 	o.default = def_rate_ul or '50'
 	o.size = 4

--- a/modules/luci-base/root/usr/share/rpcd/ucode/luci
+++ b/modules/luci-base/root/usr/share/rpcd/ucode/luci
@@ -538,6 +538,25 @@ const methods = {
 		call: function() {
 			return { result: process_list() };
 		}
+	},
+
+	getOnlineUsers: {
+		call: function() {
+			const fd = open('/proc/net/arp', 'r');
+			if (fd) {
+				let onlineusers = 0;
+
+				for (let line = fd.read('line'); length(line); line = fd.read('line'))
+					if (match(trim(line), /^.*(0x2).*(br-lan)$/))
+						onlineusers++;
+
+				fd.close();
+
+				return { onlineusers: onlineusers };
+			} else {
+				return { onlineusers: error() };
+			}
+		}
 	}
 };
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
@@ -3,6 +3,11 @@
 'require fs';
 'require network';
 
+var callOnlineUsers = rpc.declare({
+        object: 'luci',
+        method: 'getOnlineUsers'
+});
+
 function progressbar(value, max, byte) {
 	var vn = parseInt(value) || 0,
 	    mn = parseInt(max) || 100,
@@ -67,7 +72,8 @@ return baseclass.extend({
 			fs.trimmed('/proc/sys/net/netfilter/nf_conntrack_count'),
 			fs.trimmed('/proc/sys/net/netfilter/nf_conntrack_max'),
 			network.getWANNetworks(),
-			network.getWAN6Networks()
+			network.getWAN6Networks(),
+			L.resolveDefault(callOnlineUsers(), {})
 		]);
 	},
 
@@ -75,10 +81,12 @@ return baseclass.extend({
 		var ct_count  = +data[0],
 		    ct_max    = +data[1],
 		    wan_nets  = data[2],
-		    wan6_nets = data[3];
+		    wan6_nets = data[3],
+		    onlineusers = data[4];
 
 		var fields = [
-			_('Active Connections'), ct_max ? ct_count : null
+			_('Active Connections'), ct_max ? ct_count : null,
+			_('Online Users'), onlineusers ? onlineusers.onlineusers : null
 		];
 
 		var ctstatus = E('table', { 'class': 'table' });


### PR DESCRIPTION
The following development versions of OpenWrt can remove the old IP address static redundant MAC form option:
	OpenWrt 23.05
	OpenWrt 22.03
	OpenWrt 21.02