### PR TITLE
wip: luci-app-shadowsocks-libev: remove refs to ACL

### DIFF
--- a/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/instances.js
+++ b/applications/luci-app-shadowsocks-libev/htdocs/luci-static/resources/view/shadowsocks-libev/instances.js
@@ -108,12 +108,6 @@ return view.extend({
 							o.datatype = 'hostport';
 						}
 					}
-					if (stype === 'ss_local' || stype === 'ss_server') {
-						o = s.taboption('advanced', form.FileUpload, 'acl',
-							_('ACL file'),
-							_('File containing Access Control List'));
-						o.root_directory = '/etc/shadowsocks-libev';
-					}
 				}, this));
 			}
 		};


### PR DESCRIPTION
We dropped ACL support because it depends on the now to be deprecated/eol pcre library.

This reverts commit 80da11720e09e1167df2dbc140d6221c3464c7f2