### PR TITLE
luci-mod-network: DHCP redesign;  phase1

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -365,6 +365,11 @@ return view.extend({
 			_('Write received DNS queries to syslog.') + ' ' + _('Dump cache on SIGUSR1, include requesting IP.'));
 		o.optional = true;
 
+		o = s.taboption('logging', form.Flag, 'logdhcp',
+			_('Extra DHCP logging'),
+			_('Log all options sent to DHCP clients and the tags used to determine them.'));
+		o.optional = true;
+
 		o = s.taboption('forward', form.DynamicList, 'server',
 			_('DNS forwardings'),
 			_('Forward specific domain queries to specific upstream servers.'));

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -316,8 +316,8 @@ return view.extend({
 			_('Dnsmasq is a lightweight <abbr title="Dynamic Host Configuration Protocol">DHCP</abbr> server and <abbr title="Domain Name System">DNS</abbr> forwarder.'));
 
 		s = m.section(form.TypedSection, 'dnsmasq');
-		s.anonymous = true;
-		s.addremove = false;
+		s.anonymous = false;
+		s.addremove = true;
 
 
 

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -701,6 +701,19 @@ return view.extend({
 		o.datatype = 'range(0,10000)';
 		o.placeholder = 1000;
 
+		o = s.taboption('limits', form.Value, 'min_cache_ttl',
+			_('Min cache TTL'),
+			_('Extend short TTL values to the seconds value given when caching them. Use with caution.') +
+			_(' (Max 1h == 3600)'));
+		o.optional = true;
+		o.placeholder = 60;
+
+		o = s.taboption('limits', form.Value, 'max_cache_ttl',
+			_('Max cache TTL'),
+			_('Set a maximum seconds TTL value for entries in the cache.'));
+		o.optional = true;
+		o.placeholder = 3600;
+
 		o = s.taboption('pxe_tftp', form.Flag, 'enable_tftp',
 			_('Enable TFTP server'),
 			_('Enable the built-in single-instance TFTP server.'));

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -673,6 +673,22 @@ return view.extend({
 		o.datatype = 'port';
 		o.placeholder = _('any');
 
+		o = s.taboption('devices', form.Value, 'minport',
+			_('Minimum source port #'),
+			_('Min valid value %s.').format('<code>1024</code>') + ' ' + _('Useful for systems behind firewalls.'));
+		o.optional = true;
+		o.datatype = 'port';
+		o.placeholder = 1024;
+		o.depends('queryport', '');
+
+		o = s.taboption('devices', form.Value, 'maxport',
+			_('Maximum source port #'),
+			_('Max valid value %s.').format('<code>65535</code>') + ' ' + _('Useful for systems behind firewalls.'));
+		o.optional = true;
+		o.datatype = 'port';
+		o.placeholder = 50000;
+		o.depends('queryport', '');
+
 		o = s.taboption('limits', form.Value, 'dhcpleasemax',
 			_('Max. DHCP leases'),
 			_('Maximum allowed number of active DHCP leases.'));

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -370,6 +370,29 @@ return view.extend({
 			_('Log all options sent to DHCP clients and the tags used to determine them.'));
 		o.optional = true;
 
+		o = s.taboption('logging', form.Value, 'logfacility',
+			_('Log facility'),
+			_('Set log class/facility for syslog entries.'));
+		o.optional = true;
+		o.value('KERN');
+		o.value('USER');
+		o.value('MAIL');
+		o.value('DAEMON');
+		o.value('AUTH');
+		o.value('LPR');
+		o.value('NEWS');
+		o.value('UUCP');
+		o.value('CRON');
+		o.value('LOCAL0');
+		o.value('LOCAL1');
+		o.value('LOCAL2');
+		o.value('LOCAL3');
+		o.value('LOCAL4');
+		o.value('LOCAL5');
+		o.value('LOCAL6');
+		o.value('LOCAL7');
+		o.value('-', _('stderr'));
+
 		o = s.taboption('forward', form.DynamicList, 'server',
 			_('DNS forwardings'),
 			_('Forward specific domain queries to specific upstream servers.'));


### PR DESCRIPTION
Better structure the DHCP general and advanced tabs from a wall of options and add some more config options to control dnsmasq behaviour.

See individual commit messages.

Tested on 22.03.5 and 23.05.0

Preview:

https://github.com/openwrt/luci/assets/647633/3c81e285-225f-4fea-857d-204ea5c8131f

