### PR TITLE
luci-app-statistics: memory: make hiding 'free' configurable

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/memory.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/statistics/rrdtool/definitions/memory.js
@@ -5,12 +5,14 @@
 
 'use strict';
 'require baseclass';
+'require uci';
 
 return baseclass.extend({
 	title: _('Memory'),
 
 	rrdargs: function(graph, host, plugin, plugin_instance, dtype) {
 		var p = [];
+		var hide_free = uci.get("luci_statistics", "collectd_memory", "HideFree") == "1" ? true : false;
 
 		var memory = {
 			title: "%H: Memory usage",
@@ -21,7 +23,7 @@ return baseclass.extend({
 			data: {
 				instances: {
 					memory: [
-						"free",
+						...(hide_free ? [] : ["free"]),
 						"buffered",
 						"cached",
 						"used"
@@ -58,7 +60,7 @@ return baseclass.extend({
 			data: {
 				instances: {
 					percent: [
-						"free",
+						...(hide_free ? [] : ["free"]),
 						"buffered",
 						"cached",
 						"used"

--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/memory.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/memory.js
@@ -11,6 +11,11 @@ return baseclass.extend({
 
 		o = s.option(form.Flag, 'enable', _('Enable this plugin'));
 
+		o = s.option(form.Flag, 'HideFree', _('Hide free memory'),
+			_('Hiding the free memory item makes the graph to scale to actual memory usage, not to 100%.'));
+		o.default = '0';
+		o.rmempty = false;
+
 		o = s.option(form.Flag, 'ValuesAbsolute', _('Absolute values'), _('When set to true, we request absolute values'));
 		o.default = '1';
 		o.depends('enable', '1');

--- a/applications/luci-app-statistics/root/etc/config/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/config/luci_statistics
@@ -158,6 +158,7 @@ config statistics 'collectd_load'
 
 config statistics 'collectd_memory'
 	option enable '1'
+	option HideFree '0'
 	option ValuesAbsolute '1'
 	option ValuesPercentage '0'
 


### PR DESCRIPTION
Make hiding/showing the 'free' memory configurable.
Set default as disabled, not hidden.

* If enabled, the graph scales to actually used memory, enabling a more detailed view to memory usage.
* If disabled, the graph always shows the whole memory / 100%.

Example:
Enabled:
![image](https://github.com/openwrt/luci/assets/7926856/f4bb6b28-e72f-4f03-ae8a-781d2f948698)

Disabled, default (and the only choice previously):
![image](https://github.com/openwrt/luci/assets/7926856/09302ec1-cf87-470a-bfa5-c410e4a16b2b)

Maintainer: me
