### PR TITLE
luci-mod-status: fix ACL for channel analysis

### DIFF
--- a/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/rpcd/acl.d/luci-mod-status.json
@@ -61,7 +61,7 @@
 		"description": "Grant access to wireless channel status",
 		"read": {
 			"ubus": {
-				"iwinfo": [ "info", "freqlist" ]
+				"iwinfo": [ "info", "freqlist", "scan" ]
 			}
 		}
 	},


### PR DESCRIPTION
Without this fix channel analysis will not work unless write access is also granted to luci-mod-network-config