### PR TITLE
[23.05] backport "luci-app-attendedsysupgrade: add x86 efi/bios case"

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -89,7 +89,7 @@ return view.extend({
 		for (image of images) {
 			if (this.firmware.filesystem == image.filesystem) {
 				// x86 images can be combined-efi (EFI) or combined (BIOS)
-				if(this.firmware.target.indexOf("x86")) {
+				if(this.firmware.target.indexOf("x86") != -1) {
 					if (this.data.efi && image.type == 'combined-efi') {
 						return image;
 					} else if (image.type == 'combined') {

--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -88,8 +88,11 @@ return view.extend({
 		let image;
 		for (image of images) {
 			if (this.firmware.filesystem == image.filesystem) {
-				if (this.data.efi) {
-					if (image.type == 'combined-efi') {
+				// x86 images can be combined-efi (EFI) or combined (BIOS)
+				if(this.firmware.target.indexOf("x86")) {
+					if (this.data.efi && image.type == 'combined-efi') {
+						return image;
+					} else if (image.type == 'combined') {
 						return image;
 					}
 				} else {


### PR DESCRIPTION
Backport d7e905e83a11d59ea217cd37189040bd6c9d403e to the 23.05 branch, as armsr targets need this for a functional luci-app-attendedsysupgrade
Tested working on armsr/armv8

(change `DISTRIB_RELEASE` in `/etc/openwrt_release` to exactly either `23.05` or `SNAPSHOT`, as the asu server may not offer 23.05 builds from a -rc or 23.05-SNAPSHOT build)
