### PR TITLE
luci-app-adblock-fast: sync version with principal package

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.0.1-1
+PKG_VERSION:=1.0.1-2
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_DESCRIPTION:=Provides Web UI for adblock-fast service.


### PR DESCRIPTION
Depends on https://github.com/openwrt/packages/pull/22655