### PR TITLE
luci-app-adblock-fast: sync with adblock-fast 1.0.1-1

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.0.0-7
+PKG_VERSION:=1.0.1-1
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_DESCRIPTION:=Provides Web UI for adblock-fast service.

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -112,9 +112,7 @@ var status = baseclass.extend({
 					statusRestarting: _("Restarting"),
 					statusForceReloading: _("Force Reloading"),
 					statusDownloading: _("Downloading lists"),
-					statusError: _("Error"),
-					statusWarning: _("Warning"),
-					statusFail: _("Fail"),
+					statusFail: _("Failed to start"),
 					statusSuccess: _("Active"),
 				};
 
@@ -191,6 +189,10 @@ var status = baseclass.extend({
 						warningMissingRecommendedPackages: _(
 							"Some recommended packages are missing"
 						),
+						warningInvalidCompressedCacheDir: _(
+							"Invalid compressed cache directory '%s'"
+						),
+						warningFreeRamCheckFail: _("Can't detect free RAM"),
 					};
 					var warningsTitle = E(
 						"label",
@@ -278,6 +280,9 @@ var status = baseclass.extend({
 						errorDetectingFileType: _("Failed to detect format %s"),
 						errorNothingToDo: _(
 							"No blocked list URLs nor blocked-domains enabled"
+						),
+						errorTooLittleRam: _(
+							"Free ram (%s) is not enough to process all enabled block-lists"
 						),
 					};
 					var errorsTitle = E(
@@ -461,9 +466,9 @@ var status = baseclass.extend({
 				);
 				var buttonsText = E("div", {}, [
 					btn_start,
-					// btn_gap,
-					// btn_action_pause,
 					btn_gap,
+					// btn_action_pause,
+					// btn_gap,
 					btn_action_dl,
 					btn_gap,
 					btn_stop,

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:223
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:225
 msgid "%s is currently disabled"
 msgstr ""
 
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Action"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:118
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:116
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:61
 msgid "Active"
 msgstr ""
@@ -55,7 +55,7 @@ msgstr ""
 msgid "AdBlock-Fast - Configuration"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:121
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:119
 msgid "AdBlock-Fast - Status"
 msgstr ""
 
@@ -103,7 +103,7 @@ msgstr ""
 msgid "Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:134
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:132
 msgid "Blocking %s domains (with %s)."
 msgstr ""
 
@@ -115,23 +115,27 @@ msgstr ""
 msgid "Cache file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:160
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:158
 msgid "Cache file found."
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:195
+msgid "Can't detect free RAM"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:68
 msgid "Compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:139
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:137
 msgid "Compressed cache file created."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:162
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:160
 msgid "Compressed cache file found."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:221
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:223
 msgid "Config (%s) validation failure!"
 msgstr ""
 
@@ -165,7 +169,7 @@ msgid ""
 "Directory for compressed cache file of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:419
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:424
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:239
 msgid "Disable"
 msgstr ""
@@ -174,11 +178,11 @@ msgstr ""
 msgid "Disable Debugging"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:156
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:154
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:413
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:418
 msgid "Disabling %s service"
 msgstr ""
 
@@ -207,7 +211,7 @@ msgstr ""
 msgid "Downloading lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:400
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:405
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:240
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:394
 msgid "Enable"
@@ -222,109 +226,111 @@ msgstr ""
 msgid "Enables debug output to /tmp/adblock-fast.log."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:394
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:399
 msgid "Enabling %s service"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:115
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:58
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:293
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:298
 msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:117
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:60
 msgid "Fail"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:246
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:248
 msgid "Failed to access shared memory"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:242
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:244
 msgid "Failed to create '%s' file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:264
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:266
 msgid "Failed to create block-list or restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:255
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:257
 msgid "Failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:241
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:243
 msgid "Failed to create directory for %s file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:276
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:278
 msgid "Failed to create output/cache/gzip file directory"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:278
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:280
 msgid "Failed to detect format %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:271
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:273
 msgid "Failed to download %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:269
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:271
 msgid "Failed to download Config Update file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:250
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:252
 msgid "Failed to format data file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:259
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:261
 msgid "Failed to move '%s' to '%s'"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:252
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:254
 msgid "Failed to move temporary data file to '%s'"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:248
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:250
 msgid "Failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:273
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:275
 msgid "Failed to parse %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:272
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:274
 msgid "Failed to parse Config Update file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:249
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:251
 msgid "Failed to process allow-list"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:267
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:269
 msgid "Failed to reload/restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:257
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:259
 msgid "Failed to remove temporary files"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:245
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:247
 msgid "Failed to restart/reload DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:247
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:249
 msgid "Failed to sort data file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:266
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:115
+msgid "Failed to start"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:268
 msgid "Failed to stop %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:258
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:260
 msgid "Failed to unpack compressed cache"
 msgstr ""
 
@@ -332,7 +338,7 @@ msgstr ""
 msgid "Force DNS Ports"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:142
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:140
 msgid "Force DNS ports:"
 msgstr ""
 
@@ -349,12 +355,16 @@ msgstr ""
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:341
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:346
 msgid "Force redownloading %s block lists"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:198
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:285
+msgid "Free ram (%s) is not enough to process all enabled block-lists"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json:3
@@ -385,6 +395,10 @@ msgstr ""
 msgid "Individual domains to be blocked."
 msgstr ""
 
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:193
+msgid "Invalid compressed cache directory '%s'"
+msgstr ""
+
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:221
 msgid "LED to indicate status"
 msgstr ""
@@ -403,15 +417,15 @@ msgstr ""
 msgid "No AdBlock on dnsmasq"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:274
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:276
 msgid "No HTTPS/SSL support on device"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:280
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:282
 msgid "No blocked list URLs nor blocked-domains enabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:176
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:174
 msgid "Not installed or not found"
 msgstr ""
 
@@ -419,11 +433,11 @@ msgstr ""
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:362
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:367
 msgid "Pause"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:357
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:362
 msgid "Pausing %s"
 msgstr ""
 
@@ -450,7 +464,7 @@ msgstr ""
 msgid "Processing lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:347
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:352
 msgid "Redownload"
 msgstr ""
 
@@ -459,19 +473,19 @@ msgstr ""
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:460
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:465
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:286
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:291
 msgid "Service Errors"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:125
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:123
 msgid "Service Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:198
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:200
 msgid "Service Warnings"
 msgstr ""
 
@@ -491,11 +505,11 @@ msgstr ""
 msgid "Some output"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:192
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:190
 msgid "Some recommended packages are missing"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:328
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:333
 msgid "Start"
 msgstr ""
 
@@ -504,7 +518,7 @@ msgstr ""
 msgid "Starting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:322
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:327
 msgid "Starting %s service"
 msgstr ""
 
@@ -512,7 +526,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:381
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:386
 msgid "Stop"
 msgstr ""
 
@@ -525,7 +539,7 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:375
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:380
 msgid "Stopping %s service"
 msgstr ""
 
@@ -541,29 +555,29 @@ msgstr ""
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:239
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:241
 msgid "The %s failed to discover WAN gateway"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:227
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:229
 msgid ""
 "The dnsmasq ipset support is enabled, but dnsmasq is either not installed or "
 "installed dnsmasq does not support ipset"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:230
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:232
 msgid ""
 "The dnsmasq ipset support is enabled, but ipset is either not installed or "
 "installed ipset does not support '%s' type"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:233
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:235
 msgid ""
 "The dnsmasq nft set support is enabled, but dnsmasq is either not installed "
 "or installed dnsmasq does not support nft set"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:236
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:238
 msgid "The dnsmasq nft sets support is enabled, but nft is not installed"
 msgstr ""
 
@@ -589,7 +603,7 @@ msgstr ""
 msgid "Use AdBlocking on the dnsmasq instance(s)"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:189
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:187
 msgid ""
 "Use of external dnsmasq config file detected, please set '%s' option to '%s'"
 msgstr ""
@@ -606,11 +620,10 @@ msgstr ""
 msgid "Version"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:128
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:126
 msgid "Version %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:116
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:59
 msgid "Warning"
 msgstr ""

--- a/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
+++ b/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Copyright 2023 MOSSDeF, Stan Grishin (stangri@melmac.ca)
-# shellcheck disable=SC1091,SC2018,SC2019,SC2039,SC3043,SC3057,SC3060
+# shellcheck disable=SC2018,SC2019,SC3043,SC3060
 
 # TechRef: https://openwrt.org/docs/techref/rpcd
 # TESTS
@@ -14,86 +14,26 @@
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "pause" }'
 # ubus -S call luci.adblock-fast setInitAction '{"name": "adblock-fast", "action": "stop" }'
 
-. /lib/functions.sh
-. /lib/functions/network.sh
-. /usr/share/libubox/jshn.sh
-
-readonly packageName="adblock-fast"
-readonly dnsmasqAddnhostsFile="/var/run/${packageName}/dnsmasq.addnhosts"
-readonly dnsmasqAddnhostsCache="/var/run/${packageName}/dnsmasq.addnhosts.cache"
-readonly dnsmasqAddnhostsGzip="${packageName}.dnsmasq.addnhosts.gz"
-readonly dnsmasqConfFile="/tmp/dnsmasq.d/${packageName}"
-readonly dnsmasqConfCache="/var/run/${packageName}/dnsmasq.conf.cache"
-readonly dnsmasqConfGzip="${packageName}.dnsmasq.conf.gz"
-readonly dnsmasqIpsetFile="/tmp/dnsmasq.d/${packageName}.ipset"
-readonly dnsmasqIpsetCache="/var/run/${packageName}/dnsmasq.ipset.cache"
-readonly dnsmasqIpsetGzip="${packageName}.dnsmasq.ipset.gz"
-readonly dnsmasqNftsetFile="/tmp/dnsmasq.d/${packageName}.nftset"
-readonly dnsmasqNftsetCache="/var/run/${packageName}/dnsmasq.nftset.cache"
-readonly dnsmasqNftsetGzip="${packageName}.dnsmasq.nftset.gz"
-readonly dnsmasqServersFile="/var/run/${packageName}/dnsmasq.servers"
-readonly dnsmasqServersCache="/var/run/${packageName}/dnsmasq.servers.cache"
-readonly dnsmasqServersGzip="${packageName}.dnsmasq.servers.gz"
-readonly unboundFile="/var/lib/unbound/adb_list.${packageName}"
-readonly unboundCache="/var/run/${packageName}/unbound.cache"
-readonly unboundGzip="${packageName}.unbound.gz"
-readonly jsonFile="/dev/shm/$packageName-status.json"
-
-str_contains() { [ -n "$1" ] &&[ -n "$2" ] && [ "${1//$2}" != "$1" ]; }
-str_contains_word() { echo "$1" | grep -q -w "$2"; }
-str_to_lower() { echo "$1" | tr 'A-Z' 'a-z'; }
-str_to_upper() { echo "$1" | tr 'a-z' 'A-Z'; }
-is_enabled() { uci -q get "${1}.config.enabled"; }
-get_version() { grep -m1 -A2 -w "^Package: $1$" /usr/lib/opkg/status | sed -n 's/Version: //p'; }
-print_json_bool() { json_init; json_add_boolean "$1" "$2"; json_dump; json_cleanup; }
-print_json_int() { json_init; json_add_int "$1" "$2"; json_dump; json_cleanup; }
-print_json_string() { json_init; json_add_string "$1" "$2"; json_dump; json_cleanup; }
-logger() { /usr/bin/logger -t "$packageName" "$@"; }
-ubus_get_status() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances.main.data.${1}"; }
-ubus_get_ports() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances.main.data.firewall.*.dest_port"; }
-is_present() { command -v "$1" >/dev/null 2>&1; }
-sanitize_dir() { [ -d "$(readlink -fn "$1")" ] && readlink -fn "$1"; }
-json() {
-# shellcheck disable=SC2034
-	local action="$1" param="$2" value="$3" i
-	if [ -s "$jsonFile" ]; then
-		json_load_file "$jsonFile" 2>/dev/null
-		json_select 'data' 2>/dev/null
-		for i in status message error stats reload restart; do
-			json_get_var $i "$i" 2>/dev/null
-		done
-	fi
-	case "$action" in
-		get)
-			case "$param" in
-				*)
-					printf "%b" "$(eval echo "\$$param")"; return;;
-			esac
-		;;
-	esac
-}
-
-get_url_filesize() {
-	local url="$1" size size_command
-	[ -n "$url" ] || { print_json_int 'size' '0'; return 0; }
-	is_present 'curl' || { print_json_int 'size' '0'; return 0; }
-	size_command='curl --silent --insecure --fail --head --request GET'
-	size="$($size_command "$url" | grep -i 'content-length:' | awk '{print $2}'; )"
-	echo "$size"
-}
-
-_get_file_url_size() {
-	local url size
-	config_get url "$1" 'url'
-	config_get size "$1" 'size'
-	[ -n "$size" ] || size="$(get_url_filesize "$url")"
-	json_add_object
-	json_add_string 'url' "$url"
-	json_add_int 'size' "$size"
-	json_close_object
-}
+readonly adbFunctionsFile='/etc/init.d/adblock-fast'
+if [ -s "$adbFunctionsFile" ]; then
+# shellcheck source=../../../../../adblock-fast/files/etc/init.d/adblock-fast
+	. "$adbFunctionsFile"
+else
+	logger -t adblock-fast 'error' "adblock-fast init.d file ($adbFunctionsFile) not found!"
+	print_json_string 'error' "adblock-fast init.d file ($adbFunctionsFile) not found!"
+fi
 
 get_file_url_filesizes() {
+	_get_file_url_size() {
+		local url size
+		config_get url "$1" 'url'
+		config_get size "$1" 'size'
+		[ -n "$size" ] || size="$(get_url_filesize "$url")"
+		json_add_object
+		json_add_string 'url' "$url"
+		json_add_int 'size' "$size"
+		json_close_object
+	}
 	local name="$1" i
 	json_init
 	json_add_object "$name"
@@ -201,19 +141,14 @@ get_init_status() {
 	json_init
 	json_add_object  "$name"
 	json_add_boolean 'enabled' "$(is_enabled "$name")"
-	i="$(json 'get' 'status')"
-	j="$(ubus_get_status 'status')"
-	if [ "$i" = 'statusSuccess' ] && [ "$i" != "$j" ]; then
-		i='statusStopped'
-	fi
-	json_add_string 'status' "$i"
-	if [ "$i" = 'statusSuccess' ]; then
+	json_add_string 'status' "$(json 'get' 'status')"
+	if is_running "$name"; then
 		json_add_boolean 'running' '1'
 	else
 		json_add_boolean 'running' '0'
 	fi
 	json_add_string 'version' "$(get_version "$name")"
-	errors="$(ubus_get_status errors)"
+	errors="$(ubus_get_data errors)"
 	json_add_array 'errors'
 	if [ -n "$errors" ]; then
 		for i in $errors; do
@@ -231,7 +166,7 @@ get_init_status() {
 		done
 	fi
 	json_close_array
-	warnings="$(ubus_get_status warnings)"
+	warnings="$(ubus_get_data warnings)"
 	json_add_array 'warnings'
 	if [ -n "$warnings" ]; then
 		for i in $warnings; do
@@ -259,7 +194,7 @@ get_init_status() {
 	else
 		json_add_boolean 'force_dns_active' '0'
 	fi
-	json_add_int 'entries' "$(ubus_get_status entries)"
+	json_add_int 'entries' "$(ubus_get_data entries)"
 	json_add_string 'dns' "$dns"
 	json_add_string 'outputFile' "$outputFile"
 	json_add_string 'outputCache' "$outputCache"
@@ -285,23 +220,6 @@ get_init_status() {
 	json_close_object
 	json_dump
 	json_cleanup
-}
-
-check_ipset() { { command -v ipset && /usr/sbin/ipset help hash:net; } >/dev/null 2>&1; }
-check_nft() { command -v nft >/dev/null 2>&1; }
-check_dnsmasq() { command -v dnsmasq >/dev/null 2>&1; }
-check_unbound() { command -v unbound >/dev/null 2>&1; }
-check_dnsmasq_ipset() {
-	local o;
-	check_dnsmasq || return 1
-	o="$(dnsmasq -v 2>/dev/null)"
-	check_ipset && ! echo "$o" | grep -q 'no-ipset' && echo "$o" | grep -q 'ipset'
-}
-check_dnsmasq_nftset() {
-	local o;
-	check_dnsmasq || return 1
-	o="$(dnsmasq -v 2>/dev/null)"
-	check_nft && ! echo "$o" | grep -q 'no-nftset' && echo "$o" | grep -q 'nftset'
 }
 
 get_platform_support() {


### PR DESCRIPTION
* improve error/warning/status messaging
* trim rpcd script code from functions shared with principal package
* depends on https://github.com/openwrt/packages/pull/22619