### PR TITLE
luci-app-simple-adblock: bugfix: unsupported DNS options display

### DIFF
--- a/applications/luci-app-simple-adblock/Makefile
+++ b/applications/luci-app-simple-adblock/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.9.5-1
+PKG_VERSION:=1.9.5-3
 
 LUCI_TITLE:=Simple Adblock Web UI
 LUCI_DESCRIPTION:=Provides Web UI for simple-adblock service.

--- a/applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js
+++ b/applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js
@@ -79,7 +79,7 @@ var RPC = {
 var status = baseclass.extend({
 	render: function () {
 		return Promise.all([
-			L.resolveDefault(getInitStatus(), {}),
+			L.resolveDefault(getInitStatus(pkg.Name), {}),
 		]).then(function (data) {
 			var replyStatus = data[0];
 			var text ="";
@@ -103,7 +103,7 @@ var status = baseclass.extend({
 			var header = E('h2', {}, _("Simple AdBlock - Status"))
 			var statusTitle = E('label', { class: 'cbi-value-title' }, _("Service Status"));
 			if (reply.version) {
-				text += _("Version: %s").format(reply.version) + " - ";
+				text += _("Version %s").format(reply.version) + " - ";
 				switch (reply.status) {
 					case 'statusSuccess':
 						text += statusTable[reply.status] + ".";

--- a/applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js
+++ b/applications/luci-app-simple-adblock/htdocs/luci-static/resources/view/simple-adblock/overview.js
@@ -21,7 +21,7 @@ return view.extend({
 
 	render: function () {
 		return Promise.all([
-			L.resolveDefault(adb.getPlatformSupport(), {}),
+			L.resolveDefault(adb.getPlatformSupport(pkg.Name), {}),
 		]).then(function (data) {
 			var replyPlatform = data[0];
 			var status, m, s, o;
@@ -71,10 +71,10 @@ return view.extend({
 			}
 			else {
 				if (!(replyPlatform[pkg.Name].dnsmasq_ipset_support)) {
-					text += _("Please note that %s is not supported on this system.").format("<i>dnsmasq.ipset</i>") + "<br />";
+					text += "<br />" + _("Please note that %s is not supported on this system.").format("<i>dnsmasq.ipset</i>");
 				}
 				if (!(replyPlatform[pkg.Name].dnsmasq_nftset_support)) {
-					text += _("Please note that %s is not supported on this system.").format("<i>dnsmasq.nftset</i>") + "<br />";
+					text += "<br />" + _("Please note that %s is not supported on this system.").format("<i>dnsmasq.nftset</i>");
 				}
 			}
 			if (!(replyPlatform[pkg.Name].unbound_installed)) {

--- a/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
+++ b/applications/luci-app-simple-adblock/po/templates/simple-adblock.pot
@@ -391,7 +391,7 @@ msgid "Verbose output"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:106
-msgid "Version: %s"
+msgid "Version %s"
 msgstr ""
 
 #: applications/luci-app-simple-adblock/htdocs/luci-static/resources/simple-adblock/status.js:98


### PR DESCRIPTION
* bugfix: move the break tag in front of the unsupported DNS options to pretty up the output
* use pkg.Name in RPCD calls
* slightly change the version display in WebUI to make it consistent with other packages