### PR TITLE
luci-mod-status: add support for the 6g band

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -205,36 +205,38 @@ return view.extend({
 				scanCache[results[i].bssid].data.stale = false;
 			}
 
-			if (scanCache[local_wifi.bssid] == null)
-				scanCache[local_wifi.bssid] = {};
+			if (band + 'g' == radio.dev.get('band')) {
+				if (scanCache[local_wifi.bssid] == null)
+					scanCache[local_wifi.bssid] = {};
 
-			scanCache[local_wifi.bssid].data = local_wifi;
+				scanCache[local_wifi.bssid].data = local_wifi;
 
-			if (chan_analysis.offset_tbl[local_wifi.channel] != null && local_wifi.center_chan1) {
-				var center_channels = [local_wifi.center_chan1],
-				    chan_width_text = local_wifi.htmode.replace(/(V)*H[TE]/,''), /* Handle HT VHT HE */
-				    chan_width = parseInt(chan_width_text)/10;
+				if (chan_analysis.offset_tbl[local_wifi.channel] != null && local_wifi.center_chan1) {
+					var center_channels = [local_wifi.center_chan1],
+					    chan_width_text = local_wifi.htmode.replace(/(V)*H[TE]/,''), /* Handle HT VHT HE */
+					    chan_width = parseInt(chan_width_text)/10;
 
-				if (local_wifi.center_chan2) {
-					center_channels.push(local_wifi.center_chan2);
-					chan_width = 8;
+					if (local_wifi.center_chan2) {
+						center_channels.push(local_wifi.center_chan2);
+						chan_width = 8;
+					}
+
+					local_wifi.signal = -10;
+					local_wifi.ssid = 'Local Interface';
+
+					this.add_wifi_to_graph(chan_analysis, local_wifi, scanCache, center_channels, chan_width);
+					rows.push([
+						this.render_signal_badge(q, local_wifi.signal),
+						[
+							E('span', { 'style': 'color:'+scanCache[local_wifi.bssid].color }, '⬤ '),
+							local_wifi.ssid
+						],
+						'%d'.format(local_wifi.channel),
+						'%h MHz'.format(chan_width_text),
+						'%h'.format(local_wifi.mode),
+						'%h'.format(local_wifi.bssid)
+					]);
 				}
-
-				local_wifi.signal = -10;
-				local_wifi.ssid = 'Local Interface';
-
-				this.add_wifi_to_graph(chan_analysis, local_wifi, scanCache, center_channels, chan_width);
-				rows.push([
-					this.render_signal_badge(q, local_wifi.signal),
-					[
-						E('span', { 'style': 'color:'+scanCache[local_wifi.bssid].color }, '⬤ '),
-						local_wifi.ssid
-					],
-					'%d'.format(local_wifi.channel),
-					'%h MHz'.format(chan_width_text),
-					'%h'.format(local_wifi.mode),
-					'%h'.format(local_wifi.bssid)
-				]);
 			}
 
 			for (var k in scanCache)
@@ -266,6 +268,8 @@ return view.extend({
 					chan_width = 2;
 
 				/* Skip WiFi not supported by the current band */
+				if (band != res.band)
+					continue;
 				if (chan_analysis.offset_tbl[res.channel] == null)
 					continue;
 

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -144,7 +144,7 @@ return view.extend({
 
 			if ((band != 2) && freq_tbl[i+1]) {
 				var next_channel = freq_tbl[i+1];
-				/* Check if we are transitioning to another 5Ghz band range */
+				/* Check if we are transitioning to another 5/6Ghz band range */
 				if ((next_channel - channel) == 4) {
 					for (var j=1; j < 4; j++) {
 						chan_analysis.offset_tbl[channel+j] = curr_offset+step;
@@ -383,6 +383,7 @@ return view.extend({
 			var bands = {
 				[2] : { title: '2.4GHz', channels: [] },
 				[5] : { title: '5GHz', channels: [] },
+				[6] : { title: '6GHz', channels: [] },
 			};
 
 			/* Split FrequencyList in Bands */


### PR DESCRIPTION
Currently, results from the 2.4 and 6 ghz bands get mixed together, because internally the channel number is used for some checks.

This adds some checks to prevent that, and then adds a new 6g band tab.

This works on my end, but my AP is the only 6g one nearby, so I don't have others in my scan results. Can someone test that please?