### PR TITLE
luci-base: fix sort order for size columns

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -3412,6 +3412,20 @@ var UITable = baseclass.extend(/** @lends LuCI.ui.table.prototype */ {
 			if (m)
 				return '%010d%s'.format(+m[1], m[2]);
 
+			m = /^~?((?:\d+)(?:[.]\d+)?)\s(?:(K|M|G)i)?B$/.exec(value);
+
+			if (m)
+				switch (m[2]) {
+					default:
+						return +m[1];
+					case 'K':
+						return +m[1] * 1024;
+					case 'M':
+						return +m[1] * 1024 * 1024;
+					case 'G':
+						return +m[1] * 1024 * 1024 * 1024;
+				}
+
 			return String(value);
 
 		case 'ignorecase':


### PR DESCRIPTION
Currently elements of package size, packet size, etc. columns are interpreted as text strings, so we have _"800 B" > "7.54 KiB" > "5.11 MiB"_. To fix this, a new regexp is added to `UITable.deriveSortKey`.

It is still not a perfect fix for System->Software->Installed, since pagination is done based on package names, so within each page the packages are sorted correctly, but the smallest (resp., largest) package is not necessarily on the first (resp., last) page.

Closes: #5994 (see also #6120)