### PR TITLE
luci-app-statistics: cleanups of bad spacing

### DIFF
--- a/applications/luci-app-statistics/root/etc/init.d/luci_statistics
+++ b/applications/luci-app-statistics/root/etc/init.d/luci_statistics
@@ -12,9 +12,9 @@ SYSUPGRADE_BACKUP_FILE="${BACKUP_DIR}/rrdbackup.sysupgrade.tgz"
 SYSUPGRADE_BACKUP_TWIN_A="${BACKUP_DIR}/sysupgrade.trustme.txt"
 SYSUPGRADE_BACKUP_TWIN_B="${BACKUP_DIR}/sysupgrade.dont.trustme.txt"
 EXTRA_COMMANDS="backup sysupgrade_backup"
-EXTRA_HELP="\ backup Backup
-current rrd database if configured to do so\n\ sysupgrade_backup Take
-a special backup for sysupgrade/configuration saving"
+EXTRA_HELP="\
+	backup          Backup current rrd database if configured to do so\n\
+        sysupgrade_backup  Take a special backup for sysupgrade/configuration saving"
 
 TRACE=0
 


### PR DESCRIPTION
fixes the output of `/etc/init.d/luci_statistics help`
