### PR TITLE
luci-app-attendedsysupgrade: add x86 efi/bios case

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -88,8 +88,11 @@ return view.extend({
 		let image;
 		for (image of images) {
 			if (this.firmware.filesystem == image.filesystem) {
-				if (this.data.efi) {
-					if (image.type == 'combined-efi') {
+				// x86 images can be combined-efi (EFI) or combined (BIOS)
+				if(this.firmware.target.indexOf("x86")) {
+					if (this.data.efi && image.type == 'combined-efi') {
+						return image;
+					} else if (image.type == 'combined') {
 						return image;
 					}
 				} else {


### PR DESCRIPTION
x86 is the only target that allows you to install either EFI or BIOS images, thereby add an extra check for that.