### PR TITLE
luci-app-attendedsysupgrade: fix search for x86 target

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -89,7 +89,7 @@ return view.extend({
 		for (image of images) {
 			if (this.firmware.filesystem == image.filesystem) {
 				// x86 images can be combined-efi (EFI) or combined (BIOS)
-				if(this.firmware.target.indexOf("x86")) {
+				if(this.firmware.target.indexOf("x86") != -1) {
 					if (this.data.efi && image.type == 'combined-efi') {
 						return image;
 					} else if (image.type == 'combined') {


### PR DESCRIPTION
The conditional is wrong. IndexOf returns a number and not true/false, so it does not work.