### PR TITLE
luci-lib-nixio: Fix add_luci_conffiles adding duplicate files

### DIFF
--- a/libs/luci-lib-nixio/root/lib/upgrade/luci-add-conffiles.sh
+++ b/libs/luci-lib-nixio/root/lib/upgrade/luci-add-conffiles.sh
@@ -3,7 +3,7 @@ add_luci_conffiles()
 	add_luci_conffiles_helper()
 	{
 		[ ! -f $1 ] && return
-		grep $1 $2 >/dev/null && return
+		grep -q $1 $2 && return
 		echo $1 >> $2
 	}
 

--- a/libs/luci-lib-nixio/root/lib/upgrade/luci-add-conffiles.sh
+++ b/libs/luci-lib-nixio/root/lib/upgrade/luci-add-conffiles.sh
@@ -1,15 +1,26 @@
 add_luci_conffiles()
 {
+	add_luci_conffiles_helper()
+	{
+		[ ! -f $1 ] && return
+		grep $1 $2 >/dev/null && return
+		echo $1 >> $2
+	}
+
 	local filelist="$1"
 
 	# save ssl certs
 	if [ -d /etc/nixio ]; then
-		find /etc/nixio -type f >> $filelist
+		find /etc/nixio -type f | while read ff; do
+			add_luci_conffiles_helper $ff $filelist
+		done
 	fi
 
 	# save uhttpd certs
-	[ -f "/etc/uhttpd.key" ] && echo /etc/uhttpd.key >> $filelist
-	[ -f "/etc/uhttpd.crt" ] && echo /etc/uhttpd.crt >> $filelist
+	add_luci_conffiles_helper /etc/uhttpd.key $filelist
+	add_luci_conffiles_helper /etc/uhttpd.crt $filelist
+
+	unset -f add_luci_conffiles_helper
 }
 
 sysupgrade_init_conffiles="$sysupgrade_init_conffiles add_luci_conffiles"

--- a/libs/luci-lib-nixio/root/lib/upgrade/luci-add-conffiles.sh
+++ b/libs/luci-lib-nixio/root/lib/upgrade/luci-add-conffiles.sh
@@ -2,9 +2,9 @@ add_luci_conffiles()
 {
 	add_luci_conffiles_helper()
 	{
-		[ ! -f $1 ] && return
-		grep -q $1 $2 && return
-		echo $1 >> $2
+		[ ! -f "$1" ] && return
+		grep -q "$1" "$2" && return
+		echo "$1" >> "$2"
 	}
 
 	local filelist="$1"
@@ -12,13 +12,13 @@ add_luci_conffiles()
 	# save ssl certs
 	if [ -d /etc/nixio ]; then
 		find /etc/nixio -type f | while read ff; do
-			add_luci_conffiles_helper $ff $filelist
+			add_luci_conffiles_helper "$ff" "$filelist"
 		done
 	fi
 
 	# save uhttpd certs
-	add_luci_conffiles_helper /etc/uhttpd.key $filelist
-	add_luci_conffiles_helper /etc/uhttpd.crt $filelist
+	add_luci_conffiles_helper /etc/uhttpd.key "$filelist"
+	add_luci_conffiles_helper /etc/uhttpd.crt "$filelist"
 
 	unset -f add_luci_conffiles_helper
 }


### PR DESCRIPTION
add_luci_conffiles does not check whether the file already exists when adding the file, which may result in redundant backups in the sysupgrade backup.