### PR TITLE
luci-mod-firewall: Expand on naming of forwarding rule inside the zone

### DIFF
--- a/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
+++ b/applications/luci-app-firewall/htdocs/luci-static/resources/view/firewall/zones.js
@@ -144,7 +144,7 @@ return view.extend({
 		var p = [
 			s.taboption('general', form.ListValue, 'input', _('Input')),
 			s.taboption('general', form.ListValue, 'output', _('Output')),
-			s.taboption('general', form.ListValue, 'forward', _('Forward'))
+			s.taboption('general', form.ListValue, 'forward', _('Intra zone forward'))
 		];
 
 		for (var i = 0; i < p.length; i++) {


### PR DESCRIPTION
Apparently the "Forward" entry of the individual firewall zones controls forwarding within the zone (between the individual interfaces) only, and not the forwarding of packets from the zone to other zones. This is quite confusing, as the meaning is different from the global "Forward" option above, which does control forwarding between zones.

Quote from user jow on the forum:
> The per-zone forward controls forwarding traffic among the ifaces of this
> zone. Traffic from/to other zones is handled by the global forward policy,
> or individual forwardings or rules.

See https://forum.openwrt.org/t/likely-bug-in-openwrt-firewall-rule-generation/18152

Let's try to be a bit more concise with the naming here and rename this entry to "Intra-Zone Forward", which hopefully makes the difference clear.