### PR TITLE
luci-mod-network: Adjust DHCP/DNS tab order

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -254,16 +254,16 @@ return view.extend({
 		s.addremove = false;
 
 		s.tab('general', _('General Settings'));
-		s.tab('relay', _('Relay'));
-		s.tab('files', _('Resolv and Hosts Files'));
-		s.tab('pxe_tftp', _('PXE/TFTP Settings'));
 		s.tab('advanced', _('Advanced Settings'));
 		s.tab('leases', _('Static Leases'));
+		s.tab('files', _('Resolv and Hosts Files'));
 		s.tab('hosts', _('Hostnames'));
+		s.tab('ipsets', _('IP Sets'));
+		s.tab('relay', _('Relay'));
 		s.tab('srvhosts', _('SRV'));
 		s.tab('mxhosts', _('MX'));
 		s.tab('cnamehosts', _('CNAME'));
-		s.tab('ipsets', _('IP Sets'));
+		s.tab('pxe_tftp', _('PXE/TFTP Settings'));
 
 		s.taboption('general', form.Flag, 'domainneeded',
 			_('Domain required'),


### PR DESCRIPTION
Adjust the order of tabs in the DNS/DHCP page.
Based on estimated importance of tabs
* move common (old) tabs to be earlier
* move the less frequently used (new) tabs later

Before:
![image](https://github.com/openwrt/luci/assets/7926856/07dd5c1b-ea02-4bff-b878-dc73f5d16709)

New:
![image](https://github.com/openwrt/luci/assets/7926856/e04c8415-98f0-40de-bea3-7b2c7765132f)


@jow- 
I actually think that we might prefer to reorganise/group some tabs e.g the new DNS fields (MX, CNAME, SRV) to be subtabs. Possible?