### PR TITLE
luci-app-adblock-fast: update to 1.1.1-1

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.1.0-7
+PKG_VERSION:=1.1.1-1
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_DESCRIPTION:=Provides Web UI for adblock-fast service.

--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js
@@ -18,6 +18,9 @@ var pkg = {
 	humanFileSize: function (bytes, si = false, dp = 2) {
 		return `%${si ? 1000 : 1024}.${dp ?? 0}mB`.format(bytes);
 	},
+	isObjEmpty: function (obj) {
+		return Object.keys(obj).length === 0;
+	},
 };
 
 return view.extend({
@@ -46,6 +49,9 @@ return view.extend({
 				unbound_installed: false,
 				leds: [],
 			},
+			pkg: (!pkg.isObjEmpty(data[2]) && data[2]) || null,
+			dhcp: (!pkg.isObjEmpty(data[3]) && data[3]) || null,
+			smartdns: (!pkg.isObjEmpty(data[4]) && data[4]) || null,
 		};
 		var status, m, s1, s2, s3, o;
 
@@ -176,127 +182,132 @@ return view.extend({
 		);
 		o.depends("dns", "dnsmasq.conf");
 
-		o = s1.taboption(
-			"tab_basic",
-			form.ListValue,
-			"dnsmasq_instance_option",
-			_("Use AdBlocking on the dnsmasq instance(s)"),
-			_(
-				"You can limit the AdBlocking to the specific dnsmasq instance(s) (%smore information%s)."
-			).format(
-				'<a href="' + pkg.URL + "#dnsmasq_instance" + '" target="_blank">',
-				"</a>"
-			)
-		);
-		o.value("*", _("AdBlock on all instances"));
-		o.value("+", _("AdBlock on select instances"));
-		o.value("-", _("No AdBlock on dnsmasq"));
-		o.default = "*";
-		o.depends("dns", "dnsmasq.addnhosts");
-		o.depends("dns", "dnsmasq.servers");
-		o.retain = true;
-		o.cfgvalue = function (section_id) {
-			let val = this.map.data.get(
-				this.map.config,
-				section_id,
-				"dnsmasq_instance"
+		if (reply.platform.dnsmasq_installed && reply.dhcp) {
+			o = s1.taboption(
+				"tab_basic",
+				form.ListValue,
+				"dnsmasq_instance_option",
+				_("Use AdBlocking on the dnsmasq instance(s)"),
+				_(
+					"You can limit the AdBlocking to the specific dnsmasq instance(s) (%smore information%s)."
+				).format(
+					'<a href="' + pkg.URL + "#dnsmasq_instance" + '" target="_blank">',
+					"</a>"
+				)
 			);
-			switch (val) {
-				case "*":
-				case "-":
-					return val;
-				default:
-					return "+";
-			}
-		};
-		o.write = function (section_id, formvalue) {
-			L.uci.set(pkg.Name, section_id, "dnsmasq_instance", formvalue);
-		};
+			o.value("*", _("AdBlock on all instances"));
+			o.value("+", _("AdBlock on select instances"));
+			o.value("-", _("No AdBlock on dnsmasq"));
+			o.default = "*";
+			o.depends("dns", "dnsmasq.addnhosts");
+			o.depends("dns", "dnsmasq.servers");
+			o.retain = true;
+			o.cfgvalue = function (section_id) {
+				let val = this.map.data.get(
+					this.map.config,
+					section_id,
+					"dnsmasq_instance"
+				);
+				switch (val) {
+					case "*":
+					case "-":
+						return val;
+					default:
+						return "+";
+				}
+			};
+			o.write = function (section_id, formvalue) {
+				L.uci.set(pkg.Name, section_id, "dnsmasq_instance", formvalue);
+			};
 
-		o = s1.taboption(
-			"tab_basic",
-			form.MultiValue,
-			"dnsmasq_instance",
-			_("Pick the dnsmasq instance(s) for AdBlocking")
-		);
-		Object.values(L.uci.sections("dhcp", "dnsmasq")).forEach(function (
-			element
-		) {
-			var description;
-			var key;
-			if (element[".name"] === L.uci.resolveSID("dhcp", element[".name"])) {
-				key = element[".index"];
-				description = "dnsmasq[" + element[".index"] + "]";
-			} else {
-				key = element[".name"];
-				description = element[".name"];
-			}
-			o.value(key, _("%s").format(description));
-		});
-		o.depends("dnsmasq_instance_option", "+");
-		o.retain = true;
-
-		o = s1.taboption(
-			"tab_basic",
-			form.ListValue,
-			"smartdns_instance_option",
-			_("Use AdBlocking on the SmartDNS instance(s)"),
-			_(
-				"You can limit the AdBlocking to the specific SmartDNS instance(s) (%smore information%s)."
-			).format(
-				'<a href="' + pkg.URL + "#smartdns_instance" + '" target="_blank">',
-				"</a>"
-			)
-		);
-		o.value("*", _("AdBlock on all instances"));
-		o.value("+", _("AdBlock on select instances"));
-		o.value("-", _("No AdBlock on SmartDNS"));
-		o.default = "*";
-		o.depends("dns", "smartdns.domainset");
-		o.depends("dns", "smartdns.ipset");
-		o.depends("dns", "smartdns.nftset");
-		o.retain = true;
-		o.cfgvalue = function (section_id) {
-			let val = this.map.data.get(
-				this.map.config,
-				section_id,
-				"smartdns_instance"
+			o = s1.taboption(
+				"tab_basic",
+				form.MultiValue,
+				"dnsmasq_instance",
+				_("Pick the dnsmasq instance(s) for AdBlocking")
 			);
-			switch (val) {
-				case "*":
-				case "-":
-					return val;
-				default:
-					return "+";
-			}
-		};
-		o.write = function (section_id, formvalue) {
-			L.uci.set(pkg.Name, section_id, "smartdns_instance", formvalue);
-		};
+			Object.values(L.uci.sections("dhcp", "dnsmasq")).forEach(function (
+				element
+			) {
+				var description;
+				var key;
+				if (element[".name"] === L.uci.resolveSID("dhcp", element[".name"])) {
+					key = element[".index"];
+					description = "dnsmasq[" + element[".index"] + "]";
+				} else {
+					key = element[".name"];
+					description = element[".name"];
+				}
+				o.value(key, _("%s").format(description));
+			});
+			o.depends("dnsmasq_instance_option", "+");
+			o.retain = true;
+		}
 
-		o = s1.taboption(
-			"tab_basic",
-			form.MultiValue,
-			"smartdns_instance",
-			_("Pick the SmartDNS instance(s) for AdBlocking")
-		);
-		Object.values(L.uci.sections("smartdns", "smartdns")).forEach(function (
-			element
-		) {
-			var description;
-			var key;
-			if (element[".name"] === L.uci.resolveSID("smartdns", element[".name"])) {
-				key = element[".index"];
-				description = "smartdns[" + element[".index"] + "]";
-			} else {
-				key = element[".name"];
-				description = element[".name"];
-			}
-			o.value(key, _("%s").format(description));
-		});
-		o.depends("smartdns_instance_option", "+");
-		o.retain = true;
+		if (reply.platform.smartdns_installed && reply.smartdns) {
+			o = s1.taboption(
+				"tab_basic",
+				form.ListValue,
+				"smartdns_instance_option",
+				_("Use AdBlocking on the SmartDNS instance(s)"),
+				_(
+					"You can limit the AdBlocking to the specific SmartDNS instance(s) (%smore information%s)."
+				).format(
+					'<a href="' + pkg.URL + "#smartdns_instance" + '" target="_blank">',
+					"</a>"
+				)
+			);
+			o.value("*", _("AdBlock on all instances"));
+			o.value("+", _("AdBlock on select instances"));
+			o.value("-", _("No AdBlock on SmartDNS"));
+			o.default = "*";
+			o.depends("dns", "smartdns.domainset");
+			o.depends("dns", "smartdns.ipset");
+			o.depends("dns", "smartdns.nftset");
+			o.retain = true;
+			o.cfgvalue = function (section_id) {
+				let val = this.map.data.get(
+					this.map.config,
+					section_id,
+					"smartdns_instance"
+				);
+				switch (val) {
+					case "*":
+					case "-":
+						return val;
+					default:
+						return "+";
+				}
+			};
+			o.write = function (section_id, formvalue) {
+				L.uci.set(pkg.Name, section_id, "smartdns_instance", formvalue);
+			};
 
+			o = s1.taboption(
+				"tab_basic",
+				form.MultiValue,
+				"smartdns_instance",
+				_("Pick the SmartDNS instance(s) for AdBlocking")
+			);
+			Object.values(L.uci.sections("smartdns", "smartdns")).forEach(function (
+				element
+			) {
+				var description;
+				var key;
+				if (
+					element[".name"] === L.uci.resolveSID("smartdns", element[".name"])
+				) {
+					key = element[".index"];
+					description = "smartdns[" + element[".index"] + "]";
+				} else {
+					key = element[".name"];
+					description = element[".name"];
+				}
+				o.value(key, _("%s").format(description));
+			});
+			o.depends("smartdns_instance_option", "+");
+			o.retain = true;
+		}
 		o = s1.taboption(
 			"tab_basic",
 			form.ListValue,

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -1,8 +1,8 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:234
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:295
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:241
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:306
 msgid "%s"
 msgstr ""
 
@@ -23,7 +23,7 @@ msgstr ""
 msgid "-"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:505
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:516
 msgid "Action"
 msgstr ""
 
@@ -36,13 +36,13 @@ msgstr ""
 msgid "AdBlock Fast"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:191
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:251
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:198
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:260
 msgid "AdBlock on all instances"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:192
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:252
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:199
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:261
 msgid "AdBlock on select instances"
 msgstr ""
 
@@ -50,15 +50,15 @@ msgstr ""
 msgid "AdBlock-Fast"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:456
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:467
 msgid "AdBlock-Fast - Allowed and Blocked Domains"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:480
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:491
 msgid "AdBlock-Fast - Allowed and Blocked Lists URLs"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:53
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:59
 msgid "AdBlock-Fast - Configuration"
 msgstr ""
 
@@ -66,46 +66,46 @@ msgstr ""
 msgid "AdBlock-Fast - Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:358
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:369
 msgid "Add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:355
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:366
 msgid "Add IPv6 entries to block-list."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:56
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:62
 msgid "Advanced Configuration"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:506
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:511
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:517
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:522
 msgid "Allow"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:464
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:475
 msgid "Allowed Domains"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:419
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:430
 msgid ""
 "Attempt to create a compressed cache of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:343
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:354
 msgid "Automatic Config Update"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:55
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:61
 msgid "Basic Configuration"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:507
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:511
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:518
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:522
 msgid "Block"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:472
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:483
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:87
 msgid "Blocked Domains"
 msgstr ""
@@ -146,42 +146,42 @@ msgstr ""
 msgid "Config (%s) validation failure!"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:316
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:327
 msgid "Controls system log and console output verbosity."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:392
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:403
 msgid "Curl download retry"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:379
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:390
 msgid "Curl maximum file size (in bytes)"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:137
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:143
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:86
 msgid "DNS Service"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:59
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:65
 msgid "DNS resolution option, see the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:430
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:441
 msgid "Directory for compressed cache file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:432
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:443
 msgid ""
 "Directory for compressed cache file of block-list in the persistent memory."
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:424
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:346
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:357
 msgid "Disable"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:448
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:459
 msgid "Disable Debugging"
 msgstr ""
 
@@ -193,23 +193,23 @@ msgstr ""
 msgid "Disabling %s service"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:169
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:175
 msgid "Dnsmasq Config File URL"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:357
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:368
 msgid "Do not add IPv6 entries"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:422
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:433
 msgid "Do not store compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:409
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:420
 msgid "Do not use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:369
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:380
 msgid "Download time-out (in seconds)"
 msgstr ""
 
@@ -219,17 +219,17 @@ msgid "Downloading lists"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:405
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:347
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:501
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:358
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:512
 msgid "Enable"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:445
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:449
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:456
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:460
 msgid "Enable Debugging"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:446
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:457
 msgid "Enables debug output to /tmp/adblock-fast.log."
 msgstr ""
 
@@ -354,11 +354,11 @@ msgstr ""
 msgid "Force Reloading"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:304
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:315
 msgid "Force Router DNS"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:308
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:319
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
@@ -366,7 +366,7 @@ msgstr ""
 msgid "Force redownloading %s block lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:305
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:316
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
@@ -378,27 +378,27 @@ msgstr ""
 msgid "Grant UCI and file access for luci-app-adblock-fast"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:354
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:365
 msgid "IPv6 Support"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:381
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:392
 msgid ""
 "If curl is installed and detected, it would not download files bigger than "
 "this."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:394
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:405
 msgid ""
 "If curl is installed and detected, it would retry download this many times "
 "on timeout/fail."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:465
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:476
 msgid "Individual domains to be allowed."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:473
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:484
 msgid "Individual domains to be blocked."
 msgstr ""
 
@@ -406,25 +406,25 @@ msgstr ""
 msgid "Invalid compressed cache directory '%s'"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:328
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:339
 msgid "LED to indicate status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:406
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:417
 msgid ""
 "Launch all lists downloads and processing simultaneously, reducing service "
 "start time."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:307
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:318
 msgid "Let local devices use their own DNS servers if set"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:253
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:262
 msgid "No AdBlock on SmartDNS"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:193
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:200
 msgid "No AdBlock on dnsmasq"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Not installed or not found"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:315
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:326
 msgid "Output Verbosity Setting"
 msgstr ""
 
@@ -452,32 +452,32 @@ msgstr ""
 msgid "Pausing %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:344
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:355
 msgid "Perform config update before downloading the block/allow-lists."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:330
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:341
 msgid "Pick the LED not already used in %sSystem LED Configuration%s."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:281
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:290
 msgid "Pick the SmartDNS instance(s) for AdBlocking"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:220
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:227
 msgid "Pick the dnsmasq instance(s) for AdBlocking"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:67
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:72
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:77
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:82
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:89
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:96
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:105
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:112
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:119
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:128
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:73
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:78
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:83
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:88
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:95
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:102
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:111
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:118
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:125
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:134
 msgid "Please note that %s is not supported on this system."
 msgstr ""
 
@@ -511,19 +511,19 @@ msgstr ""
 msgid "Service Warnings"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:404
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:415
 msgid "Simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:488
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:499
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:498
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:509
 msgid "Size: %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:319
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:330
 msgid "Some output"
 msgstr ""
 
@@ -552,7 +552,7 @@ msgstr ""
 msgid "Stop"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:370
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:381
 msgid "Stop the download if it is stalled for set number of seconds."
 msgstr ""
 
@@ -565,15 +565,15 @@ msgstr ""
 msgid "Stopping %s service"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:423
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:434
 msgid "Store compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:417
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:428
 msgid "Store compressed cache file on router"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:318
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:329
 msgid "Suppress output"
 msgstr ""
 
@@ -603,29 +603,29 @@ msgstr ""
 msgid "The dnsmasq nft sets support is enabled, but nft is not installed"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:514
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:525
 msgid "URL"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:171
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:177
 msgid ""
 "URL to the external dnsmasq config file, see the %sREADME%s for details."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:481
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:492
 msgid "URLs to file(s) containing lists to be allowed or blocked."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:492
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:503
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:95
 msgid "Unknown"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:243
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:252
 msgid "Use AdBlocking on the SmartDNS instance(s)"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:183
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:190
 msgid "Use AdBlocking on the dnsmasq instance(s)"
 msgstr ""
 
@@ -634,11 +634,11 @@ msgid ""
 "Use of external dnsmasq config file detected, please set '%s' option to '%s'"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:410
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:421
 msgid "Use simultaneous processing"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:320
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:331
 msgid "Verbose output"
 msgstr ""
 
@@ -654,54 +654,54 @@ msgstr ""
 msgid "Warning"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:245
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:254
 msgid ""
 "You can limit the AdBlocking to the specific SmartDNS instance(s) (%smore "
 "information%s)."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:185
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:192
 msgid ""
 "You can limit the AdBlocking to the specific dnsmasq instance(s) (%smore "
 "information%s)."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:141
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:147
 msgid "dnsmasq additional hosts"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:142
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:148
 msgid "dnsmasq config"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:144
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:150
 msgid "dnsmasq ipset"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:147
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:153
 msgid "dnsmasq nft set"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:149
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:155
 msgid "dnsmasq servers file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:333
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:344
 msgid "none"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:152
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:158
 msgid "smartdns domain set"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:154
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:160
 msgid "smartdns ipset"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:157
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:163
 msgid "smartdns nft set"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:161
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:167
 msgid "unbound adblock list"
 msgstr ""

--- a/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
+++ b/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
@@ -95,7 +95,7 @@ get_init_status() {
 	local name
 	name="$(basename "$1")"
 	name="${name:-$packageName}"
-	local errors warnings ports dns outputFile outputCache outputGzip
+	local errors warnings ports dns outputFile outputCache outputGzip outputConfig
 	local i j
 # shellcheck disable=SC2034
 	local compressed_cache_dir
@@ -106,46 +106,11 @@ get_init_status() {
 	if [ -n "$(uci_get "$packageName" 'config' 'dnsmasq_config_file_url')" ]; then
 		dns="dnsmasq.conf"
 	else
-		dns="$(uci_get "$packageName" 'config' 'dns')"
+		dns="$(uci_get "$packageName" 'config' 'dns' 'dnsmasq.servers')"
 	fi
-	case "$dns" in
-		dnsmasq.addnhosts)
-			outputFile="$dnsmasqAddnhostsFile"
-			outputCache="$dnsmasqAddnhostsCache"
-			outputGzip="${compressed_cache_dir}/${dnsmasqAddnhostsGzip}"
-		;;
-		dnsmasq.conf)
-			outputFile="$dnsmasqConfFile"
-			outputCache="$dnsmasqConfCache"
-			outputGzip="${compressed_cache_dir}/${dnsmasqConfGzip}"
-		;;
-		dnsmasq.ipset)
-			outputFile="$dnsmasqIpsetFile"
-			outputCache="$dnsmasqIpsetCache"
-			outputGzip="${compressed_cache_dir}/${dnsmasqIpsetGzip}"
-		;;
-		dnsmasq.nftset)
-			outputFile="$dnsmasqNftsetFile"
-			outputCache="$dnsmasqNftsetCache"
-			outputGzip="${compressed_cache_dir}/${dnsmasqNftsetGzip}"
-		;;
-		dnsmasq.servers)
-			outputFile="$dnsmasqServersFile"
-			outputCache="$dnsmasqServersCache"
-			outputGzip="${compressed_cache_dir}/${dnsmasqServersGzip}"
-		;;
-		smartdns.domainset)
-			outputFilter="$smartdnsDomainSetFilter"
-			outputFile="$smartdnsDomainSetFile"
-			outputCache="$smartdnsDomainSetCache"
-			outputGzip="${compressed_cache_dir}/${smartdnsDomainSetGzip}"
-		;;
-		unbound.adb_list)
-			outputFile="$unboundFile"
-			outputCache="$unboundCache"
-			outputGzip="${compressed_cache_dir}/${unboundGzip}"
-		;;
-	esac
+
+	dns_set_output_values "$dns"
+
 	json_init
 	json_add_object  "$name"
 	json_add_boolean 'enabled' "$(is_enabled "$name")"

--- a/applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json
+++ b/applications/luci-app-adblock-fast/root/usr/share/rpcd/acl.d/luci-app-adblock-fast.json
@@ -3,7 +3,9 @@
 		"description": "Grant UCI and file access for luci-app-adblock-fast",
 		"read": {
 			"file": {
-				"/dev/shm/adblock-fast-status.json": [ "list", "read" ]
+				"/dev/shm/adblock-fast.config": [ "list", "read" ],
+				"/dev/shm/adblock-fast.error": [ "list", "read" ],
+				"/dev/shm/adblock-fast.status": [ "list", "read" ]
 			},
 			"ubus": {
 				"luci.adblock-fast": [


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* Final (hopefully) attempt to avoid errors if dhcp/smartdns configs are missing
* New user experience for picking dnsmasq/smartdns instances to enable the adblocking on
* use function from init script to set up output paths
* update paths to run-time files in ACL