### PR TITLE
Add File Manager / File Browser based on form.FileUpload

### DIFF
--- a/applications/luci-app-filebrowser/Makefile
+++ b/applications/luci-app-filebrowser/Makefile
@@ -1,0 +1,15 @@
+# This is free software, licensed under the Apache License, Version 2.0 .
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI File Browser module
+LUCI_DEPENDS:=+luci-base
+
+PKG_LICENSE:=Apache-2.0
+PKG_VERSION:=1.1.0
+PKG_RELEASE:=1
+PKG_MAINTAINER:=Sergey Ponomarev <stokito@gmail.com>
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-filebrowser/htdocs/luci-static/resources/view/system/filebrowser.js
+++ b/applications/luci-app-filebrowser/htdocs/luci-static/resources/view/system/filebrowser.js
@@ -1,0 +1,34 @@
+'use strict';
+'require view';
+'require ui';
+'require form';
+
+var formData = {
+	files: {
+		root: null,
+	}
+};
+
+return view.extend({
+	render: function() {
+		var m, s, o;
+
+		m = new form.JSONMap(formData, _('File Browser'), '');
+
+		s = m.section(form.NamedSection, 'files', 'files');
+
+		o = s.option(form.FileUpload, 'root', '');
+		o.root_directory = '/';
+		o.browser = true;
+		o.show_hidden = true;
+		o.enable_upload = true;
+		o.enable_remove = true;
+		o.enable_download = true;
+
+		return m.render();
+	},
+
+	handleSave: null,
+	handleSaveApply: null,
+	handleReset: null
+})

--- a/applications/luci-app-filebrowser/po/templates/filebrowser.pot
+++ b/applications/luci-app-filebrowser/po/templates/filebrowser.pot
@@ -1,0 +1,11 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-filebrowser/htdocs/luci-static/resources/view/system/filebrowser.js:16
+#: applications/luci-app-filebrowser/root/usr/share/luci/menu.d/luci-app-filebrowser.json:3
+msgid "File Browser"
+msgstr ""
+
+#: applications/luci-app-filebrowser/root/usr/share/rpcd/acl.d/luci-app-filebrowser.json:3
+msgid "Grant access to File Browser"
+msgstr ""

--- a/applications/luci-app-filebrowser/root/usr/share/luci/menu.d/luci-app-filebrowser.json
+++ b/applications/luci-app-filebrowser/root/usr/share/luci/menu.d/luci-app-filebrowser.json
@@ -1,0 +1,13 @@
+{
+	"admin/system/filebrowser": {
+		"title": "File Browser",
+		"order": 80,
+		"action": {
+			"type": "view",
+			"path": "system/filebrowser"
+		},
+		"depends": {
+			"acl": [ "luci-app-filebrowser" ]
+		}
+	}
+}

--- a/applications/luci-app-filebrowser/root/usr/share/rpcd/acl.d/luci-app-filebrowser.json
+++ b/applications/luci-app-filebrowser/root/usr/share/rpcd/acl.d/luci-app-filebrowser.json
@@ -1,0 +1,14 @@
+{
+	"luci-app-filebrowser": {
+		"description": "Grant access to File Browser",
+		"write": {
+			"cgi-io": [ "upload", "download" ],
+			"ubus": {
+				"file": [ "*" ]
+			},
+			"file": {
+				"/*": [  "list", "read", "write" ]
+			}
+		}
+	}
+}

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -4547,6 +4547,7 @@ var CBIFileUpload = CBIValue.extend(/** @lends LuCI.form.FileUpload.prototype */
 		this.show_hidden = false;
 		this.enable_upload = true;
 		this.enable_remove = true;
+		this.enable_download = false;
 		this.root_directory = '/etc/luci-uploads';
 	},
 
