### PR TITLE
luci-app-unbound: dns assist in zone-detail add 'unprotected-loop' option #6524

### DIFF
--- a/applications/luci-app-unbound/luasrc/model/cbi/unbound/zone-details.lua
+++ b/applications/luci-app-unbound/luasrc/model/cbi/unbound/zone-details.lua
@@ -55,6 +55,7 @@ else
     ast:value("dnsmasq", "dnsmasq")
     ast:value("ipset-dns", "ipset-dns")
     ast:value("nsd", "nsd")
+    ast:value("unprotected-loop", "unprotected-loop")
 
     rlv = s7:option(Flag, "resolv_conf", translate("Use 'resolv.conf.auto'"),
         translate("Forward to upstream nameservers (ISP)"))


### PR DESCRIPTION
[luci-app-unbound: zone detail DNS assist lacks a option](https://github.com/openwrt/luci/issues/6524)
here is the detail