### PR TITLE
luci-app-adblock-fast: bugfix: localizable entries in overview

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.0.0-6
+PKG_VERSION:=1.0.0-7
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_DESCRIPTION:=Provides Web UI for adblock-fast service.

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -328,7 +328,7 @@ var status = baseclass.extend({
 					_("Start")
 				);
 
-				var btn_action = E(
+				var btn_action_dl = E(
 					"button",
 					{
 						class: "btn cbi-button cbi-button-apply",
@@ -338,13 +338,28 @@ var status = baseclass.extend({
 								E(
 									"p",
 									{ class: "spinning" },
-									_("Force re-downloading %s block lists").format(pkg.Name)
+									_("Force redownloading %s block lists").format(pkg.Name)
 								),
 							]);
 							return RPC.setInitAction(pkg.Name, "dl");
 						},
 					},
-					_("Force Re-Download")
+					_("Redownload")
+				);
+
+				var btn_action_pause = E(
+					"button",
+					{
+						class: "btn cbi-button cbi-button-apply",
+						disabled: true,
+						click: function (ev) {
+							ui.showModal(null, [
+								E("p", { class: "spinning" }, _("Pausing %s").format(pkg.Name)),
+							]);
+							return RPC.setInitAction(pkg.Name, "pause");
+						},
+					},
+					_("Pause")
 				);
 
 				var btn_stop = E(
@@ -410,17 +425,20 @@ var status = baseclass.extend({
 					switch (reply.status.status) {
 						case "statusSuccess":
 							btn_start.disabled = true;
-							btn_action.disabled = false;
+							btn_action_dl.disabled = false;
+							btn_action_pause.disabled = false;
 							btn_stop.disabled = false;
 							break;
 						case "statusStopped":
 							btn_start.disabled = false;
-							btn_action.disabled = true;
+							btn_action_dl.disabled = true;
+							btn_action_pause.disabled = true;
 							btn_stop.disabled = true;
 							break;
 						default:
 							btn_start.disabled = false;
-							btn_action.disabled = true;
+							btn_action_dl.disabled = true;
+							btn_action_pause.disabled = true;
 							btn_stop.disabled = false;
 							btn_enable.disabled = true;
 							btn_disable.disabled = true;
@@ -428,7 +446,8 @@ var status = baseclass.extend({
 					}
 				} else {
 					btn_start.disabled = true;
-					btn_action.disabled = true;
+					btn_action_dl.disabled = true;
+					btn_action_pause.disabled = true;
 					btn_stop.disabled = true;
 					btn_enable.disabled = false;
 					btn_disable.disabled = true;
@@ -442,8 +461,10 @@ var status = baseclass.extend({
 				);
 				var buttonsText = E("div", {}, [
 					btn_start,
+					// btn_gap,
+					// btn_action_pause,
 					btn_gap,
-					btn_action,
+					btn_action_dl,
 					btn_gap,
 					btn_stop,
 					btn_gap_long,

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js
@@ -378,7 +378,7 @@ return view.extend({
 		s3.anonymous = true;
 		s3.addremove = true;
 
-		o = s3.option(form.DummyValue, "_size", "Size");
+		o = s3.option(form.DummyValue, "_size", _("Size"));
 		o.modalonly = false;
 		o.cfgvalue = function (section_id) {
 			let url = uci.get(pkg.Name, section_id, "url");
@@ -399,6 +399,10 @@ return view.extend({
 		o.value("allow", _("Allow"));
 		o.value("block", _("Block"));
 		o.default = "block";
+		o.textvalue = function (section_id) {
+			var val = this.cfgvalue(section_id);
+			return val == "allow" ? _("Allow") : _("Block");
+		};
 
 		o = s3.option(form.Value, "url", _("URL"));
 		o.optional = false;

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js
@@ -1,0 +1,108 @@
+"require ui";
+"require rpc";
+"require form";
+"require baseclass";
+
+var pkg = {
+	get Name() {
+		return "adblock-fast";
+	},
+	get URL() {
+		return "https://docs.openwrt.melmac.net/" + pkg.Name + "/";
+	},
+};
+
+var getInitStatus = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getInitStatus",
+	params: ["name"],
+});
+
+return baseclass.extend({
+	title: _("AdBlock-Fast"),
+
+	load: function () {
+		return Promise.all([getInitStatus(pkg.Name)]);
+	},
+
+	render: function (data) {
+		var reply = {
+			status: (data[0] && data[0][pkg.Name]) || {
+				enabled: false,
+				status: null,
+				running: null,
+				version: null,
+				errors: [],
+				warnings: [],
+				force_dns_active: null,
+				force_dns_ports: [],
+				entries: null,
+				dns: null,
+				outputFile: null,
+				outputCache: null,
+				outputGzip: null,
+				outputFileExists: null,
+				outputCacheExists: null,
+				outputGzipExists: null,
+				leds: [],
+			},
+		};
+		var statusTable = {
+			statusNoInstall: _("%s is not installed or not found").format(pkg.Name),
+			statusStopped: _("Stopped"),
+			statusStarting: _("Starting"),
+			statusProcessing: _("Processing lists"),
+			statusRestarting: _("Restarting"),
+			statusForceReloading: _("Force Reloading"),
+			statusDownloading: _("Downloading lists"),
+			statusError: _("Error"),
+			statusWarning: _("Warning"),
+			statusFail: _("Fail"),
+			statusSuccess: _("Active"),
+		};
+
+		var cacheText;
+		if (reply.status.outputCacheExists) {
+			cacheText = _("Cache file");
+		} else if (reply.status.outputGzipExists) {
+			cacheText = _("Compressed cache");
+		}
+		var forceDnsText = "";
+		if (reply.status.force_dns_active) {
+			reply.status.force_dns_ports.forEach((element) => {
+				forceDnsText += element + " ";
+			});
+		} else {
+			forceDnsText = "-";
+		}
+
+		var table = E(
+			"table",
+			{ class: "table", id: "adblock-fast_status_table" },
+			[
+				E("tr", { class: "tr table-titles" }, [
+					E("th", { class: "th" }, _("Status")),
+					E("th", { class: "th" }, _("Version")),
+					E("th", { class: "th" }, _("DNS Service")),
+					E("th", { class: "th" }, _("Blocked Domains")),
+					E("th", { class: "th" }, _("Cache")),
+					E("th", { class: "th" }, _("Force DNS Ports")),
+				]),
+				E("tr", { class: "tr" }, [
+					E(
+						"td",
+						{ class: "td" },
+						statusTable[reply.status.status] || _("Unknown")
+					),
+					E("td", { class: "td" }, reply.status.version || _("-")),
+					E("td", { class: "td" }, reply.status.dns || _("-")),
+					E("td", { class: "td" }, reply.status.entries || _("-")),
+					E("td", { class: "td" }, cacheText || _("-")),
+					E("td", { class: "td" }, forceDnsText || _("-")),
+				]),
+			]
+		);
+
+		return table;
+	},
+});

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -6,7 +6,16 @@ msgid "%s is currently disabled"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:106
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:51
 msgid "%s is not installed or not found"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:97
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:98
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:99
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:100
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:101
+msgid "-"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:398
@@ -14,6 +23,7 @@ msgid "Action"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:118
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:61
 msgid "Active"
 msgstr ""
 
@@ -27,6 +37,10 @@ msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:156
 msgid "AdBlock on all instances"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:22
+msgid "AdBlock-Fast"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:349
@@ -58,6 +72,7 @@ msgid "Advanced Configuration"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:399
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:404
 msgid "Allow"
 msgstr ""
 
@@ -79,10 +94,12 @@ msgid "Basic Configuration"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:400
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:404
 msgid "Block"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:365
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:87
 msgid "Blocked Domains"
 msgstr ""
 
@@ -90,8 +107,20 @@ msgstr ""
 msgid "Blocking %s domains (with %s)."
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:88
+msgid "Cache"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:66
+msgid "Cache file"
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:160
 msgid "Cache file found."
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:68
+msgid "Compressed cache"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:139
@@ -119,6 +148,7 @@ msgid "Curl maximum file size (in bytes)"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:111
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:86
 msgid "DNS Service"
 msgstr ""
 
@@ -135,7 +165,7 @@ msgid ""
 "Directory for compressed cache file of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:404
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:419
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:239
 msgid "Disable"
 msgstr ""
@@ -148,7 +178,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:398
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:413
 msgid "Disabling %s service"
 msgstr ""
 
@@ -173,10 +203,11 @@ msgid "Download time-out (in seconds)"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:114
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:57
 msgid "Downloading lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:385
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:400
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:240
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:394
 msgid "Enable"
@@ -191,11 +222,12 @@ msgstr ""
 msgid "Enables debug output to /tmp/adblock-fast.log."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:379
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:394
 msgid "Enabling %s service"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:115
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:58
 msgid "Error"
 msgstr ""
 
@@ -204,6 +236,7 @@ msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:117
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:60
 msgid "Fail"
 msgstr ""
 
@@ -295,15 +328,16 @@ msgstr ""
 msgid "Failed to unpack compressed cache"
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:89
+msgid "Force DNS Ports"
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:142
 msgid "Force DNS ports:"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:347
-msgid "Force Re-Download"
-msgstr ""
-
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:113
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:56
 msgid "Force Reloading"
 msgstr ""
 
@@ -316,7 +350,7 @@ msgid "Force Router DNS server to all local devices"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:341
-msgid "Force re-downloading %s block lists"
+msgid "Force redownloading %s block lists"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:198
@@ -385,6 +419,14 @@ msgstr ""
 msgid "Output Verbosity Setting"
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:362
+msgid "Pause"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:357
+msgid "Pausing %s"
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:237
 msgid "Perform config update before downloading the block/allow-lists."
 msgstr ""
@@ -404,14 +446,20 @@ msgid "Please note that %s is not supported on this system."
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:111
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:54
 msgid "Processing lists"
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:347
+msgid "Redownload"
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:112
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:55
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:441
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:460
 msgid "Service Control"
 msgstr ""
 
@@ -431,6 +479,10 @@ msgstr ""
 msgid "Simultaneous processing"
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:381
+msgid "Size"
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:391
 msgid "Size: %s"
 msgstr ""
@@ -448,6 +500,7 @@ msgid "Start"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:110
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:53
 msgid "Starting"
 msgstr ""
 
@@ -455,7 +508,11 @@ msgstr ""
 msgid "Starting %s service"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:366
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:84
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:381
 msgid "Stop"
 msgstr ""
 
@@ -464,10 +521,11 @@ msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:109
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:52
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:360
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:375
 msgid "Stopping %s service"
 msgstr ""
 
@@ -509,7 +567,7 @@ msgstr ""
 msgid "The dnsmasq nft sets support is enabled, but nft is not installed"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:403
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:407
 msgid "URL"
 msgstr ""
 
@@ -523,6 +581,7 @@ msgid "URLs to file(s) containing lists to be allowed or blocked."
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:385
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:95
 msgid "Unknown"
 msgstr ""
 
@@ -543,11 +602,16 @@ msgstr ""
 msgid "Verbose output"
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:85
+msgid "Version"
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:128
 msgid "Version %s"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:116
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:59
 msgid "Warning"
 msgstr ""
 

--- a/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
+++ b/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
@@ -11,6 +11,7 @@
 # ubus -S call luci.adblock-fast getPlatformSupport '{"name": "adblock-fast" }'
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "start" }'
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "dl" }'
+# ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "pause" }'
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "stop" }'
 
 . /lib/functions.sh
@@ -135,10 +136,10 @@ set_init_action() {
 			cmd="uci -q set ${name}.config.enabled=1 && uci commit $name";;
 		disable)
 			cmd="uci -q set ${name}.config.enabled=0 && uci commit $name";;
-		start|stop|reload|restart|dl)
+		start|stop|reload|restart|dl|pause)
 			cmd="/etc/init.d/${name} ${action}";;
 	esac
-	if [ -n "$cmd" ] && eval "${cmd}" 1>/dev/null 2>&1; then
+	if [ -n "$cmd" ] && eval "${cmd}" >/dev/null 2>&1; then
 		print_json_bool "result" '1'
 	else
 		print_json_bool "result" '0'


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0

Description:
* bugfix: localizable entries in overview
* update grammar/naming for buttons
* prepare for pause button
* add status include file to show service status