@@ -4604,6 +4605,14 @@ var CBIFileUpload = CBIValue.extend(/** @lends LuCI.form.FileUpload.prototype */
 	 */
 
 	/**
+	 * Toggle download file functionality.
+	 *
+	 * @name LuCI.form.FileUpload.prototype#enable_download
+	 * @type boolean
+	 * @default false
+	 */
+
+	/**
 	 * Specify the root directory for file browsing.
 	 *
 	 * This property defines the topmost directory the file browser widget may
@@ -4628,6 +4637,7 @@ var CBIFileUpload = CBIValue.extend(/** @lends LuCI.form.FileUpload.prototype */
 			show_hidden: this.show_hidden,
 			enable_upload: this.enable_upload,
 			enable_remove: this.enable_remove,
+			enable_download: this.enable_download,
 			root_directory: this.root_directory,
 			disabled: (this.readonly != null) ? this.readonly : this.map.readonly
 		});

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -4543,11 +4543,21 @@ var CBIFileUpload = CBIValue.extend(/** @lends LuCI.form.FileUpload.prototype */
 	__init__: function(/* ... */) {
 		this.super('__init__', arguments);
 
+		this.browser = false;
 		this.show_hidden = false;
 		this.enable_upload = true;
 		this.enable_remove = true;
 		this.root_directory = '/etc/luci-uploads';
 	},
+
+
+	/**
+	 * Open in a file browser mode instead of selecting for a file
+	 *
+	 * @name LuCI.form.FileUpload.prototype#browser
+	 * @type boolean
+	 * @default false
+	 */
 
 	/**
 	 * Toggle display of hidden files.
@@ -4614,6 +4624,7 @@ var CBIFileUpload = CBIValue.extend(/** @lends LuCI.form.FileUpload.prototype */
 		var browserEl = new ui.FileUpload((cfgvalue != null) ? cfgvalue : this.default, {
 			id: this.cbid(section_id),
 			name: this.cbid(section_id),
+			browser: this.browser,
 			show_hidden: this.show_hidden,
 			enable_upload: this.enable_upload,
 			enable_remove: this.enable_remove,

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -2613,6 +2613,9 @@ var UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */ {
 	 * @typedef {LuCI.ui.AbstractElement.InitOptions} InitOptions
 	 * @memberof LuCI.ui.FileUpload
 	 *
+	 * @property {boolean} [browser=false]
+	 * Use a file browser mode.
+	 *
 	 * @property {boolean} [show_hidden=false]
 	 * Specifies whether hidden files should be displayed when browsing remote
 	 * files. Note that this is not a security feature, hidden files are always
@@ -2643,6 +2646,7 @@ var UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */ {
 	__init__: function(value, options) {
 		this.value = value;
 		this.options = Object.assign({
+			browser: false,
 			show_hidden: false,
 			enable_upload: true,
 			enable_remove: true,
@@ -2664,7 +2668,7 @@ var UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */ {
 
 	/** @override */
 	render: function() {
-		return L.resolveDefault(this.value != null ? fs.stat(this.value) : null).then(L.bind(function(stat) {
+		var renderFileBrowser = L.resolveDefault(this.value != null ? fs.stat(this.value) : null).then(L.bind(function(stat) {
 			var label;
 
 			if (L.isObject(stat) && stat.type != 'directory')
@@ -2676,13 +2680,13 @@ var UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */ {
 				label = [ this.iconForType('file'), ' %s (%s)'.format(this.truncatePath(this.value), _('File not accessible')) ];
 			else
 				label = [ _('Select file…') ];
-
-			return this.bind(E('div', { 'id': this.options.id }, [
-				E('button', {
-					'class': 'btn',
-					'click': UI.prototype.createHandlerFn(this, 'handleFileBrowser'),
-					'disabled': this.options.disabled ? '' : null
-				}, label),
+			let btnOpenFileBrowser = E('button', {
+				'class': 'btn open-file-browser',
+				'click': UI.prototype.createHandlerFn(this, 'handleFileBrowser'),
+				'disabled': this.options.disabled ? '' : null
+			}, label);
+			var fileBrowserEl = E('div', { 'id': this.options.id }, [
+				btnOpenFileBrowser,
 				E('div', {
 					'class': 'cbi-filebrowser'
 				}),
@@ -2691,8 +2695,18 @@ var UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */ {
 					'name': this.options.name,
 					'value': this.value
 				})
-			]));
+			]);
+			return this.bind(fileBrowserEl);
 		}, this));
+		// in a browser mode open dir listing after render by clicking on a Select button
+		if (this.options.browser) {
+			return renderFileBrowser.then(function (fileBrowserEl) {
+				var btnOpenFileBrowser = fileBrowserEl.getElementsByClassName('open-file-browser').item(0);
+				btnOpenFileBrowser.click();
+				return fileBrowserEl;
+			});
+		}
+		return renderFileBrowser
 	},
 
 	/** @private */
@@ -2947,11 +2961,11 @@ var UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */ {
 			rows,
 			E('div', { 'class': 'right' }, [
 				this.renderUpload(path, list),
-				E('a', {
+				!this.options.browser ? E('a', {
 					'href': '#',
 					'class': 'btn',
 					'click': UI.prototype.createHandlerFn(this, 'handleCancel')
-				}, _('Cancel'))
+				}, _('Cancel')) : ''
 			]),
 		]);
 	},
@@ -2989,7 +3003,7 @@ var UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */ {
 			dom.content(ul, E('em', { 'class': 'spinning' }, _('Loading directory contents…')));
 			L.resolveDefault(fs.list(path), []).then(L.bind(this.renderListing, this, browser, path));
 		}
-		else {
+		else if (!this.options.browser) {
 			var button = this.node.firstElementChild,
 			    hidden = this.node.lastElementChild;
 


### PR DESCRIPTION
Luci [needs for a file manager](https://forum.openwrt.org/t/adding-a-file-browser-file-text-editor-and-tty-command-shell-for-luci-openwrt/138930/).
The FileUpload CBI element allows to browse files and directories on a router, delete and upload. This already covers a basic needs. The only really missing features are:
* Download a file. Required.
* Edit right in a browser. Highly improves UX but not necessary. User can download, edit with a Notepad and upload.
* See and change permissions. Important.
* Copy\Move. Good to have.
* Compress, extract and browse archive. Often used.

So we can extend the FileUpload and add a "browser mode" when you don't select a file but just walking on directories. The PR is PoC of the idea: it adds a new menu item System / File Browser that opens a page with the FileUpload in a browser mode:

![luci file browser sample](https://github.com/openwrt/luci/assets/415502/53e0115c-2c9d-4fa4-aab9-999e4eab8049)

Here the directory listing was opened automatically and no Cancel or Select buttons.

It's ugly but just something that shows the idea (or even can be used today if you really need).

So my questions are:
* Would you accept a PR with a file browser?
* How do you feel about reuse of the FileUploader?


Some other existing solutions:
* https://github.com/giaulo/luci-app-filebrowser nice but based on Lua. Some [redit discussion](https://www.reddit.com/r/openwrt/comments/5iiv7i/luci_file_browser_for_openwrt/)
* https://github.com/muink/luci-app-tinyfilemanager uses PHP
* https://github.com/helmiau/helmiwrt-packages/tree/main/luci-app-tinyfm for of the TinyFilemanager for HelmiWrt
* https://github.com/shidahuilang/openwrt-package/tree/Lede/luci-app-fileassistant also Lua based
* https://github.com/openwrt/luci/tree/openwrt-19.07/applications/luci-app-rosy-file-server was removed




CC @giaulo @muink @xiaozhuai @helmiau @ozon @stangri: You guys may be interested in the topic.