### PR TITLE
luci-proto-ipv6: dhcpv6.js fix translation

### DIFF
--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -7502,6 +7502,14 @@ msgstr ""
 msgid "Request IPv6-address"
 msgstr ""
 
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:18
+msgid "try"
+msgstr ""
+
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:19
+msgid "force"
+msgstr ""
+
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:23
 msgid "Request IPv6-prefix of length"
 msgstr ""
@@ -10682,6 +10690,7 @@ msgstr ""
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:967
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:1044
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:91
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:20
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js:25
 msgid "disabled"
 msgstr ""


### PR DESCRIPTION
This is an option that hasn't been translated in many years