### PR TITLE
luci-app-https-dns-proxy: add status->overview include file

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -5,11 +5,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2023-05-25-4
+PKG_VERSION:=2023-10-25-1
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-base +https-dns-proxy
+LUCI_PKGARCH:=all
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js
@@ -2,6 +2,7 @@
 // This code wouldn't have been possible without help from:
 // - [@stokito](https://github.com/stokito)
 // - [@vsviridov](https://github.com/vsviridov)
+// noinspection JSAnnotator
 
 "require ui";
 "require rpc";
@@ -241,7 +242,7 @@ var status = baseclass.extend({
 									});
 									name += " (" + option + ")";
 								} else {
-									if (match[1] != "") name += " (" + match[1] + ")";
+									if (match[1] !== "") name += " (" + match[1] + ")";
 								}
 							}
 						}

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
@@ -3,6 +3,7 @@
 // - [@jow-](https://github.com/jow-)
 // - [@stokito](https://github.com/stokito)
 // - [@vsviridov](https://github.com/vsviridov)
+// noinspection JSAnnotator
 
 "use strict";
 "require form";
@@ -12,12 +13,15 @@
 "require https-dns-proxy.status as hdp";
 
 var pkg = {
+
 	get Name() {
 		return "https-dns-proxy";
 	},
+
 	get URL() {
 		return "https://docs.openwrt.melmac.net/" + pkg.Name + "/";
 	},
+
 	templateToRegexp: function (template) {
 		return RegExp(
 			"^" +
@@ -32,6 +36,7 @@ var pkg = {
 				"$"
 		);
 	},
+
 	templateToResolver: function (template, args) {
 		return template.replace(/{(\w+)}/g, (_, v) => args[v]);
 	},
@@ -72,6 +77,7 @@ return view.extend({
 		m = new form.Map(pkg.Name, _("HTTPS DNS Proxy - Configuration"));
 
 		s = m.section(form.NamedSection, "config", pkg.Name);
+
 		o = s.option(
 			form.ListValue,
 			"dnsmasq_config_update",
@@ -86,6 +92,7 @@ return view.extend({
 			)
 		);
 		o.value("*", _("Update all configs"));
+
 		var sections = uci.sections("dhcp", "dnsmasq");
 		sections.forEach((element) => {
 			var description;
@@ -317,48 +324,57 @@ return view.extend({
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
+
 		o = s.option(form.Value, "listen_addr", _("Listen Address"));
 		o.datatype = "ipaddr";
 		o.default = "";
 		o.optional = true;
 		o.placeholder = "127.0.0.1";
-		var n = 0;
+
 		o = s.option(form.Value, "listen_port", _("Listen Port"));
 		o.datatype = "port";
 		o.default = "";
 		o.optional = true;
-		o.placeholder = n + 5053;
+		o.placeholder = "5053";
+
 		o = s.option(form.Value, "user", _("Run As User"));
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
+
 		o = s.option(form.Value, "group", _("Run As Group"));
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
+
 		o = s.option(form.Value, "dscp_codepoint", _("DSCP Codepoint"));
 		o.datatype = "and(uinteger, range(0,63))";
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
+
 		o = s.option(form.Value, "verbosity", _("Logging Verbosity"));
 		o.datatype = "and(uinteger, range(0,4))";
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
+
 		o = s.option(form.Value, "logfile", _("Logging File Path"));
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
+
 		o = s.option(form.Value, "polling_interval", _("Polling Interval"));
 		o.datatype = "and(uinteger, range(5,3600))";
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
+
 		o = s.option(form.Value, "proxy_server", _("Proxy Server"));
 		o.default = "";
 		o.modalonly = true;
 		o.optional = true;
+
 		o = s.option(form.ListValue, "use_http1", _("Use HTTP/1"));
 		o.modalonly = true;
 		o.optional = true;
@@ -366,6 +382,7 @@ return view.extend({
 		o.value("", _("Use negotiated HTTP version"));
 		o.value("1", _("Force use of HTTP/1"));
 		o.default = "";
+
 		o = s.option(
 			form.ListValue,
 			"use_ipv6_resolvers_only",

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js
@@ -1,0 +1,152 @@
+"require ui";
+"require rpc";
+"require uci";
+"require form";
+"require baseclass";
+
+var pkg = {
+	get Name() {
+		return "https-dns-proxy";
+	},
+	get URL() {
+		return "https://docs.openwrt.melmac.net/" + pkg.Name + "/";
+	},
+	templateToRegexp: function (template) {
+		return RegExp(
+			"^" +
+				template
+					.split(/(\{\w+\})/g)
+					.map((part) => {
+						let placeholder = part.match(/^\{(\w+)\}$/);
+						if (placeholder) return `(?<${placeholder[1]}>.*?)`;
+						else return part.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+					})
+					.join("") +
+				"$"
+		);
+	},
+};
+
+var getInitStatus = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getInitStatus",
+	params: ["name"],
+});
+
+var getPlatformSupport = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getPlatformSupport",
+	params: ["name"],
+});
+
+var getProviders = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getProviders",
+	params: ["name"],
+});
+
+var getRuntime = rpc.declare({
+	object: "luci." + pkg.Name,
+	method: "getRuntime",
+	params: ["name"],
+});
+
+return baseclass.extend({
+	title: _("HTTPS DNS Proxy Instances"),
+
+	load: function () {
+		return Promise.all([
+			getInitStatus(pkg.Name),
+			getProviders(pkg.Name),
+			getRuntime(pkg.Name),
+		]);
+	},
+
+	render: function (data) {
+		var reply = {
+			status: (data[0] && data[0][pkg.Name]) || {
+				enabled: null,
+				running: null,
+				force_dns_active: null,
+				version: null,
+			},
+			providers: (data[1] && data[1][pkg.Name]) || { providers: [] },
+			runtime: (data[2] && data[2][pkg.Name]) || { instances: [] },
+		};
+		reply.providers.sort(function (a, b) {
+			return _(a.title).localeCompare(_(b.title));
+		});
+		reply.providers.push({
+			title: "Custom",
+			template: "{option}",
+			params: { option: { type: "text" } },
+		});
+
+		var forceDnsText = "";
+		if (reply.status.force_dns_active) {
+			reply.status.force_dns_ports.forEach((element) => {
+				forceDnsText += element + " ";
+			});
+		} else {
+			forceDnsText = "-";
+		}
+
+		var table = E(
+			"table",
+			{ class: "table", id: "https-dns-proxy_status_table" },
+			[
+				E("tr", { class: "tr table-titles" }, [
+					E("th", { class: "th" }, _("Name / Type")),
+					E("th", { class: "th" }, _("Listen Address")),
+					E("th", { class: "th" }, _("Listen Port")),
+					E("th", { class: "th" }, _("Force DNS Ports")),
+				]),
+			]
+		);
+
+		var rows = [];
+		Object.values(reply.runtime.instances).forEach((element) => {
+			var resolver;
+			var address;
+			var port;
+			var name;
+			var option;
+			var found;
+			element.command.forEach((param, index, arr) => {
+				if (param === "-r") resolver = arr[index + 1];
+				if (param === "-a") address = arr[index + 1];
+				if (param === "-p") port = arr[index + 1];
+			});
+			resolver = resolver || "Unknown";
+			address = address || "127.0.0.1";
+			port = port || "Unknown";
+			reply.providers.forEach((prov) => {
+				let regexp = pkg.templateToRegexp(prov.template);
+				if (!found && regexp.test(resolver)) {
+					found = true;
+					name = _(prov.title);
+					let match = resolver.match(regexp);
+					if (match[1] != null) {
+						if (
+							prov.params &&
+							prov.params.option &&
+							prov.params.option.options
+						) {
+							prov.params.option.options.forEach((opt) => {
+								if (opt.value === match[1]) option = _(opt.description);
+							});
+							name += " (" + option + ")";
+						} else {
+							if (match[1] !== "") name += " (" + match[1] + ")";
+						}
+					}
+				}
+			});
+			rows.push([name, address, port, forceDnsText]);
+		});
+
+		cbi_update_table(table, rows, E("em", _("There are no active instances.")));
+
+		return table;
+	},
+});

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,230 +1,90 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:258
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:259
 msgid "%s%s%s proxy at %s on port %s.%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:250
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:251
 msgid "%s%s%s proxy on port %s.%s"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/co.oszx.dns.json:14
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json:14
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.mullvad.doh.json:15
-msgid "AdBlocking Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json:2
-msgid "AdGuard"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:30
-msgid "Ads + Malware + Social Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:26
-msgid "Ads + Malware Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json:14
-msgid "Adult Content Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.ahadns.blitz.json:2
-msgid "AhaDNS Blitz"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:2
-msgid "AhaDNS Regional"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.alidns.dns.json:2
-msgid "AliDNS"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.applied-privacy.doh.json:2
-msgid "Applied Privacy DNS (AT)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:14
-msgid "Australia"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:2
-msgid "BlahDNS"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:136
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:143
 msgid ""
 "Blocks access to Mozilla Encrypted resolvers, forcing local devices to use "
 "router for DNS resolution (%smore information%s)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:120
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:127
 msgid ""
 "Blocks access to iCloud Private Relay resolvers, forcing local devices to "
 "use router for DNS resolution (%smore information%s)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:316
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:323
 msgid "Bootstrap DNS"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.cfiec.dns.json:2
-msgid "CFIEC Public IPv6 Only DNS (CN)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ca.cira.canadianshield.json:2
-msgid "CIRA Canadian Shield"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:134
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:141
 msgid "Canary Domains Mozilla"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:118
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:125
 msgid "Canary Domains iCloud"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json:2
-msgid "CleanBrowsing"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.cloudflare-dns.json:2
-msgid "Cloudflare"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/app.tiarap.doh.json:18
-msgid "Cloudlfare Cached"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/one.comss.dns.json:2
-msgid "Comss DNS (RU)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:2
-msgid "ControlD"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.dnsforfamily.dns-doh.json:2
-msgid "DNS For Family"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/de.dnsforge.json:2
-msgid "DNS Forge (DE)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/pub.doh.json:2
-msgid "DNSPod Public DNS (CN)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.dnslify.doh.json:2
-msgid "DNSlify DNS"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:339
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:350
 msgid "DSCP Codepoint"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.decloudus.dns.json:2
-msgid "DeCloudUs DNS"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ch.digitale-gesellschaft.dns.json:2
-msgid "Digitale Gesellschaft (CH)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/app.tiarap.doh.json:14
-msgid "Direct"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:376
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:377
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:370
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:371
 msgid "Disabling %s service"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:102
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:109
 msgid "Do not update configs"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/cn.360.doh.json:2
-msgid "DoH 360 DNS (CN)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/sb.dns.json:2
-msgid "DoH DNS (SB)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:357
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:358
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:351
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:352
 msgid "Enabling %s service"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ffmuc.doh.json:2
-msgid "FFMUC DNS (DE)"
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:102
+msgid "Force DNS Ports"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ca.cira.canadianshield.json:14
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json:14
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.cloudflare-dns.json:14
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:14
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json:14
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json:18
-msgid "Family Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json:8
-msgid "Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.ahadns.blitz.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.rethinkdns.sky.json:8
-msgid "Filters"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:22
-msgid "Finland"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:171
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:172
 msgid "Force DNS ports:"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:108
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:115
 msgid "Force Router DNS"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:112
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:127
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:146
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:119
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:134
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:153
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:367
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:383
 msgid "Force use of HTTP/1"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:378
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:395
 msgid "Force use of IPv6 DNS resolvers"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:109
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:116
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:18
-msgid "Germany"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/google.dns.json:2
-msgid "Google"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/root/usr/share/rpcd/acl.d/luci-app-https-dns-proxy.json:3
@@ -235,363 +95,182 @@ msgstr ""
 msgid "HTTPS DNS Proxy"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:72
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:77
 msgid "HTTPS DNS Proxy - Configuration"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:173
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:180
 msgid "HTTPS DNS Proxy - Instances"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:161
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:162
 msgid "HTTPS DNS Proxy - Status"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.he.ordns.json:2
-msgid "Hurricane Electric"
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:55
+msgid "HTTPS DNS Proxy Instances"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.idnet.doh.json:2
-msgid "IDNet (UK)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/jp.iij.dns.public.json:2
-msgid "IIJ Public DNS (JP)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:80
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:86
 msgid ""
 "If update option is selected, the %s'DNS forwardings' section of DHCP and "
 "DNS%s will be automatically updated to use selected DoH providers (%smore "
 "information%s)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:26
-msgid "India"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:30
-msgid "Italy"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:26
-msgid "Japan"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/fi.lelux.resolver-eu.json:2
-msgid "Lelux DNS (FI)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:145
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:152
 msgid "Let local devices use Mozilla Private Relay"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:126
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:133
 msgid "Let local devices use iCloud Private Relay"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:111
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:118
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json:2
-msgid "LibreDNS (GR)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:320
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:328
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:100
 msgid "Listen Address"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:326
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:334
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:101
 msgid "Listen Port"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/one.comss.dns.json:7
-msgid "Location"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:349
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:362
 msgid "Logging File Path"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:344
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:356
 msgid "Logging Verbosity"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:22
-msgid "Malware Filter"
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:99
+msgid "Name / Type"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/one.comss.dns.json:17
-msgid "Moscow, St Petersburg"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.mullvad.doh.json:2
-msgid "Mullvad"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:38
-msgid "Netherlands"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/io.nextdns.dns.json:2
-msgid "NextDNS.io"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:42
-msgid "Norway"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:187
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:188
 msgid "Not installed or not found"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/cz.nic.odvr.json:2
-msgid "ODVR (CZ)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/co.oszx.dns.json:2
-msgid "OSZX DNS (UK)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json:2
-msgid "OpenDNS"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:249
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:281
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:256
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:288
 msgid "Parameter"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:154
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:163
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:161
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:170
 msgid ""
 "Please note that %s is not supported on this system (%smore information%s)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:50
-msgid "Poland"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:353
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:367
 msgid "Polling Interval"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ca.cira.canadianshield.json:18
-msgid "Private Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ca.cira.canadianshield.json:22
-msgid "Protected Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:215
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:222
 msgid "Provider"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:358
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:373
 msgid "Proxy Server"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/tw.twnic.dns.json:2
-msgid "Quad 101 (TW)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.quad9.json:2
-msgid "Quad 9"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:319
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:320
 msgid "Restart"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:313
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:314
 msgid "Restarting %s service"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/lu.restena.kaitain.json:2
-msgid "Restena DNS (LU)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.rethinkdns.sky.json:2
-msgid "Rethink DNS"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/cn.rubyfish.dns.json:2
-msgid "RubyFish (CN)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:335
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:345
 msgid "Run As Group"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:331
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:340
 msgid "Run As User"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/io.seby.doh-2.json:2
-msgid "Seby DNS (AU)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.quad9.json:18
-msgid "Secured"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.quad9.json:26
-msgid "Secured with ECS Support"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.cloudflare-dns.json:22
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json:22
-msgid "Security Filter"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:203
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:204
 msgid "See the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:402
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:403
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:201
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:202
 msgid "Service Instances"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:165
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:166
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/one.comss.dns.json:13
-msgid "Siberia"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:30
-msgid "Singapore"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.snopyta.dns.doh.fi.json:2
-msgid "Snopyta DNS (FI)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:22
-msgid "Spain"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/co.oszx.dns.json:18
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json:18
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.cloudflare-dns.json:18
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:18
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json:18
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json:18
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.mullvad.doh.json:19
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.quad9.json:14
-msgid "Standard"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:300
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:301
 msgid "Start"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:294
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:295
 msgid "Starting %s service"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:338
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:339
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:332
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:333
 msgid "Stopping %s service"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ch.switch.dns.json:2
-msgid "Switch DNS (CH)"
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:148
+msgid "There are no active instances."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:14
-msgid "Switzerland"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/app.tiarap.doh.json:2
-msgid "Tiarap Public DNS (JP)"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:18
-msgid "US/Chicago"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:34
-msgid "US/Los Angeles"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:46
-msgid "US/New York"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:211
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:218
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.quad9.json:22
-msgid "Unsecured"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:100
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:107
 msgid "Update %s only"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:78
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:84
 msgid "Update DNSMASQ Config on Start/Stop"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:88
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:94
 msgid "Update all configs"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:362
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:378
 msgid "Use HTTP/1"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:372
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:389
 msgid "Use IPv6 resolvers"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:377
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:394
 msgid "Use any family DNS resolvers"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:366
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:382
 msgid "Use negotiated HTTP version"
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/io.nextdns.dns.json:8
-msgid "Username"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/app.tiarap.doh.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ca.cira.canadianshield.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/co.oszx.dns.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.cloudflare-dns.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json:8
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.mullvad.doh.json:9
-#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.quad9.json:8
-msgid "Variant"
-msgstr ""
-
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:169
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:170
 msgid "Version %s - Running."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:181
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:182
 msgid "Version %s - Stopped (Disabled)."
 msgstr ""
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:179
+#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:180
 msgid "Version %s - Stopped."
 msgstr ""

--- a/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
+++ b/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
@@ -20,8 +20,8 @@ readonly providersDir="/usr/share/${packageName}/providers"
 is_enabled() { "/etc/init.d/${1}" enabled; }
 is_running() { [ "$(ubus call service list "{ 'name': '$1' }" | jsonfilter -q -e "@['$1'].instances[*].running" | uniq)" = 'true' ]; }
 get_version() { grep -m1 -A2 -w "^Package: $1$" /usr/lib/opkg/status | sed -n 's/Version: //p'; }
-check_http2() { grep -q 'Provides: libnghttp2' /usr/lib/opkg/status; }
-check_http3() { grep -q 'Provides: libnghttp3' /usr/lib/opkg/status; }
+check_http2() { curl --version | grep -q 'nghttp2'; }
+check_http3() { curl --version | grep -q 'nghttp3'; }
 ubus_get_ports() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances[*].data.firewall.*.dest_port"; }
 logger() { /usr/bin/logger -t "$packageName" "$@"; }
 print_json_bool() { json_init; json_add_boolean "$1" "$2"; json_dump; json_cleanup; }


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.0

Description:
* add status->overview include file
* sync version to principal package
* minor code formatting/styling fixes for js files
* improve HTTP/2 and HTTP/3 detection in RPCD script
