### PR TITLE
luci-app-advanced-reboot: bump version number due to changes in code

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.0.1-8
+PKG_VERSION:=1.0.1-9
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/


### PR DESCRIPTION
Bumps version of `luci-app-advanced-reboot` package in response to changes introduced in #6709, @stangri 