### PR TITLE
luci-app-dockerman: fix stats page always blank

### DIFF
--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/container.lua
@@ -752,35 +752,40 @@ elseif action == "stats" then
 	local response = dk.containers:top({id = container_id, query = {ps_args="-aux"}})
 	local container_top
 
-	if response.code == 200 then
-		container_top=response.body
-	else
-		response = dk.containers:top({id = container_id})
-		if response.code == 200 then
-			container_top=response.body
+	if response.code ~= 409 then
+		if response.code ~= 200 then
+			response = dk.containers:top({id = container_id})
 		end
-	end
 
-	if type(container_top) == "table" then
-		s = m:section(SimpleSection)
-		s.container_id = container_id
-		s.template = "dockerman/container_stats"
-		table_stats = {
-			cpu={
+		if response.code ~= 200 then
+			response = dk.containers:top({id = container_id, query = {ps_args="-ww"}})
+		end
+
+		if response.code == 200 then
+			container_top = response.body
+		end
+
+		local table_stats = {
+			cpu = {
 				key=translate("CPU Usage"),
 				value='-'
 			},
-			memory={
+			memory = {
 				key=translate("Memory Usage"),
 				value='-'
 			}
 		}
-
-		container_top = response.body
 		s = m:section(Table, table_stats, translate("Stats"))
 		s:option(DummyValue, "key", translate("Stats")).width="33%"
 		s:option(DummyValue, "value")
-		top_section = m:section(Table, container_top.Processes, translate("TOP"))
+
+		s = m:section(SimpleSection)
+		s.container_id = container_id
+		s.template = "dockerman/container_stats"
+	end
+
+	if type(container_top) == "table" then
+		local top_section = m:section(Table, container_top.Processes, translate("TOP"))
 		for i, v in ipairs(container_top.Titles) do
 			top_section:option(DummyValue, i, translate(v))
 		end


### PR DESCRIPTION
I have never saw stats page has any 'stats', maybe dockerd call `ps -aux` or `ps -ef` on openwrt host, which not supported.

`CPU usage` and `Memory usage` does not depends on docker:top, always show on container running (docker:top status code is not 409).