### PR TITLE
luci-base: Fix typos in JsDocs

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/cbi.js
+++ b/modules/luci-base/htdocs/luci-static/resources/cbi.js
@@ -370,12 +370,7 @@ function cbi_validate_form(form, errmsg)
 function cbi_validate_named_section_add(input)
 {
 	var button = input.parentNode.parentNode.querySelector('.cbi-button-add');
-	if (input.value !== '') {
-		button.disabled = false;
-	}
-	else {
-		button.disabled = true;
-	}
+	button.disabled = input.value === '';
 }
 
 function cbi_validate_reset(form)

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -204,7 +204,7 @@ var CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement.p
 	/**
 	 * Add another form element as children to this element.
 	 *
-	 * @param {AbstractElement} element
+	 * @param {AbstractElement} obj
 	 * The form element to add.
 	 */
 	append: function(obj) {
@@ -217,7 +217,7 @@ var CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement.p
 	 * The `parse()` function recursively walks the form element tree and
 	 * triggers input value reading and validation for each encountered element.
 	 *
-	 * Elements which are hidden due to unsatisified dependencies are skipped.
+	 * Elements which are hidden due to unsatisfied dependencies are skipped.
 	 *
 	 * @returns {Promise<void>}
 	 * Returns a promise resolving once this element's value and the values of
@@ -277,7 +277,7 @@ var CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement.p
 	/**
 	 * Strip any HTML tags from the given input string.
 	 *
-	 * @param {string} input
+	 * @param {string} s
 	 * The input string to clean.
 	 *
 	 * @returns {string}
@@ -348,7 +348,7 @@ var CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement.p
  * @classdesc
  *
  * The `Map` class represents one complete form. A form usually maps one UCI
- * configuraton file and is divided into multiple sections containing multiple
+ * configuration file and is divided into multiple sections containing multiple
  * fields each.
  *
  * It serves as main entry point into the `LuCI.form` for typical view code.
@@ -364,7 +364,7 @@ var CBIAbstractElement = baseclass.extend(/** @lends LuCI.form.AbstractElement.p
  *
  * @param {string} [description]
  * The description text of the form which is usually rendered as text
- * paragraph below the form title and before the actual form conents.
+ * paragraph below the form title and before the actual form contents.
  * If omitted, the corresponding paragraph element will not be rendered.
  */
 var CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
@@ -502,11 +502,11 @@ var CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 * @param {LuCI.form.AbstractSection} sectionclass
 	 * The section class to use for rendering the configuration section.
 	 * Note that this value must be the class itself, not a class instance
-	 * obtained from calling `new`. It must also be a class dervied from
+	 * obtained from calling `new`. It must also be a class derived from
 	 * `LuCI.form.AbstractSection`.
 	 *
 	 * @param {...string} classargs
-	 * Additional arguments which are passed as-is to the contructor of the
+	 * Additional arguments which are passed as-is to the constructor of the
 	 * given section class. Refer to the class specific constructor
 	 * documentation for details.
 	 *
@@ -558,7 +558,7 @@ var CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 * The `parse()` function recursively walks the form element tree and
 	 * triggers input value reading and validation for each child element.
 	 *
-	 * Elements which are hidden due to unsatisified dependencies are skipped.
+	 * Elements which are hidden due to unsatisfied dependencies are skipped.
 	 *
 	 * @returns {Promise<void>}
 	 * Returns a promise resolving once the entire form completed parsing all
@@ -588,7 +588,7 @@ var CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	 *
 	 * @param {boolean} [silent=false]
 	 * If set to `true`, trigger an alert message to the user in case saving
-	 * the form data failes. Otherwise fail silently.
+	 * the form data failures. Otherwise fail silently.
 	 *
 	 * @returns {Promise<void>}
 	 * Returns a promise resolving once the entire save operation is complete.
@@ -688,15 +688,15 @@ var CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
 	/**
 	 * Find a form option element instance.
 	 *
-	 * @param {string} name_or_id
+	 * @param {string} name
 	 * The name or the full ID of the option element to look up.
 	 *
 	 * @param {string} [section_id]
 	 * The ID of the UCI section containing the option to look up. May be
 	 * omitted if a full ID is passed as first argument.
 	 *
-	 * @param {string} [config]
-	 * The name of the UCI configuration the option instance is belonging to.
+	 * @param {string} [config_name]
+	 * The name of the UCI configuration the option instance belongs to.
 	 * Defaults to the main UCI configuration of the map if omitted.
 	 *
 	 * @returns {Array<LuCI.form.AbstractValue,string>|null}
@@ -797,7 +797,7 @@ var CBIMap = CBIAbstractElement.extend(/** @lends LuCI.form.Map.prototype */ {
  *
  * @param {string} [description]
  * The description text of the form which is usually rendered as text
- * paragraph below the form title and before the actual form conents.
+ * paragraph below the form title and before the actual form contents.
  * If omitted, the corresponding paragraph element will not be rendered.
  */
 var CBIJSONMap = CBIMap.extend(/** @lends LuCI.form.JSONMap.prototype */ {
@@ -921,7 +921,7 @@ var CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 * triggers input value reading and validation for each encountered child
 	 * option element.
 	 *
-	 * Options which are hidden due to unsatisified dependencies are skipped.
+	 * Options which are hidden due to unsatisfied dependencies are skipped.
 	 *
 	 * @returns {Promise<void>}
 	 * Returns a promise resolving once the values of all child elements have
@@ -967,7 +967,7 @@ var CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 * contents. If omitted, no description will be rendered.
 	 *
 	 * @throws {Error}
-	 * Throws an exeption if a tab with the same `name` already exists.
+	 * Throws an exception if a tab with the same `name` already exists.
 	 */
 	tab: function(name, title, description) {
 		if (this.tabs && this.tabs[name])
@@ -997,11 +997,11 @@ var CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	 * @param {LuCI.form.AbstractValue} optionclass
 	 * The option class to use for rendering the configuration option. Note
 	 * that this value must be the class itself, not a class instance obtained
-	 * from calling `new`. It must also be a class dervied from
+	 * from calling `new`. It must also be a class derived from
 	 * [LuCI.form.AbstractSection]{@link LuCI.form.AbstractSection}.
 	 *
 	 * @param {...*} classargs
-	 * Additional arguments which are passed as-is to the contructor of the
+	 * Additional arguments which are passed as-is to the constructor of the
 	 * given option class. Refer to the class specific constructor
 	 * documentation for details.
 	 *
@@ -1024,17 +1024,17 @@ var CBIAbstractSection = CBIAbstractElement.extend(/** @lends LuCI.form.Abstract
 	/**
 	 * Add a configuration option widget to a tab of the section.
 	 *
-	 * @param {string} tabname
+	 * @param {string} tabName
 	 * The name of the section tab to add the option element to.
 	 *
 	 * @param {LuCI.form.AbstractValue} optionclass
 	 * The option class to use for rendering the configuration option. Note
 	 * that this value must be the class itself, not a class instance obtained
-	 * from calling `new`. It must also be a class dervied from
+	 * from calling `new`. It must also be a class derived from
 	 * [LuCI.form.AbstractSection]{@link LuCI.form.AbstractSection}.
 	 *
 	 * @param {...*} classargs
-	 * Additional arguments which are passed as-is to the contructor of the
+	 * Additional arguments which are passed as-is to the constructor of the
 	 * given option class. Refer to the class specific constructor
 	 * documentation for details.
 	 *
@@ -1377,7 +1377,7 @@ var CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.AbstractVa
 
 	/**
 	 * If set to `true`, the underlying ui input widget value is not cleared
-	 * from the configuration on unsatisfied depedencies. The default behavior
+	 * from the configuration on unsatisfied dependencies. The default behavior
 	 * is to remove the values of all options whose dependencies are not
 	 * fulfilled.
 	 *
@@ -1539,10 +1539,10 @@ var CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.AbstractVa
 	 */
 
 	/**
-	 * Add a dependency contraint to the option.
+	 * Add a dependency constraint to the option.
 	 *
 	 * Dependency constraints allow making the presence of option elements
-	 * dependant on the current values of certain other options within the
+	 * dependent on the current values of certain other options within the
 	 * same form. An option element with unsatisfied dependencies will be
 	 * hidden from the view and its current value is omitted when saving.
 	 *
@@ -1554,7 +1554,7 @@ var CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.AbstractVa
 	 * a logical "and" expression.
 	 *
 	 * Option names may be given in "dot notation" which allows to reference
-	 * option elements outside of the current form section. If a name without
+	 * option elements outside the current form section. If a name without
 	 * dot is specified, it refers to an option within the same configuration
 	 * section. If specified as <code>configname.sectionid.optionname</code>,
 	 * options anywhere within the same form may be specified.
@@ -1620,11 +1620,11 @@ var CBIAbstractValue = CBIAbstractElement.extend(/** @lends LuCI.form.AbstractVa
 	 *  </li>
 	 * </ul>
 	 *
-	 * @param {string|Object<string, string|RegExp>} optionname_or_depends
+	 * @param {string|Object<string, string|RegExp>} field
 	 * The name of the option to depend on or an object describing multiple
-	 * dependencies which must be satified (a logical "and" expression).
+	 * dependencies which must be satisfied (a logical "and" expression).
 	 *
-	 * @param {string} optionvalue|RegExp
+	 * @param {string|RegExp} value
 	 * When invoked with a plain option name as first argument, this parameter
 	 * specifies the expected value. In case an object is passed as first
 	 * argument, this parameter is ignored.
@@ -3126,7 +3126,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
 	 * @returns {*|Promise<*>}
 	 * Return values of this function are ignored but if a promise is returned,
 	 * it is run to completion before the rendering is continued, allowing
-	 * custom logic to perform asynchroneous work before the modal dialog
+	 * custom logic to perform asynchronous work before the modal dialog
 	 * is shown.
 	 */
 	addModalOptions: function(modalSection, section_id, ev) {
@@ -3298,7 +3298,7 @@ var CBITableSection = CBITypedSection.extend(/** @lends LuCI.form.TableSection.p
  *
  * Another important difference is that the table cells show a readonly text
  * preview of the corresponding option elements by default, unless the child
- * option element is explicitely made writable by setting the `editable`
+ * option element is explicitly made writable by setting the `editable`
  * property to `true`.
  *
  * Additionally, the grid section honours a `modalonly` property of child
@@ -3347,7 +3347,7 @@ var CBIGridSection = CBITableSection.extend(/** @lends LuCI.form.GridSection.pro
 	 * contents. If omitted, no description will be rendered.
 	 *
 	 * @throws {Error}
-	 * Throws an exeption if a tab with the same `name` already exists.
+	 * Throws an exception if a tab with the same `name` already exists.
 	 */
 	tab: function(name, title, description) {
 		CBIAbstractSection.prototype.tab.call(this, name, title, description);
@@ -3665,7 +3665,7 @@ var CBIValue = CBIAbstractValue.extend(/** @lends LuCI.form.Value.prototype */ {
 	 * @param {string} key
 	 * The choice value to add.
 	 *
-	 * @param {Node|string} value
+	 * @param {Node|string} val
 	 * The caption for the choice value. May be a DOM node, a document fragment
 	 * or a plain text string. If omitted, the `key` value is used as caption.
 	 */
@@ -3877,7 +3877,7 @@ var CBIDynamicList = CBIValue.extend(/** @lends LuCI.form.DynamicList.prototype 
  * @classdesc
  *
  * The `ListValue` class implements a simple static HTML select element
- * allowing the user to chose a single value from a set of predefined choices.
+ * allowing the user chose a single value from a set of predefined choices.
  * It builds upon the {@link LuCI.ui.Select} widget.
  *
  * @param {LuCI.form.Map|LuCI.form.JSONMap} form
@@ -4799,7 +4799,7 @@ var CBISectionValue = CBIValue.extend(/** @lends LuCI.form.SectionValue.prototyp
  * @hideconstructor
  * @classdesc
  *
- * The LuCI form class provides high level abstractions for creating creating
+ * The LuCI form class provides high level abstractions for creating
  * UCI- or JSON backed configurations forms.
  *
  * To import the class in views, use `'require form'`, to import it in

--- a/modules/luci-base/htdocs/luci-static/resources/form.js
+++ b/modules/luci-base/htdocs/luci-static/resources/form.js
@@ -4326,7 +4326,7 @@ var CBIDummyValue = CBIValue.extend(/** @lends LuCI.form.DummyValue.prototype */
 	__name__: 'CBI.DummyValue',
 
 	/**
-	 * Set an URL which is opened when clicking on the dummy value text.
+	 * Set a URL which is opened when clicking on the dummy value text.
 	 *
 	 * By setting this property, the dummy value text is wrapped in an `<a>`
 	 * element with the property value used as `href` attribute.

--- a/modules/luci-base/htdocs/luci-static/resources/fs.js
+++ b/modules/luci-base/htdocs/luci-static/resources/fs.js
@@ -229,7 +229,7 @@ var FileSystem = baseclass.extend(/** @lends LuCI.fs.prototype */ {
 	/**
 	 * Unlink the given file.
 	 *
-	 * @param {string}
+	 * @param {string} path
 	 * The file path to remove.
 	 *
 	 * @returns {Promise<number>}
@@ -345,7 +345,7 @@ var FileSystem = baseclass.extend(/** @lends LuCI.fs.prototype */ {
 	 * @param {string} path
 	 * The file path to read.
 	 *
-	 * @param {string} [type=text]
+	 * @param {"blob"|"text"|"blob"} [type=text]
 	 * The expected type of read file contents. Valid values are `text` to
 	 * interpret the contents as string, `json` to parse the contents as JSON
 	 * or `blob` to return the contents as Blob instance.
@@ -387,7 +387,7 @@ var FileSystem = baseclass.extend(/** @lends LuCI.fs.prototype */ {
 	 * @param {string[]} [params]
 	 * The arguments to pass to the command.
 	 *
-	 * @param {string} [type=text]
+	 * @param {"blob"|"text"|"blob"} [type=text]
 	 * The expected output type of the invoked program. Valid values are
 	 * `text` to interpret the output as string, `json` to parse the output
 	 * as JSON or `blob` to return the output as Blob instance.

--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -2802,7 +2802,7 @@
 		 * omitted, it defaults to an empty string.
 		 *
 		 * @param {string[]} [parts]
-		 * An array of parts to join into an URL path. Parts may contain
+		 * An array of parts to join into a URL path. Parts may contain
 		 * slashes and any of the other characters mentioned above.
 		 *
 		 * @return {string}
@@ -2822,7 +2822,7 @@
 		},
 
 		/**
-		 * Construct an URL  pathrelative to the script path of the server
+		 * Construct a URL  pathrelative to the script path of the server
 		 * side LuCI application (usually `/cgi-bin/luci`).
 		 *
 		 * The resulting URL is guaranteed to only contain the characters
@@ -2833,7 +2833,7 @@
 		 * @memberof LuCI
 		 *
 		 * @param {string[]} [parts]
-		 * An array of parts to join into an URL path. Parts may contain
+		 * An array of parts to join into a URL path. Parts may contain
 		 * slashes and any of the other characters mentioned above.
 		 *
 		 * @return {string}
@@ -2844,7 +2844,7 @@
 		},
 
 		/**
-		 * Construct an URL path relative to the global static resource path
+		 * Construct a URL path relative to the global static resource path
 		 * of the LuCI ui (usually `/luci-static/resources`).
 		 *
 		 * The resulting URL is guaranteed to only contain the characters
@@ -2855,7 +2855,7 @@
 		 * @memberof LuCI
 		 *
 		 * @param {string[]} [parts]
-		 * An array of parts to join into an URL path. Parts may contain
+		 * An array of parts to join into a URL path. Parts may contain
 		 * slashes and any of the other characters mentioned above.
 		 *
 		 * @return {string}
@@ -2866,7 +2866,7 @@
 		},
 
 		/**
-		 * Construct an URL path relative to the media resource path of the
+		 * Construct a URL path relative to the media resource path of the
 		 * LuCI ui (usually `/luci-static/$theme_name`).
 		 *
 		 * The resulting URL is guaranteed to only contain the characters
@@ -2877,7 +2877,7 @@
 		 * @memberof LuCI
 		 *
 		 * @param {string[]} [parts]
-		 * An array of parts to join into an URL path. Parts may contain
+		 * An array of parts to join into a URL path. Parts may contain
 		 * slashes and any of the other characters mentioned above.
 		 *
 		 * @return {string}

--- a/modules/luci-base/htdocs/luci-static/resources/luci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/luci.js
@@ -81,7 +81,7 @@
 		 * subclass.
 		 *
 		 * @returns {LuCI.baseclass}
-		 * Returns a new LuCI.baseclass sublassed from this class, extended
+		 * Returns a new LuCI.baseclass subclassed from this class, extended
 		 * by the given properties and with its prototype set to this base
 		 * class to enable inheritance. The resulting value represents a
 		 * class constructor and can be instantiated with `new`.
@@ -218,7 +218,7 @@
 			 * would copy all values till the end.
 			 *
 			 * @param {...*} [extra_args]
-			 * Extra arguments to add to prepend to the resultung array.
+			 * Extra arguments to add to prepend to the resulting array.
 			 *
 			 * @returns {Array<*>}
 			 * Returns a new array consisting of the optional extra arguments
@@ -836,7 +836,7 @@
 		 *
 		 * @instance
 		 * @memberof LuCI.request
-		 * @param {string} target
+		 * @param {string} url
 		 * The URL to request.
 		 *
 		 * @param {LuCI.request.RequestOptions} [options]
@@ -854,7 +854,7 @@
 		 *
 		 * @instance
 		 * @memberof LuCI.request
-		 * @param {string} target
+		 * @param {string} url
 		 * The URL to request.
 		 *
 		 * @param {*} [data]
@@ -925,7 +925,7 @@
 		 * @hideconstructor
 		 * @classdesc
 		 *
-		 * The `Request.poll` class provides some convience wrappers around
+		 * The `Request.poll` class provides some convince wrappers around
 		 * {@link LuCI.poll} mainly to simplify registering repeating HTTP
 		 * request calls as polling functions.
 		 */
@@ -1055,7 +1055,7 @@
 
 		/**
 		 * Add a new operation to the polling loop. If the polling loop is not
-		 * already started at this point, it will be implicitely started.
+		 * already started at this point, it will be implicitly started.
 		 *
 		 * @instance
 		 * @memberof LuCI.poll
@@ -1098,8 +1098,8 @@
 		},
 
 		/**
-		 * Remove an operation from the polling loop. If no further operatons
-		 * are registered, the polling loop is implicitely stopped.
+		 * Remove an operation from the polling loop. If no further operations
+		 * are registered, the polling loop is implicitly stopped.
 		 *
 		 * @instance
 		 * @memberof LuCI.poll
@@ -1161,7 +1161,7 @@
 		 * @instance
 		 * @memberof LuCI.poll
 		 * @returns {boolean}
-		 * Returns `true` if polling has been stopped or `false` if it din't
+		 * Returns `true` if polling has been stopped or `false` if it didn't
 		 * run to begin with.
 		 */
 		stop: function() {
@@ -1331,7 +1331,7 @@
 		 * The `Node` argument to append the children to.
 		 *
 		 * @param {*} [children]
-		 * The childrens to append to the given node.
+		 * The children to append to the given node.
 		 *
 		 * When `children` is an array, then each item of the array
 		 * will be either appended as child element or text node,
@@ -1346,11 +1346,11 @@
 		 * as first and the return value of the `children` function as
 		 * second parameter.
 		 *
-		 * When `children` is is a DOM `Node` instance, it will be
+		 * When `children` is a DOM `Node` instance, it will be
 		 * appended to the given `node`.
 		 *
 		 * When `children` is any other non-`null` value, it will be
-		 * converted to a string and appened to the `innerHTML` property
+		 * converted to a string and appended to the `innerHTML` property
 		 * of the given `node`.
 		 *
 		 * @returns {Node|null}
@@ -1389,7 +1389,7 @@
 		 * Replaces the content of the given node with the given children.
 		 *
 		 * This function first removes any children of the given DOM
-		 * `Node` and then adds the given given children following the
+		 * `Node` and then adds the given children following the
 		 * rules outlined below.
 		 *
 		 * @instance
@@ -1398,7 +1398,7 @@
 		 * The `Node` argument to replace the children of.
 		 *
 		 * @param {*} [children]
-		 * The childrens to replace into the given node.
+		 * The children to replace into the given node.
 		 *
 		 * When `children` is an array, then each item of the array
 		 * will be either appended as child element or text node,
@@ -1413,11 +1413,11 @@
 		 * as first and the return value of the `children` function as
 		 * second parameter.
 		 *
-		 * When `children` is is a DOM `Node` instance, it will be
+		 * When `children` is a DOM `Node` instance, it will be
 		 * appended to the given `node`.
 		 *
 		 * When `children` is any other non-`null` value, it will be
-		 * converted to a string and appened to the `innerHTML` property
+		 * converted to a string and appended to the `innerHTML` property
 		 * of the given `node`.
 		 *
 		 * @returns {Node|null}
@@ -1471,7 +1471,7 @@
 		 *
 		 * When `val` is of any other type, it will be added as attribute
 		 * to the given `node` as-is, with the underlying `setAttribute()`
-		 * call implicitely turning it into a string.
+		 * call implicitly turning it into a string.
 		 */
 		attr: function(node, key, val) {
 			if (!this.elem(node))
@@ -2034,7 +2034,7 @@
 		 * Any return values of this function are discarded, but
 		 * passed through `Promise.resolve()` to ensure that any
 		 * returned promise runs to completion before the button
-		 * is reenabled.
+		 * is re-enabled.
 		 */
 		handleSave: function(ev) {
 			var tasks = [];
@@ -2078,7 +2078,7 @@
 		 * Any return values of this function are discarded, but
 		 * passed through `Promise.resolve()` to ensure that any
 		 * returned promise runs to completion before the button
-		 * is reenabled.
+		 * is re-enabled.
 		 */
 		handleSaveApply: function(ev, mode) {
 			return this.handleSave(ev).then(function() {
@@ -2115,7 +2115,7 @@
 		 * Any return values of this function are discarded, but
 		 * passed through `Promise.resolve()` to ensure that any
 		 * returned promise runs to completion before the button
-		 * is reenabled.
+		 * is re-enabled.
 		 */
 		handleReset: function(ev) {
 			var tasks = [];
@@ -2327,7 +2327,7 @@
 
 		/**
 		 * A wrapper around {@link LuCI#raise raise()} which also renders
-		 * the error either as modal overlay when `ui.js` is already loaed
+		 * the error either as modal overlay when `ui.js` is already loaded
 		 * or directly into the view body.
 		 *
 		 * @instance
@@ -2822,7 +2822,7 @@
 		},
 
 		/**
-		 * Construct a URL  pathrelative to the script path of the server
+		 * Construct a URL with path relative to the script path of the server
 		 * side LuCI application (usually `/cgi-bin/luci`).
 		 *
 		 * The resulting URL is guaranteed to only contain the characters
@@ -2931,14 +2931,14 @@
 		 * The object to extract the keys from. If the given value is
 		 * not an object, the function will return an empty array.
 		 *
-		 * @param {string} [key]
+		 * @param {string|null} [key]
 		 * Specifies the key to order by. This is mainly useful for
 		 * nested objects of objects or objects of arrays when sorting
 		 * shall not be performed by the primary object keys but by
 		 * some other key pointing to a value within the nested values.
 		 *
-		 * @param {string} [sortmode]
-		 * May be either `addr` or `num` to override the natural
+		 * @param {"addr"|"num"} [sortmode]
+		 * Can be either `addr` or `num` to override the natural
 		 * lexicographic sorting with a sorting suitable for IP/MAC style
 		 * addresses or numeric values respectively.
 		 *
@@ -3049,7 +3049,7 @@
 		},
 
 		/**
-		 * Returns a promise resolving with either the given value or or with
+		 * Returns a promise resolving with either the given value or with
 		 * the given default in case the input value is a rejecting promise.
 		 *
 		 * @instance

--- a/modules/luci-base/htdocs/luci-static/resources/network.js
+++ b/modules/luci-base/htdocs/luci-static/resources/network.js
@@ -679,7 +679,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 * @method
 	 *
 	 * @param {string} netmask
-	 * The netmask to convert into a bit count.
+	 * The netmask to convert into a bits count.
 	 *
 	 * @param {boolean} [v6=false]
 	 * Whether to parse the given netmask as IPv4 (`false`) or IPv6 (`true`)
@@ -1611,7 +1611,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	},
 
 	/**
-	 * Describes an swconfig switch topology by specifying the CPU
+	 * Describes a swconfig switch topology by specifying the CPU
 	 * connections and external port labels of a switch.
 	 *
 	 * @typedef {Object<string, Object|Array>} SwitchTopology
@@ -1626,7 +1626,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	 * @property {Array<Object<string, boolean|number|string>>} ports
 	 * The `ports` property points to an array describing the populated
 	 * ports of the switch in the external label order. Each array item is
-	 * an object containg the following keys:
+	 * an object containing the following keys:
 	 *  - `num` - the internal switch port number
 	 *  - `label` - the label of the port, e.g. `LAN 1` or `CPU (eth0)`
 	 *  - `device` - the connected Linux network device name (CPU ports only)
@@ -1730,7 +1730,7 @@ Network = baseclass.extend(/** @lends LuCI.network.prototype */ {
 	},
 
 	/**
-	 * Obtains the the network device name of the given object.
+	 * Obtains the network device name of the given object.
 	 *
 	 * @param {LuCI.network.Protocol|LuCI.network.Device|LuCI.network.WifiDevice|LuCI.network.WifiNetwork|string} obj
 	 * The object to get the device name from.
@@ -2038,7 +2038,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	},
 
 	/**
-	 * Get the associared Linux network device of this network.
+	 * Get the associated Linux network device of this network.
 	 *
 	 * @returns {null|string}
 	 * Returns the name of the associated network device or `null` if
@@ -2075,7 +2075,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	},
 
 	/**
-	 * Return a human readable description for the protcol, such as
+	 * Return a human readable description for the protocol, such as
 	 * `Static address` or `DHCP client`.
 	 *
 	 * This function should be overwritten by subclasses.
@@ -2426,7 +2426,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	 *
 	 * @returns {string}
 	 * Returns the name of the opkg package required for the protocol to
-	 * function, e.g. `odhcp6c` for the `dhcpv6` prototocol.
+	 * function, e.g. `odhcp6c` for the `dhcpv6` protocol.
 	 */
 	getOpkgPackage: function() {
 		return null;
@@ -2473,7 +2473,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	 * on demand instead of using existing physical interfaces.
 	 *
 	 * Examples for virtual protocols are `6in4` which `gre` spawn tunnel
-	 * network device on startup, examples for non-virtual protcols are
+	 * network device on startup, examples for non-virtual protocols are
 	 * `dhcp` or `static` which apply IP configuration to existing interfaces.
 	 *
 	 * This function should be overwritten by subclasses.
@@ -2490,7 +2490,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	 * Checks whether this protocol is "floating".
 	 *
 	 * A "floating" protocol is a protocol which spawns its own interfaces
-	 * on demand, like a virtual one but which relies on an existinf lower
+	 * on demand, like a virtual one but which relies on an existing lower
 	 * level interface to initiate the connection.
 	 *
 	 * An example for such a protocol is "pppoe".
@@ -2703,7 +2703,7 @@ Protocol = baseclass.extend(/** @lends LuCI.network.Protocol.prototype */ {
 	 * interface.
 	 *
 	 * @returns {null|Array<LuCI.network.Device>}
-	 * Returns an array of of `Network.Device` class instances representing
+	 * Returns an array of `Network.Device` class instances representing
 	 * the sub-devices attached to this logical interface or `null` if the
 	 * logical interface does not support sub-devices, e.g. because it is
 	 * virtual and not a bridge.
@@ -3309,7 +3309,7 @@ WifiDevice = baseclass.extend(/** @lends LuCI.network.WifiDevice.prototype */ {
 	 * @param {string} opt
 	 * The name of the UCI option to set.
 	 *
-	 * @param {null|string|string[]} val
+	 * @param {null|string|string[]} value
 	 * The value to set or `null` to remove the given option from the
 	 * configuration.
 	 */
@@ -3409,7 +3409,7 @@ WifiDevice = baseclass.extend(/** @lends LuCI.network.WifiDevice.prototype */ {
 
 	/**
 	 * A wireless scan result object describes a neighbouring wireless
-	 * network found in the vincinity.
+	 * network found in the vicinity.
 	 *
 	 * @typedef {Object<string, number|string|LuCI.network.WifiEncryption>} WifiScanResult
 	 * @memberof LuCI.network
@@ -3447,7 +3447,7 @@ WifiDevice = baseclass.extend(/** @lends LuCI.network.WifiDevice.prototype */ {
 	 *
 	 * @returns {Promise<Array<LuCI.network.WifiScanResult>>}
 	 * Returns a promise resolving to an array of scan result objects
-	 * describing the networks found in the vincinity.
+	 * describing the networks found in the vicinity.
 	 */
 	getScanList: function() {
 		return callIwinfoScan(this.sid);
@@ -3498,7 +3498,7 @@ WifiDevice = baseclass.extend(/** @lends LuCI.network.WifiDevice.prototype */ {
 	 *
 	 * @returns {Promise<Array<LuCI.network.WifiNetwork>>}
 	 * Returns a promise resolving to an array of `Network.WifiNetwork`
-	 * instances respresenting the wireless networks associated with this
+	 * instances representing the wireless networks associated with this
 	 * radio device.
 	 */
 	getWifiNetworks: function() {
@@ -3627,7 +3627,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * @param {string} opt
 	 * The name of the UCI option to set.
 	 *
-	 * @param {null|string|string[]} val
+	 * @param {null|string|string[]} value
 	 * The value to set or `null` to remove the given option from the
 	 * configuration.
 	 */
@@ -3714,7 +3714,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	/**
 	 * Get the internal network ID of this wireless network.
 	 *
-	 * The network ID is a LuCI specific identifer in the form
+	 * The network ID is a LuCI specific identifier in the form
 	 * `radio#.network#` to identify wireless networks by their corresponding
 	 * radio and network index numbers.
 	 *
@@ -3896,7 +3896,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * Query the current encryption settings from runtime information.
 	 *
 	 * @returns {string}
-	 * Returns a string describing the current encryption or `-` if the the
+	 * Returns a string describing the current encryption or `-` if the
 	 * encryption state could not be found in `ubus` runtime information.
 	 */
 	getActiveEncryption: function() {
@@ -3997,7 +3997,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 *  - `UNKNOWN`
 	 *
 	 * @property {number} [mesh non-peer PS]
-	 * The powersafe mode for all non-peer neigbours, may be an empty
+	 * The powersafe mode for all non-peer neighbours, may be an empty
 	 * string (`''`) or absent if not applicable or supported by the driver.
 	 *
 	 * The following modes are known:
@@ -4032,7 +4032,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * The amount of bytes that have been received or sent.
 	 *
 	 * @property {number} [failed]
-	 * The amount of failed tranmission attempts. Only applicable to
+	 * The amount of failed transmission attempts. Only applicable to
 	 * transmit rates.
 	 *
 	 * @property {number} [retries]
@@ -4056,7 +4056,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * HT or VHT rates.
 	 *
 	 * @property {number} [40mhz]
-	 * Specifies whether the tranmission rate used 40MHz wide channel.
+	 * Specifies whether the transmission rate used 40MHz wide channel.
 	 * Only applicable to HT or VHT rates.
 	 *
 	 * Note: this option exists for backwards compatibility only and its
@@ -4321,18 +4321,18 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 *
 	 * @returns {LuCI.network.Device}
 	 * Returns a `Network.Device` instance representing the Linux network
-	 * device associted with this wireless network.
+	 * device associated with this wireless network.
 	 */
 	getDevice: function() {
 		return Network.prototype.instantiateDevice(this.getIfname());
 	},
 
 	/**
-	 * Check whether this wifi network supports deauthenticating clients.
+	 * Check whether this wifi network supports de-authenticating clients.
 	 *
 	 * @returns {boolean}
 	 * Returns `true` when this wifi network instance supports forcibly
-	 * deauthenticating clients, otherwise `false`.
+	 * de-authenticating clients, otherwise `false`.
 	 */
 	isClientDisconnectSupported: function() {
 		return L.isObject(this.ubus('hostapd', 'del_client'));
@@ -4345,7 +4345,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * The MAC address of the client to disconnect.
 	 *
 	 * @param {boolean} [deauth=false]
-	 * Specifies whether to deauthenticate (`true`) or disassociate (`false`)
+	 * Specifies whether to de-authenticate (`true`) or disassociate (`false`)
 	 * the client.
 	 *
 	 * @param {number} [reason=1]
@@ -4355,7 +4355,7 @@ WifiNetwork = baseclass.extend(/** @lends LuCI.network.WifiNetwork.prototype */ 
 	 * @param {number} [ban_time=0]
 	 * Specifies the amount of milliseconds to ban the client from
 	 * reconnecting. By default, no ban time is set which allows the client
-	 * to reassociate / reauthenticate immediately.
+	 * to re-associate / reauthenticate immediately.
 	 *
 	 * @returns {Promise<number>}
 	 * Returns a promise resolving to the underlying ubus call result code

--- a/modules/luci-base/htdocs/luci-static/resources/network.js
+++ b/modules/luci-base/htdocs/luci-static/resources/network.js
@@ -210,8 +210,8 @@ function getWifiNetidBySid(sid) {
 	var s = uci.get('wireless', sid);
 	if (s != null && s['.type'] == 'wifi-iface') {
 		var radioname = s.device;
-		if (typeof(s.device) == 'string') {
-			var i = 0, netid = null, sections = uci.sections('wireless', 'wifi-iface');
+		if (typeof(radioname) == 'string') {
+			var sections = uci.sections('wireless', 'wifi-iface');
 			for (var i = 0, n = 0; i < sections.length; i++) {
 				if (sections[i].device != s.device)
 					continue;

--- a/modules/luci-base/htdocs/luci-static/resources/rpc.js
+++ b/modules/luci-base/htdocs/luci-static/resources/rpc.js
@@ -186,7 +186,7 @@ return baseclass.extend(/** @lends LuCI.rpc.prototype */ {
 	 *    the corresponding args object sent to the remote procedure will be
 	 *    `{ foo: true, bar: false }`.
 	 *  - `params: [ "test" ], filter: function(reply, args, extra) { ... }` -
-	 *    When the resultung generated function is invoked with
+	 *    When the resulting generated function is invoked with
 	 *    `fn("foo", "bar", "baz")` then `{ "test": "foo" }` will be sent as
 	 *    argument to the remote procedure and the filter function will be
 	 *    invoked with `filterFn(reply, [ "foo" ], "bar", "baz")`
@@ -226,7 +226,7 @@ return baseclass.extend(/** @lends LuCI.rpc.prototype */ {
 	 *    be returned as default instead.
 	 *
 	 * @property {LuCI.rpc~filterFn} [filter]
-	 * Specfies an optional filter function which is invoked to transform the
+	 * Specifies an optional filter function which is invoked to transform the
 	 * received reply data before it is returned to the caller.
 	 *
 	 * @property {boolean} [reject=false]
@@ -379,7 +379,7 @@ return baseclass.extend(/** @lends LuCI.rpc.prototype */ {
 	/**
 	 * Set the RPC base URL to use.
 	 *
-	 * @param {string} sid
+	 * @param {string} url
 	 * Sets the RPC URL endpoint to issue requests against.
 	 */
 	setBaseURL: function(url) {
@@ -454,7 +454,7 @@ return baseclass.extend(/** @lends LuCI.rpc.prototype */ {
 	 * Registers a new interceptor function.
 	 *
 	 * @param {LuCI.rpc~interceptorFn} interceptorFn
-	 * The inteceptor function to register.
+	 * The interceptor function to register.
 	 *
 	 * @returns {LuCI.rpc~interceptorFn}
 	 * Returns the given function value.
@@ -469,7 +469,7 @@ return baseclass.extend(/** @lends LuCI.rpc.prototype */ {
 	 * Removes a registered interceptor function.
 	 *
 	 * @param {LuCI.rpc~interceptorFn} interceptorFn
-	 * The inteceptor function to remove.
+	 * The interceptor function to remove.
 	 *
 	 * @returns {boolean}
 	 * Returns `true` if the given function has been removed or `false`

--- a/modules/luci-base/htdocs/luci-static/resources/uci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/uci.js
@@ -18,7 +18,7 @@ function isEmpty(object, ignore) {
  *
  * The `LuCI.uci` class utilizes {@link LuCI.rpc} to declare low level
  * remote UCI `ubus` procedures and implements a local caching and data
- * manipulation layer on top to allow for synchroneous operations on
+ * manipulation layer on top to allow for synchronous operations on
  * UCI configuration data.
  */
 return baseclass.extend(/** @lends LuCI.uci.prototype */ {
@@ -93,7 +93,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * identifier in the form `cfgXXXXXX` once the configuration is saved
 	 * by the remote `ubus` UCI api.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The configuration to generate the new section ID for.
 	 *
 	 * @returns {string}
@@ -116,7 +116,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * Resolves a given section ID in extended notation to the internal
 	 * section ID value.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The configuration to resolve the section ID for.
 	 *
 	 * @param {string} sid
@@ -209,7 +209,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * To force reloading a configuration, it has to be unloaded with
 	 * {@link LuCI.uci#unload uci.unload()} first.
 	 *
-	 * @param {string|string[]} config
+	 * @param {string|string[]} packages
 	 * The name of the configuration or an array of configuration
 	 * names to load.
 	 *
@@ -245,7 +245,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	/**
 	 * Unloads the given UCI configurations from the local cache.
 	 *
-	 * @param {string|string[]} config
+	 * @param {string|string[]} packages
 	 * The name of the configuration or an array of configuration
 	 * names to unload.
 	 */
@@ -267,7 +267,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * Adds a new section of the given type to the given configuration,
 	 * optionally named according to the given name.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to add the section to.
 	 *
 	 * @param {string} type
@@ -302,7 +302,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	/**
 	 * Removes the section with the given ID from the given configuration.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to remove the section from.
 	 *
 	 * @param {string} sid
@@ -334,7 +334,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * enclosed within a configuration section, as well as some additional
 	 * meta data such as sort indexes and internal ID.
 	 *
-	 * Any internal metadata fields are prefixed with a dot which is isn't
+	 * Any internal metadata fields are prefixed with a dot which isn't
 	 * an allowed character for normal option names.
 	 *
 	 * @typedef {Object<string, boolean|number|string|string[]>} SectionObject
@@ -345,7 +345,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * anonymous (`true`) or named (`false`).
 	 *
 	 * @property {number} .index
-	 * The `.index` property specifes the sort order of the section.
+	 * The `.index` property specifies the sort order of the section.
 	 *
 	 * @property {string} .name
 	 * The `.name` property holds the name of the section object. It may be
@@ -383,7 +383,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * Enumerates the sections of the given configuration, optionally
 	 * filtered by type.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to enumerate the sections for.
 	 *
 	 * @param {string} [type]
@@ -436,13 +436,13 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * of the given configuration or the entire section object if the
 	 * option name is omitted.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to read the value from.
 	 *
 	 * @param {string} sid
 	 * The name or ID of the section to read.
 	 *
-	 * @param {string} [option]
+	 * @param {string} [opt]
 	 * The option name to read the value from. If the option name is
 	 * omitted or `null`, the entire section is returned instead.
 	 *
@@ -530,16 +530,16 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * If either config, section or option is null, or if `option` begins
 	 * with a dot, the function will do nothing.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to set the option value in.
 	 *
 	 * @param {string} sid
 	 * The name or ID of the section to set the option value in.
 	 *
-	 * @param {string} option
+	 * @param {string} opt
 	 * The option name to set the value for.
 	 *
-	 * @param {null|string|string[]} value
+	 * @param {null|string|string[]} val
 	 * The option value to set. If the value is `null` or an empty string,
 	 * the option will be removed, otherwise it will be set or overwritten
 	 * with the given value.
@@ -616,13 +616,13 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * This function is a convenience wrapper around
 	 * `uci.set(config, section, option, null)`.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to remove the option from.
 	 *
 	 * @param {string} sid
 	 * The name or ID of the section to remove the option from.
 	 *
-	 * @param {string} option
+	 * @param {string} opt
 	 * The name of the option to remove.
 	 */
 	unset: function(conf, sid, opt) {
@@ -632,9 +632,9 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	/**
 	 * Gets the value of the given option or the entire section object of
 	 * the first found section of the specified type or the first found
-	 * section of the entire configuration if no type is specfied.
+	 * section of the entire configuration if no type is specified.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to read the value from.
 	 *
 	 * @param {string} [type]
@@ -642,7 +642,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * section of the entire config is read, otherwise the first section
 	 * matching the given type.
 	 *
-	 * @param {string} [option]
+	 * @param {string} [opt]
 	 * The option name to read the value from. If the option name is
 	 * omitted or `null`, the entire section is returned instead.
 	 *
@@ -675,7 +675,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * If either config, type or option is null, or if `option` begins
 	 * with a dot, the function will do nothing.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to set the option value in.
 	 *
 	 * @param {string} [type]
@@ -683,10 +683,10 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * section of the entire config is written to, otherwise the first
 	 * section matching the given type is used.
 	 *
-	 * @param {string} option
+	 * @param {string} opt
 	 * The option name to set the value for.
 	 *
-	 * @param {null|string|string[]} value
+	 * @param {null|string|string[]} val
 	 * The option value to set. If the value is `null` or an empty string,
 	 * the option will be removed, otherwise it will be set or overwritten
 	 * with the given value.
@@ -710,7 +710,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * This function is a convenience wrapper around
 	 * `uci.set_first(config, type, option, null)`.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The name of the configuration to set the option value in.
 	 *
 	 * @param {string} [type]
@@ -718,7 +718,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * section of the entire config is written to, otherwise the first
 	 * section matching the given type is used.
 	 *
-	 * @param {string} option
+	 * @param {string} opt
 	 * The option name to set the value for.
 	 */
 	unset_first: function(conf, type, opt) {
@@ -729,7 +729,7 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 	 * Move the first specified section within the given configuration
 	 * before or after the second specified section.
 	 *
-	 * @param {string} config
+	 * @param {string} conf
 	 * The configuration to move the section within.
 	 *
 	 * @param {string} sid1

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -26,7 +26,7 @@ var modalDiv = null,
  * events.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -134,7 +134,7 @@ var UIElement = baseclass.extend(/** @lends LuCI.ui.AbstractElement.prototype */
 	 * @memberof LuCI.ui.AbstractElement
 	 * @returns {boolean}
 	 * Returns `true` if the input value has been altered by the user or
-	 * `false` if it is unchaged. Note that if the user modifies the initial
+	 * `false` if it is unchanged. Note that if the user modifies the initial
 	 * value and changes it back to the original state, it is still reported
 	 * as changed.
 	 */
@@ -316,7 +316,7 @@ var UIElement = baseclass.extend(/** @lends LuCI.ui.AbstractElement.prototype */
  * The `Textfield` class implements a standard single line text input field.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -441,7 +441,7 @@ var UITextfield = UIElement.extend(/** @lends LuCI.ui.Textfield.prototype */ {
  * The `Textarea` class implements a multiline text area input field.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -557,7 +557,7 @@ var UITextarea = UIElement.extend(/** @lends LuCI.ui.Textarea.prototype */ {
  * The `Checkbox` class implements a simple checkbox input field.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -696,7 +696,7 @@ var UICheckbox = UIElement.extend(/** @lends LuCI.ui.Checkbox.prototype */ {
  * values are enabled or not.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -726,7 +726,7 @@ var UISelect = UIElement.extend(/** @lends LuCI.ui.Select.prototype */ {
 	 * @property {boolean} [multiple=false]
 	 * Specifies whether multiple choice values may be selected.
 	 *
-	 * @property {string} [widget=select]
+	 * @property {"select"|"individual"} [widget=select]
 	 * Specifies the kind of widget to render. May be either `select` or
 	 * `individual`. When set to `select` an HTML `<select>` element will be
 	 * used, otherwise a group of checkbox or radio button elements is created,
@@ -904,7 +904,7 @@ var UISelect = UIElement.extend(/** @lends LuCI.ui.Select.prototype */ {
  * supports non-text choice labels.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -1988,7 +1988,7 @@ var UIDropdown = UIElement.extend(/** @lends LuCI.ui.Dropdown.prototype */ {
  * with a set of enforced default properties for easier instantiation.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -2055,7 +2055,7 @@ var UICombobox = UIDropdown.extend(/** @lends LuCI.ui.Combobox.prototype */ {
  * into a dropdown to chose from a set of different action choices.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -2078,7 +2078,7 @@ var UIComboButton = UIDropdown.extend(/** @lends LuCI.ui.ComboButton.prototype *
 	/**
 	 * ComboButtons support the same properties as
 	 * [Dropdown.InitOptions]{@link LuCI.ui.Dropdown.InitOptions} but enforce
-	 * specific values for some properties and add aditional button specific
+	 * specific values for some properties and add additional button specific
 	 * properties.
 	 *
 	 * @typedef {LuCI.ui.Dropdown.InitOptions} InitOptions
@@ -2172,7 +2172,7 @@ var UIComboButton = UIDropdown.extend(/** @lends LuCI.ui.ComboButton.prototype *
  * from a set of predefined choices.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -2195,7 +2195,7 @@ var UIComboButton = UIDropdown.extend(/** @lends LuCI.ui.ComboButton.prototype *
  */
 var UIDynamicList = UIElement.extend(/** @lends LuCI.ui.DynamicList.prototype */ {
 	/**
-	 * In case choices are passed to the dynamic list contructor, the widget
+	 * In case choices are passed to the dynamic list constructor, the widget
 	 * supports the same properties as [Dropdown.InitOptions]{@link LuCI.ui.Dropdown.InitOptions}
 	 * but enforces specific values for some dropdown properties.
 	 *
@@ -2527,7 +2527,7 @@ var UIDynamicList = UIElement.extend(/** @lends LuCI.ui.DynamicList.prototype */
  * which allows to store form data without exposing it to the user.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -2593,7 +2593,7 @@ var UIHiddenfield = UIElement.extend(/** @lends LuCI.ui.Hiddenfield.prototype */
  * browse, select and delete files beneath a predefined remote directory.
  *
  * UI widget instances are usually not supposed to be created by view code
- * directly, instead they're implicitely created by `LuCI.form` when
+ * directly, instead they're implicitly created by `LuCI.form` when
  * instantiating CBI forms.
  *
  * This class is automatically instantiated as part of `LuCI.ui`. To use it
@@ -2638,9 +2638,9 @@ var UIFileUpload = UIElement.extend(/** @lends LuCI.ui.FileUpload.prototype */ {
 	 *
 	 * @property {string} [root_directory=/etc/luci-uploads]
 	 * Specifies the remote directory the upload and file browsing actions take
-	 * place in. Browsing to directories outside of the root directory is
+	 * place in. Browsing to directories outside the root directory is
 	 * prevented by the widget. Note that this is not a security feature.
-	 * Whether remote directories are browseable or not solely depends on the
+	 * Whether remote directories are browsable or not solely depends on the
 	 * ACL setup for the current session.
 	 */
 	__init__: function(value, options) {
@@ -3085,7 +3085,7 @@ var UIMenu = baseclass.singleton(/** @lends LuCI.ui.menu.prototype */ {
 	 * @property {string} name - The internal name of the node, as used in the URL
 	 * @property {number} order - The sort index of the menu node
 	 * @property {string} [title] - The title of the menu node, `null` if the node should be hidden
-	 * @property {satisified} boolean - Boolean indicating whether the menu enries dependencies are satisfied
+	 * @property {satisfied} boolean - Boolean indicating whether the menu entries dependencies are satisfied
 	 * @property {readonly} [boolean] - Boolean indicating whether the menu entries underlying ACLs are readonly
 	 * @property {LuCI.ui.menu.MenuNode[]} [children] - Array of child menu nodes.
 	 */
@@ -3527,7 +3527,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * be opened. Invoking showModal() while a modal dialog is already open will
 	 * replace the open dialog with a new one having the specified contents.
 	 *
-	 * Additional CSS class names may be passed to influence the appearence of
+	 * Additional CSS class names may be passed to influence the appearance of
 	 * the dialog. Valid values for the classes depend on the underlying theme.
 	 *
 	 * @see LuCI.dom.content
@@ -3535,7 +3535,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * @param {string} [title]
 	 * The title of the dialog. If `null`, no title element will be rendered.
 	 *
-	 * @param {*} contents
+	 * @param {*} children
 	 * The contents to add to the modal dialog. This should be a DOM node or
 	 * a document fragment in most cases. The value is passed as-is to the
 	 * `dom.content()` function - refer to its documentation for applicable
@@ -3659,11 +3659,11 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * Add a notification banner at the top of the current view.
 	 *
 	 * A notification banner is an alert message usually displayed at the
-	 * top of the current view, spanning the entire availibe width.
+	 * top of the current view, spanning the entire available width.
 	 * Notification banners will stay in place until dismissed by the user.
 	 * Multiple banners may be shown at the same time.
 	 *
-	 * Additional CSS class names may be passed to influence the appearence of
+	 * Additional CSS class names may be passed to influence the appearance of
 	 * the banner. Valid values for the classes depend on the underlying theme.
 	 *
 	 * @see LuCI.dom.content
@@ -3672,7 +3672,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * The title of the notification banner. If `null`, no title element
 	 * will be rendered.
 	 *
-	 * @param {*} contents
+	 * @param {*} children
 	 * The contents to add to the notification banner. This should be a DOM
 	 * node or a document fragment in most cases. The value is passed as-is
 	 * to the `dom.content()` function - refer to its documentation for
@@ -3723,7 +3723,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	},
 
 	/**
-	 * Display or update an header area indicator.
+	 * Display or update a header area indicator.
 	 *
 	 * An indicator is a small label displayed in the header area of the screen
 	 * providing few amounts of status information such as item counts or state
@@ -3750,7 +3750,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * Note that this parameter only applies to new indicators, when updating
 	 * existing labels it is ignored.
 	 *
-	 * @param {string} [style=active]
+	 * @param {"active"|"inactive"} [style=active]
 	 * The indicator style to use. May be either `active` or `inactive`.
 	 *
 	 * @returns {boolean}
@@ -3793,7 +3793,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	},
 
 	/**
-	 * Remove an header area indicator.
+	 * Remove a header area indicator.
 	 *
 	 * This function removes the given indicator label from the header indicator
 	 * area. When the given indicator is not found, this function does nothing.
@@ -3827,7 +3827,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * subsequently wrapped into a `<span class="nowrap">` element.
 	 *
 	 * The resulting `<span>` element tuples are joined by the given separators
-	 * to form the final markup which is appened to the given parent DOM node.
+	 * to form the final markup which is appended to the given parent DOM node.
 	 *
 	 * @param {Node} node
 	 * The parent DOM node to append the markup to. Any previous child elements
@@ -4154,7 +4154,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * @param {string} path
 	 * The remote file path to upload the local file to.
 	 *
-	 * @param {Node} [progessStatusNode]
+	 * @param {Node} [progressStatusNode]
 	 * An optional DOM text node whose content text is set to the progress
 	 * percentage value during file upload.
 	 *
@@ -4268,7 +4268,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	/**
 	 * Perform a device connectivity test.
 	 *
-	 * Attempt to fetch a well known ressource from the remote device via HTTP
+	 * Attempt to fetch a well known resource from the remote device via HTTP
 	 * in order to test connectivity. This function is mainly useful to wait
 	 * for the router to come back online after a reboot or reconfiguration.
 	 *
@@ -4276,7 +4276,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 * The protocol to use for fetching the resource. May be either `http`
 	 * (the default) or `https`.
 	 *
-	 * @param {string} [host=window.location.host]
+	 * @param {string} [ipaddr=window.location.host]
 	 * Override the host address to probe. By default the current host as seen
 	 * in the address bar is probed.
 	 *
@@ -4365,7 +4365,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 		 *
 		 * @instance
 		 * @memberof LuCI.ui.changes
-		 * @param {number} numChanges
+		 * @param {number} n
 		 * The number of changes to indicate.
 		 */
 		setIndicator: function(n) {
@@ -4906,7 +4906,7 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 	 *
 	 * By instantiating the view class, its corresponding contents are
 	 * rendered and included into the view area. Any runtime errors are
-	 * catched and rendered using [LuCI.error()]{@link LuCI#error}.
+	 * caught and rendered using [LuCI.error()]{@link LuCI#error}.
 	 *
 	 * @param {string} path
 	 * The view path to render.


### PR DESCRIPTION
When opening in IntelliJ IDE it checks for grammar and marks a lot of problems.
So I fixed them to avoid distraction next time. 