### PR TITLE
luci-proto-external: migrate from support to cni-protocol to external…

### DIFF
--- a/protocols/luci-proto-external/Makefile
+++ b/protocols/luci-proto-external/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=Support for CNI protocol
-LUCI_DEPENDS:=+cni-protocol
+LUCI_TITLE:=Support for externally managed protocol
+LUCI_DEPENDS:=+external-protocol
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-external/htdocs/luci-static/resources/protocol/external.js
+++ b/protocols/luci-proto-external/htdocs/luci-static/resources/protocol/external.js
@@ -2,13 +2,13 @@
 'require form';
 'require network';
 
-return network.registerProtocol('cni', {
+return network.registerProtocol('external', {
 	getI18n: function () {
-		return _('CNI (Externally managed interface)');
+		return _('Externally managed interface');
 	},
 
 	getOpkgPackage: function() {
-		return "cni-protocol";
+		return "external-protocol";
 	},
 
 	isFloating: function() {
@@ -31,10 +31,15 @@ return network.registerProtocol('cni', {
 		o.optional = false;
 		o.rmempty = false;
 
-		o = s.taboption('general', form.Value, '_delay', _('Delay'), _('Afer making changes to network using CNI protocol, network must be manually restarted.'));
+		o = s.taboption('general', form.Value, '_delay', _('Delay'), _('Afer making changes to network using external protocol, network must be manually restarted.'));
 		o.ucioption = 'delay';
 		o.placeholder = '10';
 		o.datatype = 'min(1)';
+		o.optional = true;
+		o.rmempty = true;
+
+		o = s.taboption('general', form.Value, '_searchdomain', _('Search domain'));
+		o.ucioption = 'searchdomain'
 		o.optional = true;
 		o.rmempty = true;
 	}


### PR DESCRIPTION
As previously introduced cni protocol support (for netifd) has evolved more to a multipurpose protocol useful for cni/netavark/some vpn/etc connections I have decided to rename it from cni-protocol to external-protocol.

That's why also it's luci companion, luci-proto-cni, should be renamed to luci-proto-external and migrated to support external-protocol.

This patch also adds support for new option in external-protocol, delay.
This closes promise made in openwrt/packages#22702 on openwrt packages repository.