### PR TITLE
luci-app-mosquitto: fixes for notification options

### DIFF
--- a/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
+++ b/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
@@ -160,7 +160,7 @@ topics = s:option(DynamicList, "topic", _("topic"),
 
 OptionalFlag(s, "cleansession", _("Clean session"))
 OptionalFlag(s, "notifications", _("notifications"),
-    _("Attempt to notify the local and remote broker of connection status, defaults to $SYS/broker/connections/<clientid>/state"))
+    _("Attempt to notify the local and remote broker of connection status, defaults to $SYS/broker/connections/&lt;clientid&gt;/state"))
 s:option(Value, "notification_topic", _("Topic to use for local+remote remote for notifications.")).optional = true
 OptionalFlag(s, "notifications_local_only", _("Notifications local only"), _("Bridge connection states should only be published locally"))
 

--- a/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
+++ b/applications/luci-app-mosquitto/luasrc/model/cbi/mosquitto.lua
@@ -162,7 +162,7 @@ OptionalFlag(s, "cleansession", _("Clean session"))
 OptionalFlag(s, "notifications", _("notifications"),
     _("Attempt to notify the local and remote broker of connection status, defaults to $SYS/broker/connections/<clientid>/state"))
 s:option(Value, "notification_topic", _("Topic to use for local+remote remote for notifications.")).optional = true
-OptionalFlag(s, "notification_local_only", _("Notifications local only"), _("Bridge connection states should only be published locally"))
+OptionalFlag(s, "notifications_local_only", _("Notifications local only"), _("Bridge connection states should only be published locally"))
 
 s:option(Value, "remote_clientid", _("Client id to use on remote end of this bridge connection")).optional = true
 s:option(Value, "local_clientid", _("Client id to use locally. Important when bridging to yourself")).optional = true


### PR DESCRIPTION
1. Fix notifications_local_only flag -  the option wasn't being applied at all because of a typo.
2. Fix invalid XML in option description - trying to add "notifications" option resulted in malformed XML.