### PR TITLE
luci-app-uhttpd: Remove LUA_TARGET

### DIFF
--- a/applications/luci-app-uhttpd/Makefile
+++ b/applications/luci-app-uhttpd/Makefile
@@ -9,12 +9,9 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=uHTTPd Webserver Configuration
 LUCI_DEPENDS:= +uhttpd
-LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
-
-LUA_TARGET:=source
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-vpnc/Makefile
+++ b/protocols/luci-proto-vpnc/Makefile
@@ -8,12 +8,9 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for VPNC VPN
 LUCI_DEPENDS:=+vpnc
-LUCI_PKGARCH:=all
 
 PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
 PKG_LICENSE:=Apache-2.0
-
-LUA_TARGET:=source
 
 include ../../luci.mk
 


### PR DESCRIPTION
The app was migrated to JS so the LUA_TARGET is not needed. Also remove LUCI_PKGARCH:=all which is anyway a default.

Same for luci-proto-vpnc