### PR TITLE
luci-mod-status: add missing vht40 channels

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/channel_analysis.js
@@ -291,7 +291,10 @@ return view.extend({
 
 				if (res.vht_operation != null) {
 					center_channels[0] = res.vht_operation.center_freq_1;
-					if (res.vht_operation.channel_width == 80) {
+					if (res.vht_operation.channel_width == 40) {
+						chan_width = 4;
+						res.channel_width = "40 MHz";
+					} else if (res.vht_operation.channel_width == 80) {
 						chan_width = 8;
 						res.channel_width = "80 MHz";
 					} else if (res.vht_operation.channel_width == 8080) {


### PR DESCRIPTION
As of now, channel_analysis detects

- regular 20 MHz channels (all kinds: it is the default)
- 40 MHz HT channels, as well as
- 80 and 80+80 and 160 MHz VHT channels.

It is missing 40 MHz VHT channels. What it does for those right now is display them as 20 MHz channels (both in the plot and the table below), but it uses the center frequency of the 40 MHz channel, which means their (wrong) 20 MHz band in the plot is offset by 2.

This fixes #6419. Note that this only occurs for **other** stations. The code for local_wifi is different and already complete.