### PR TITLE
luci-app-statistics: regenerate graphs on window resize

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/graphs.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/graphs.js
@@ -244,6 +244,10 @@ return view.extend({
 
 		requestAnimationFrame(L.bind(this.updateGraphs, this, hostSel, spanSel, timeSel, graphDiv));
 
+		var resizeTimeout;
+		var rgCallback = L.bind(this.refreshGraphs, this, hostSel, spanSel, timeSel, graphDiv);
+		addEventListener('resize', function() { clearTimeout(resizeTimeout); resizeTimeout = setTimeout(rgCallback, 250); });
+
 		return view;
 	},
 


### PR DESCRIPTION
Currently graphs are redrawn only based on the refresh interval (_never_ or _every 5/30/60 seconds_).
Since the image size is calculated based on the window size, redraw graphs (once) also after resizing the window. This also captures window resize due to orientation change (e.g., for mobile).
Since multiple resize events are fired when dragging the window border, there is a 250ms delay for debouncing.