### PR TITLE
luci-app-advanced-reboot: add support for Mercusys MR90X v1

### DIFF
--- a/applications/luci-app-advanced-reboot/root/usr/libexec/rpcd/luci.advanced_reboot
+++ b/applications/luci-app-advanced-reboot/root/usr/libexec/rpcd/luci.advanced_reboot
@@ -23,7 +23,7 @@ is_alt_mountable() {
 }
 
 alt_partition_mount() {
-	local ubi_dev op_ubi="$1"
+	local ubi_dev op_ubi="$1" ubi_vol="${2:-0}"
 	mkdir -p /var/alt_rom
 	ubi_dev="$(ubiattach -m "$op_ubi")"
 	ubi_dev="$(echo "$ubi_dev" | sed -n "s/^UBI device number\s*\(\d*\),.*$/\1/p")"
@@ -31,12 +31,12 @@ alt_partition_mount() {
 		ubidetach -m "$op_ubi"
 		return 1
 	fi
-	ubiblock --create "/dev/ubi${ubi_dev}_0" && \
-	mount -t squashfs -r "/dev/ubiblock${ubi_dev}_0" /var/alt_rom
+	ubiblock --create "/dev/ubi${ubi_dev}_${ubi_vol}" && \
+	mount -t squashfs -r "/dev/ubiblock${ubi_dev}_${ubi_vol}" /var/alt_rom
 }
 
 alt_partition_unmount() {
-	local mtdCount i=0 op_ubi="$1"
+	local mtdCount i=0 op_ubi="$1" ubi_vol="${2:-0}"
 	mtdCount="$(ubinfo | grep 'Present UBI devices' | tr ',' '\n' | grep -c 'ubi')"
 	[ -z "$mtdCount" ] && mtdCount=10
 	[ -d /var/alt_rom ] && umount /var/alt_rom
@@ -46,7 +46,7 @@ alt_partition_unmount() {
 		fi
 		ubi_mtd="$(cat /sys/devices/virtual/ubi/ubi${i}/mtd_num)"
 		if [ -n "$ubi_mtd" ] && [ "$ubi_mtd" = "$op_ubi" ]; then
-			ubiblock --remove /dev/ubi${i}_0
+			ubiblock --remove /dev/ubi${i}_${ubi_vol}
 			ubidetach -m "$op_ubi"
 			rm -rf /var/alt_rom
 		fi
@@ -66,18 +66,21 @@ get_main_partition_os_info(){
 }
 
 get_alt_partition_os_info(){
-	local op_info op_ubi="$1"
+	local op_info op_ubi="$1" vendor_name="$2" ubi_vol="$3"
 	logger "attempting to mount alternative partition (mtd${op_ubi})"
-	alt_partition_unmount "$op_ubi"
-	alt_partition_mount "$op_ubi"
+	alt_partition_unmount "$op_ubi" "$ubi_vol"
+	alt_partition_mount "$op_ubi" "$ubi_vol"
 	if [ -s "/var/alt_rom/etc/os-release" ]; then
 		op_info="$(. /var/alt_rom/etc/os-release && echo "$PRETTY_NAME")"
 		if [ "${op_info//SNAPSHOT}" != "$op_info" ]; then
 			op_info="$(. /var/alt_rom/etc/os-release && echo "${OPENWRT_RELEASE%%-*}")"
 		fi
 	fi
+	if [ -s "/var/alt_rom/etc/partition_config/soft-version" ]; then
+		op_info="${vendor_name:+$vendor_name }$(awk -F: '$1=="soft_ver" { print $2 ;}' /var/alt_rom/etc/partition_config/soft-version)"
+	fi
 	logger "attempting to unmount alternative partition (mtd${op_ubi})"
-	alt_partition_unmount "$op_ubi"
+	alt_partition_unmount "$op_ubi" "$ubi_vol"
 	echo "$op_info"
 }
 
@@ -102,6 +105,7 @@ print_json() { json_init; json_add_string "$1" "$2"; json_dump; json_cleanup; }
 obtain_device_info(){
 	local romBoardName p zyxelFlagPartition i
 	local vendorName deviceName partition1MTD partition2MTD labelOffset
+	local opOffset ubiVolume
 	local bootEnv1 bootEnv1Partition1Value bootEnv1Partition2Value
 	local bootEnv2 bootEnv2Partition1Value bootEnv2Partition2Value
 	local p1_label p1_version p2_label p2_version p1_os p2_os
@@ -122,7 +126,8 @@ obtain_device_info(){
 	json_load_file "$p"
 	for i in vendorName deviceName partition1MTD partition2MTD labelOffset \
 		bootEnv1 bootEnv1Partition1Value bootEnv1Partition2Value \
-		bootEnv2 bootEnv2Partition1Value bootEnv2Partition2Value; do
+		bootEnv2 bootEnv2Partition1Value bootEnv2Partition2Value \
+		opOffset ubiVolume; do
 		json_get_var $i "$i"
 	done
 	json_cleanup
@@ -185,13 +190,15 @@ obtain_device_info(){
 	fi
 
 	if is_alt_mountable "$partition1MTD" "$partition2MTD"; then
+		opOffset="${opOffset:-1}"
+		ubiVolume="${ubiVolume:-0}"
 		if [ "$current_partition" = "$bootEnv1Partition1Value" ]; then
-			op_ubi=$(( ${partition2MTD:3:3} + 1 ))
+			op_ubi=$(( ${partition2MTD:3:3} + $opOffset ))
 		else
-			op_ubi=$(( ${partition1MTD:3:3} + 1 ))
+			op_ubi=$(( ${partition1MTD:3:3} + $opOffset ))
 		fi
 		cp_info="$(get_main_partition_os_info $op_ubi)"
-		op_info="$(get_alt_partition_os_info $op_ubi)"
+		op_info="$(get_alt_partition_os_info $op_ubi $vendorName $ubiVolume)"
 		if [ "$current_partition" = "$bootEnv1Partition1Value" ]; then
 			p1_os="${cp_info:-$p1_os}"
 			p2_os="${op_info:-$p2_os}"

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/mercusys-mr90xv1.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/mercusys-mr90xv1.json
@@ -1,0 +1,16 @@
+{
+    "vendorName": "MERCUSYS",
+    "deviceName": "MR90X v1",
+    "boardNames": [ "mercusys,mr90x-v1" ],
+    "partition1MTD": "mtd2",
+    "partition2MTD": "mtd3",
+    "opOffset": 0,
+    "ubiVolume": 2,
+    "labelOffset": null,
+    "bootEnv1": "tp_boot_idx",
+    "bootEnv1Partition1Value": 0,
+    "bootEnv1Partition2Value": 1,
+    "bootEnv2": null,
+    "bootEnv2Partition1Value": null,
+    "bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
![screenshot](https://github.com/openwrt/luci/assets/4098364/ba5ea481-8ffb-44b4-9832-65272e5cde06)

You might want to see [UBI volume structure](https://openwrt.org/toh/mercusys/mr90x_v1#ubi_sctructure) of this device to understand some changes

I didn't want to intrude into the bash part too much, but I think other devices might benefit from certain changes in the future. It's completely backwards compatible and won't affect previously added devices

~~I will mark it as draft for now for more tests, but pretty sure it's more or less final unless reviewers request any changes :)~~

Tested, works perfectly. To reboot back from OEM firmware one would need to:
1. Connect using ssh to [router ip]:20001
2. Edit `/etc/hotplug.d/iface/65-iptv`, adding `telnetd -l /bin/login.sh` on a newline after `#!/bin/sh`
3. Toggle on `IPTV/VLAN Enable` in the web interface
4. Telnet into the router
5. Check `fw_printenv | grep tp_boot_idx`
6. Do `fw_setenv tp_boot_idx 0` or `fw_setenv tp_boot_idx 1`, whichever it wasn't set to in step 5

P.S. I don't understand the meaning behind [this +1 offset](https://github.com/openwrt/luci/blob/41cee29f3bc832bbadc24786f082fddfb78c009d/applications/luci-app-advanced-reboot/root/usr/libexec/rpcd/luci.advanced_reboot#L189), it always shifted the partition off by one for me, must be some device-specific thing?

```
root@OpenWrt:~# ubus call system board
...
        "system": "ARMv8 Processor rev 4",
        "model": "MERCUSYS MR90X v1",
        "board_name": "mercusys,mr90x-v1",
        "rootfs_type": "squashfs",
...
```
```
root@OpenWrt:~# cat /tmp/sysinfo/board_name
mercusys,mr90x-v1
```
```
root@OpenWrt:~# cat /proc/mtd
dev:    size   erasesize  name
mtd0: 00200000 00020000 "boot"
mtd1: 00100000 00020000 "u-boot-env"
mtd2: 03200000 00020000 "ubi0"
mtd3: 03200000 00020000 "ubi1"
mtd4: 00800000 00020000 "userconfig"
mtd5: 00400000 00020000 "tp_data"
```
```
root@OpenWrt:~# fw_printenv
...
loadaddr=0x46000000
mtdids=spi-nand0=spi-nand0
mtdparts=spi-nand0:2M(boot),1M(u-boot-env),50M(ubi0),50M(ubi1),8M(userconfig),4M(tp_data)
bootargs=ubi.mtd=ubi0 console=ttyS0,115200n1 loglevel=8 earlycon=uart8250,mmio32,0x11002000 init=/etc/preinit
tp_boot_idx=0
```