### PR TITLE
luci-app-statistics: missing sensor types added

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/sensors.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/sensors.js
@@ -44,6 +44,74 @@ return baseclass.extend({
 				}
 			});
 		}
+		if (types.indexOf('voltage') > -1) {
+			rv.push({
+				per_instance: true,
+				title: "%H: %pi - %di",
+				vlabel: "V",
+				number_format: "%4.1lf V",
+				data: {
+					types: [ "voltage" ],
+					options: {
+						voltage__value: {
+							color: "0000ff",
+							title: "Voltage"
+						}
+					}
+				}
+			});
+		}
+		if (types.indexOf('current') > -1) {
+			rv.push({
+				per_instance: true,
+				title: "%H: %pi - %di",
+				vlabel: "A",
+				number_format: "%4.1lf A",
+				data: {
+					types: [ "current" ],
+					options: {
+						current__value: {
+							color: "00ff00",
+							title: "Current"
+						}
+					}
+				}
+			});
+		}
+		if (types.indexOf('power') > -1) {
+			rv.push({
+				per_instance: true,
+				title: "%H: %pi - %di",
+				vlabel: "W",
+				number_format: "%4.1lf W",
+				data: {
+					types: [ "power" ],
+					options: {
+						power__value: {
+							color: "ff0000",
+							title: "Power"
+						}
+					}
+				}
+			});
+		}
+		if (types.indexOf('fanspeed') > -1) {
+			rv.push({
+				per_instance: true,
+				title: "%H: %pi - %di",
+				vlabel: "rpm",
+				number_format: "%4lf rpm",
+				data: {
+					types: [ "fanspeed" ],
+					options: {
+						fanspeed__value: {
+							color: "0000ff",
+							title: "Fan speed"
+						}
+					}
+				}
+			});
+		}
 
 		return rv;
 	}

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/sensors.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/sensors.js
@@ -9,6 +9,7 @@ var sensorTypes = [
 	/^(?:cpu_temp|remote_temp|temp)[0-9]*$/,					'temperature',
 	/^(?:fan)[0-9]*$/,											'fanspeed',
 	/^(?:humidity)[0-9]*$/,										'humidity',
+	/^(?:curr)[0-9]*$/,											'current',
 	/^(?:power)[0-9]*$/,										'power'
 ];
 


### PR DESCRIPTION
Added missing graphs for voltage, current, power and fanspeed sensors.
No new or modified translation strings.

Signed-off-by: Carsten Spieß <mail@carsten-spiess.de>