### PR TITLE
Prevent odhcp6c from asking for Softwire46 OROs by default, as `map` package isn't installed by default

### DIFF
--- a/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js
+++ b/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js
@@ -30,7 +30,31 @@ return network.registerProtocol('dhcpv6', {
 		o.value('64');
 		o.default = 'auto';
 
+		o = s.taboption('general', form.Flag, 'defaultreqopts', _('Request all known DHCPv6 options'));
+		o.rmempty = false;
+		o.default = '0';
+
+		o = s.taboption('general', form.MultiValue, 'reqopts', _('Request Specific DHCPv6 Options'));
+		o.depends('defaultreqopts', '0');
+		o.widget = 'checkbox';
+		o.multiple = true;
+		o.value('21', 'SIP Server Domain Name List (21)');
+		o.value('22', 'SIP Servers IPv6 Address List (22)');
+		o.value('23', 'DNS Recursive Name Server (23)');
+		o.value('24', 'Domain Search List (24)');
+		o.value('31', 'Simple NTP Server (31)');
+		o.value('56', 'NTP Server (56)');
+		o.value('64', 'DS-Lite AFTR Name (64)');
+		o.value('94', 'MAP-E (94)');
+		o.value('95', 'MAP-T (95)');
+		o.value('96', 'LW4over6 (96)');
+		o.default = '21 22 23 24 31 56';
+
 		o = s.taboption('advanced', form.Value, 'clientid', _('Client ID to send when requesting DHCP'));
 		o.datatype  = 'hexstring';
+
+		o = s.taboption('advanced', form.Flag, 'norelease', _('Do not send a Release when restarting'),
+						_('Enable to minimise the chance of prefix change after a restart'));
+		o.default = '0';
 	}
 });


### PR DESCRIPTION
Add defaultreqopts toggle that's off by default
Add MultiValue list to select Option Request options, leaving non-softwire46 OROs enabled by default.

Closes #6739

Note: requires a [PR14136](https://github.com/openwrt/openwrt/pull/14136) in to OpenWRT to be accepted