### PR TITLE
luci-app-vnstat2: use more efficient way to get database interfaces

### DIFF
--- a/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js
+++ b/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js
@@ -58,13 +58,10 @@ return view.extend({
 		o = s.option(form.DummyValue, '_database');
 
 		o.load = function(section_id) {
-			return fs.exec('/usr/bin/vnstat', ['--json', 'f', '1']).then(L.bind(function(result) {
+			return fs.exec('/usr/bin/vnstat', ['--dbiflist', '1']).then(L.bind(function(result) {
 				var databaseInterfaces = [];
 				if (result.code == 0) {
-					var vnstatData = JSON.parse(result.stdout);
-					for (var i = 0; i < vnstatData.interfaces.length; i++) {
-						databaseInterfaces.push(vnstatData.interfaces[i].name);
-					}
+					databaseInterfaces = result.stdout.trim().split('\n');
 				}
 
 				var configInterfaces = uci.get_first('vnstat', 'vnstat', 'interface') || [];


### PR DESCRIPTION
The currently used command "vnstat --json f 1" can be very slow when the database contains many entries. This can result in an XHR timeout error on the configuration page.

Use the "--dbiflist" option instead, which was added in vnStat 2.7.

Fixes: #6702

---

This should also be cherry-picked for 23.05 and 22.03.