### PR TITLE
luci-app-ksmbd: add UI for multiple interfaces

### DIFF
--- a/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
+++ b/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
@@ -2,6 +2,7 @@
 'require view';
 'require fs';
 'require form';
+'require uci';
 'require tools.widgets as widgets';
 
 return view.extend({
@@ -32,8 +33,20 @@ return view.extend({
 		s.tab('general',  _('General Settings'));
 		s.tab('template', _('Edit Template'), _('Edit the template that is used for generating the ksmbd configuration.'));
 
-		s.taboption('general', widgets.NetworkSelect, 'interface', _('Interface'),
+		o = s.taboption('general', widgets.NetworkSelect, 'interface', _('Interface'),
 			_('Listen only on the given interface or, if unspecified, on lan'));
+		o.multiple = true;
+		o.cfgvalue = (section_id => L.toArray(uci.get('ksmbd', section_id, 'interface')));
+		o.write = function(section_id, formvalue) {
+			var cfgvalue = this.cfgvalue(section_id),
+			    oldNetworks = L.toArray(cfgvalue),
+			    newNetworks = L.toArray(formvalue);
+			oldNetworks.sort();
+			newNetworks.sort();
+			if (oldNetworks.join(' ') == newNetworks.join(' '))
+				return;
+			return uci.set('ksmbd', section_id, 'interface', newNetworks.join(' '));
+		};
 
 		o = s.taboption('general', form.Value, 'workgroup', _('Workgroup'));
 		o.placeholder = 'WORKGROUP';


### PR DESCRIPTION
`/etc/config/ksmbd` supports multiple interfaces (in `config globals`->`option interface`) but the current UI only supports selecting a single one. This patch adds support for selecting multiple interfaces, based on how `luci-app-samba4` does it.

Closes: #6620

Suggested-by: @AndroKev (let me know if you want your name in the commit)