### PR TITLE
luci-mod-status: fix iptables not showing comments

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/iptables.js
@@ -173,7 +173,7 @@ return view.extend({
 					srcnet,
 					dstnet,
 					options,
-					[ comment ]
+					[ comment, '%h'.format(comment) ]
 				]);
 
 				if (target) {


### PR DESCRIPTION

fix  comments disappeared after this commit https://github.com/openwrt/luci/commit/b3ef7a17eacc6ce2f2385bbb517c67906dd2a753

@jow- 