### PR TITLE
luci-proto-wireguard: Escape IPv6 endpoints with [] in generated wireguard config

### DIFF
--- a/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
+++ b/protocols/luci-proto-wireguard/htdocs/luci-static/resources/protocol/wireguard.js
@@ -700,6 +700,11 @@ return network.registerProtocol('wireguard', {
 			    eport = this.section.formvalue(section_id, 'endpoint_port'),
 			    keep = this.section.formvalue(section_id, 'persistent_keepalive');
 
+			// If endpoint is IPv6 we must escape it with []
+			if (endpoint.indexOf(':') > 0) {
+				endpoint = '['+endpoint+']';
+			}
+
 			return [
 				'[Interface]',
 				'PrivateKey = ' + prv,


### PR DESCRIPTION
If the chosen wireguard Endpoint is an IPv6 address, we currently generate invalid format, as IPv6 addresses with a port appended need escaping with `[]`

Fixes issue #6592