### PR TITLE
luci-app-firewall: cleaning up outdated instructions on hardware NAT

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -86,7 +86,7 @@ return view.extend({
 
 			o = s.option(form.Flag, 'flow_offloading_hw',
 				_('Hardware flow offloading'),
-				_('Requires hardware NAT support. Implemented at least for mt7621'));
+				_('Requires hardware NAT support.'));
 			o.optional = true;
 			o.depends('flow_offloading', '1');
 		}

--- a/applications/luci-app-firewall/po/ar/firewall.po
+++ b/applications/luci-app-firewall/po/ar/firewall.po
@@ -906,8 +906,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "يتطلب دعم NAT للأجهزة. تم التنفيذ على الأقل ل MT7621"
+msgid "Requires hardware NAT support."
+msgstr "يتطلب دعم NAT للأجهزة."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/bg/firewall.po
+++ b/applications/luci-app-firewall/po/bg/firewall.po
@@ -832,7 +832,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/bn_BD/firewall.po
+++ b/applications/luci-app-firewall/po/bn_BD/firewall.po
@@ -831,7 +831,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/ca/firewall.po
+++ b/applications/luci-app-firewall/po/ca/firewall.po
@@ -843,7 +843,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/cs/firewall.po
+++ b/applications/luci-app-firewall/po/cs/firewall.po
@@ -872,8 +872,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Vyžaduje hardwarovou podporu NAT. Implementováno alespoň pro mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Vyžaduje hardwarovou podporu NAT."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/da/firewall.po
+++ b/applications/luci-app-firewall/po/da/firewall.po
@@ -950,9 +950,9 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
-"Kræver hardware NAT-understøttelse. Implementeret i det mindste for mt7621"
+"Kræver hardware NAT-understøttelse."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/de/firewall.po
+++ b/applications/luci-app-firewall/po/de/firewall.po
@@ -969,9 +969,9 @@ msgid "Reflection zones"
 msgstr "Reflection-Zonen"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
-"Erfordert Hardware-NAT-Unterstützung. (Zumindest für mt7621 implementiert)"
+"Erfordert Hardware-NAT-Unterstützung."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/el/firewall.po
+++ b/applications/luci-app-firewall/po/el/firewall.po
@@ -836,7 +836,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/en/firewall.po
+++ b/applications/luci-app-firewall/po/en/firewall.po
@@ -834,7 +834,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/es/firewall.po
+++ b/applications/luci-app-firewall/po/es/firewall.po
@@ -976,9 +976,9 @@ msgid "Reflection zones"
 msgstr "Zonas de reflexión"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
-"Requiere soporte de NAT por hardware. Implementado al menos para mt7621"
+"Requiere soporte de NAT por hardware."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/fa/firewall.po
+++ b/applications/luci-app-firewall/po/fa/firewall.po
@@ -918,8 +918,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "نیاز به پشتیبانی سخت افزاری NAT دارد. حداقل برای mt7621 اجرا شده است"
+msgid "Requires hardware NAT support."
+msgstr "نیاز به پشتیبانی سخت افزاری NAT دارد."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/fi/firewall.po
+++ b/applications/luci-app-firewall/po/fi/firewall.po
@@ -923,8 +923,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Edellyttää laitteiston NAT-tukea. Toteutettu ainakin mt7621: lle"
+msgid "Requires hardware NAT support."
+msgstr "Edellyttää laitteiston NAT-tukea."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/fr/firewall.po
+++ b/applications/luci-app-firewall/po/fr/firewall.po
@@ -973,9 +973,9 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
-"Nécessite un support NAT matériel. Mis en œuvre minimalement pour mt7621"
+"Nécessite un support NAT matériel."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/he/firewall.po
+++ b/applications/luci-app-firewall/po/he/firewall.po
@@ -829,7 +829,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/hi/firewall.po
+++ b/applications/luci-app-firewall/po/hi/firewall.po
@@ -831,7 +831,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/hu/firewall.po
+++ b/applications/luci-app-firewall/po/hu/firewall.po
@@ -883,8 +883,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Hardveres NAT támogatás szükséges. Legalább az mt7621-hez megvalósítva"
+msgid "Requires hardware NAT support."
+msgstr "Hardveres NAT támogatás szükséges."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/id/firewall.po
+++ b/applications/luci-app-firewall/po/id/firewall.po
@@ -874,7 +874,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/it/firewall.po
+++ b/applications/luci-app-firewall/po/it/firewall.po
@@ -856,7 +856,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/ja/firewall.po
+++ b/applications/luci-app-firewall/po/ja/firewall.po
@@ -925,9 +925,9 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
-"ハードウェア NAT サポートが必要です。 mt7621 のみにおいて実装されています。"
+"ハードウェア NAT サポートが必要です。"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/ko/firewall.po
+++ b/applications/luci-app-firewall/po/ko/firewall.po
@@ -836,7 +836,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/lt/firewall.po
+++ b/applications/luci-app-firewall/po/lt/firewall.po
@@ -831,7 +831,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/mr/firewall.po
+++ b/applications/luci-app-firewall/po/mr/firewall.po
@@ -831,7 +831,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/ms/firewall.po
+++ b/applications/luci-app-firewall/po/ms/firewall.po
@@ -829,7 +829,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/nb_NO/firewall.po
+++ b/applications/luci-app-firewall/po/nb_NO/firewall.po
@@ -838,7 +838,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/nl/firewall.po
+++ b/applications/luci-app-firewall/po/nl/firewall.po
@@ -969,10 +969,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr ""
-"Vereist hardware NAT-ondersteuning. Geïmplementeerd in ieder geval voor "
-"mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Vereist hardware NAT-ondersteuning."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/pl/firewall.po
+++ b/applications/luci-app-firewall/po/pl/firewall.po
@@ -961,8 +961,8 @@ msgid "Reflection zones"
 msgstr "Strefy odbicia"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Wymaga sprzętowej obsługi NAT. Wdrożono dla co najmniej mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Wymaga sprzętowej obsługi NAT."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/pt/firewall.po
