### PR TITLE
luci-app-vnstat2: fix configuration page when database is empty

### DIFF
--- a/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js
+++ b/applications/luci-app-vnstat2/htdocs/luci-static/resources/view/vnstat2/config.js
@@ -60,7 +60,7 @@ return view.extend({
 		o.load = function(section_id) {
 			return fs.exec('/usr/bin/vnstat', ['--dbiflist', '1']).then(L.bind(function(result) {
 				var databaseInterfaces = [];
-				if (result.code == 0) {
+				if (result.code == 0 && result.stdout) {
 					databaseInterfaces = result.stdout.trim().split('\n');
 				}
 


### PR DESCRIPTION
The output of the command "vnstat --dbiflist 1" is empty when there are no interfaces in the database. Add a check to avoid a "result.stdout is undefined" error in that case.

Ref: https://forum.openwrt.org/t/error-in-luci-vnstat2-configuration-menu/179700
Fixes: 3ac4f567dfdf ("luci-app-vnstat2: use more efficient way to get database interfaces")

---

This fix is also needed in the openwrt-23.05 and openwrt-22.03 branches.