### PR TITLE
[23.05] luci-app-adblock-fast: bugfix: working re-download

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.0.0-4
+PKG_VERSION:=1.0.0-6
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_DESCRIPTION:=Provides Web UI for adblock-fast service.

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -288,11 +288,11 @@ var status = baseclass.extend({
 					var text = "";
 					reply.status.errors.forEach((element) => {
 						text +=
-							errorTable[element.id].format(element.extra || " ") + "<br />";
+							errorTable[element.id].format(element.extra || " ") + "!<br />";
 					});
-					text += _("Errors encountered, please check the %sREADME%s!").format(
+					text += _("Errors encountered, please check the %sREADME%s").format(
 						'<a href="' + pkg.URL + '" target="_blank">',
-						"</a><br />"
+						"</a>!<br />"
 					);
 					var errorsText = E("div", {}, text);
 					var errorsField = E("div", { class: "cbi-value-field" }, errorsText);

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -200,7 +200,7 @@ msgid "Error"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:293
-msgid "Errors encountered, please check the %sREADME%s!"
+msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:117

--- a/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
+++ b/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
@@ -10,6 +10,7 @@
 # ubus -S call luci.adblock-fast getInitStatus '{"name": "adblock-fast" }'
 # ubus -S call luci.adblock-fast getPlatformSupport '{"name": "adblock-fast" }'
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "start" }'
+# ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "dl" }'
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "stop" }'
 
 . /lib/functions.sh
@@ -134,7 +135,7 @@ set_init_action() {
 			cmd="uci -q set ${name}.config.enabled=1 && uci commit $name";;
 		disable)
 			cmd="uci -q set ${name}.config.enabled=0 && uci commit $name";;
-		start|stop|reload|restart)
+		start|stop|reload|restart|dl)
 			cmd="/etc/init.d/${name} ${action}";;
 	esac
 	if [ -n "$cmd" ] && eval "${cmd}" 1>/dev/null 2>&1; then


### PR DESCRIPTION
* bugfix: add missing dl command to RPCD script
* improve output of error messages/link to README

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit d15a1fb6939684583b327f7388a1473c7d49841d)