+++ b/applications/luci-app-firewall/po/pt/firewall.po
@@ -973,9 +973,9 @@ msgid "Reflection zones"
 msgstr "Zonas de reflexão"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
-"Requer suporte de hardware para NAT. Implementado pelo menos para mt7621"
+"Requer suporte de hardware para NAT."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/pt_BR/firewall.po
+++ b/applications/luci-app-firewall/po/pt_BR/firewall.po
@@ -971,8 +971,8 @@ msgid "Reflection zones"
 msgstr "Zonas de reflexão"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Requer suporte de NAT em hardware. Implementado ao menos para mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Requer suporte de NAT em hardware."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/ro/firewall.po
+++ b/applications/luci-app-firewall/po/ro/firewall.po
@@ -967,8 +967,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Necesită suport hardware NAT. Implementat cel puțin pentru mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Necesită suport hardware NAT."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/ru/firewall.po
+++ b/applications/luci-app-firewall/po/ru/firewall.po
@@ -975,9 +975,8 @@ msgid "Reflection zones"
 msgstr "Зоны отражения"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr ""
-"Требуется аппаратная поддержка NAT. Реализовано, по крайней мере, для mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Требуется аппаратная поддержка NAT."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/si/firewall.po
+++ b/applications/luci-app-firewall/po/si/firewall.po
@@ -831,7 +831,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/sk/firewall.po
+++ b/applications/luci-app-firewall/po/sk/firewall.po
@@ -863,8 +863,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Vyžaduje hardvérovú podporu NAT. Implementované minimálne pre mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Vyžaduje hardvérovú podporu NAT."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/sv/firewall.po
+++ b/applications/luci-app-firewall/po/sv/firewall.po
@@ -850,8 +850,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Kräver hårdvarustöd för NAT. Implementerad åtminstone för mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Kräver hårdvarustöd för NAT."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/templates/firewall.pot
+++ b/applications/luci-app-firewall/po/templates/firewall.pot
@@ -818,7 +818,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/tr/firewall.po
+++ b/applications/luci-app-firewall/po/tr/firewall.po
@@ -926,8 +926,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Donanımsal NAT desteği gerektirir. En az mt7621 için uygulanabilir"
+msgid "Requires hardware NAT support."
+msgstr "Donanımsal NAT desteği gerektirir."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/uk/firewall.po
+++ b/applications/luci-app-firewall/po/uk/firewall.po
@@ -943,8 +943,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Необхідна апаратна підтримка NAT. Упроваджено принаймні для mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Необхідна апаратна підтримка NAT."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/ur/firewall.po
+++ b/applications/luci-app-firewall/po/ur/firewall.po
@@ -830,7 +830,7 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
+msgid "Requires hardware NAT support."
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266

--- a/applications/luci-app-firewall/po/vi/firewall.po
+++ b/applications/luci-app-firewall/po/vi/firewall.po
@@ -940,8 +940,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "Yêu cầu hỗ trợ NAT phần cứng. Được triển khai ít nhất cho mt7621"
+msgid "Requires hardware NAT support."
+msgstr "Yêu cầu hỗ trợ NAT phần cứng."
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/zh_Hans/firewall.po
+++ b/applications/luci-app-firewall/po/zh_Hans/firewall.po
@@ -907,8 +907,8 @@ msgid "Reflection zones"
 msgstr "反射区"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "需要硬件 NAT 支持。目前 mt7621 已实现"
+msgid "Requires hardware NAT support."
+msgstr "需要硬件 NAT 支持。"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"

--- a/applications/luci-app-firewall/po/zh_Hant/firewall.po
+++ b/applications/luci-app-firewall/po/zh_Hant/firewall.po
@@ -892,8 +892,8 @@ msgid "Reflection zones"
 msgstr ""
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:89
-msgid "Requires hardware NAT support. Implemented at least for mt7621"
-msgstr "需要硬體 NAT 支援。目前 mt7621 已實現"
+msgid "Requires hardware NAT support."
+msgstr "需要硬體 NAT 支援。"
 
 #: applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js:266
 msgid "Restrict Masquerading to given destination subnets"


### PR DESCRIPTION
The MT7621 is no longer the only SoC that supports hardware NAT, so the description has been removed.

BTW, is there a detailed list of hardware NAT support?