### PR TITLE
luci-app-sshtunnel: Improve keys

### DIFF
--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js
@@ -6,6 +6,10 @@
 
 
 return view.extend({
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null,
+
 	load: function () {
 		return Promise.all([
 			fs.lines('/root/.ssh/known_hosts'),
@@ -18,7 +22,7 @@ return view.extend({
 		var m, s, o;
 
 		m = new form.Map('sshtunnel', _('SSH Tunnels'),
-			_('This configures <a %s>SSH Tunnels</a>')
+			_('This configures <a %s>SSH Tunnels</a>.')
 				.format('href="https://openwrt.org/docs/guide-user/services/ssh/sshtunnel"')
 		);
 

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
@@ -8,6 +8,10 @@ var allSshKeys = {};
 var hasSshKeygen = false;
 
 return view.extend({
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null,
+
 	load: function () {
 		return L.resolveDefault(fs.list('/root/.ssh/'), []).then(function (entries) {
 			var tasks = [
@@ -33,7 +37,7 @@ return view.extend({
 		var m, s, o;
 
 		m = new form.Map('sshtunnel', _('SSH Tunnels'),
-			_('This configures <a %s>SSH Tunnels</a>')
+			_('This configures <a %s>SSH Tunnels</a>.')
 				.format('href="https://openwrt.org/docs/guide-user/services/ssh/sshtunnel"')
 		);
 

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
@@ -20,7 +20,7 @@ return view.extend({
 			for (var sshKeyName of sshKeyNames) {
 				var sshPubKeyName = sshKeyName + '.pub';
 				tasks.push(Promise.resolve(sshKeyName));
-				tasks.push(fs.lines('/root/.ssh/' + sshPubKeyName));
+				tasks.push(_loadPublicKey(sshPubKeyName));
 			}
 			return Promise.all(tasks);
 		});
@@ -45,29 +45,25 @@ return view.extend({
 });
 
 function _findAllPossibleIdKeys(entries) {
-	var sshKeyNames = [];
-	for (var item of entries) {
-		if (item.type !== 'file') {
-			continue
-		}
+	var sshKeyNames = new Set();
+	var fileNames = entries.filter(item => item.type === 'file').map(item => item.name);
+	for (var fileName of fileNames) {
 		// a key file should have a corresponding .pub file
-		if (item.name.endsWith('.pub')) {
-			var sshPubKeyName = item.name;
-			var sshKeyName = sshPubKeyName.substring(0, sshPubKeyName.length - 4);
-			if (!sshKeyNames.includes(sshKeyName)) {
-				sshKeyNames.push(sshKeyName)
+		if (fileName.endsWith('.pub')) {
+			var sshKeyName = fileName.slice(0, -4);
+			// if such a key exists then add it
+			if (fileNames.includes(sshKeyName)) {
+				sshKeyNames.add(sshKeyName);
 			}
 		} else {
 			// or at least it should start with id_ e.g. id_dropbear
-			if (item.name.startsWith('id_')) {
-				var sshKeyName = item.name;
-				if (!sshKeyNames.includes(sshKeyName)) {
-					sshKeyNames.push(sshKeyName)
-				}
+			if (fileName.startsWith('id_')) {
+				var sshKeyName = fileName;
+				sshKeyNames.add(sshKeyName);
 			}
 		}
 	}
-	return sshKeyNames;
+	return Array.from(sshKeyNames);
 }
 
 function _splitSshKeys(sshFiles) {
@@ -157,4 +153,31 @@ function _handleKeyGenSubmit(event) {
 		ui.addNotification(null, E('p', _('Unable to generate a key: %s').format(e.message)), 'error');
 	});
 	return false;
+}
+
+function _extractPubKeyFromOutput(res) {
+	var lines  = res.stdout.split('\n');
+	for (var line of lines) {
+		if (line.startsWith('ssh-')) {
+			return line;
+		}
+	}
+	return '';
+}
+
+function _loadPublicKey(sshPubKeyName) {
+	return fs.read('/root/.ssh/' + sshPubKeyName)
+		.catch(() => {
+			// If there is no the .pub file then this is probably a Dropbear key e.g. id_dropbear.
+			// We can extract it's public key by executing: dropbearkey -y -f /root/.ssh/id_dropbear
+			var sshKeyName = sshPubKeyName.substring(0, sshPubKeyName.length - 4);
+			return fs.exec('/usr/bin/dropbearkey', ['-y', '-f', '/root/.ssh/' + sshKeyName]).then((res) => {
+				if (res.code === 0) {
+					return _extractPubKeyFromOutput(res);
+				} else {
+					console.log('dropbearkey: ' + res.stdout + ' ' + res.stderr);
+					return '';
+				}
+			}).catch(()=> '');
+		});
 }

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js
@@ -67,16 +67,17 @@ function _renderSshKeys(sshKeys) {
 	cbi_update_table(table, rows, null);
 
 	var keyGenBtn = E('div', {}, [
+		E('h4', _('Generate a new key')),
 		E('form', {
 			'submit': _handleKeyGenSubmit,
 		}, [
-			E('label', {}, _('Generate a new key') + ': '),
+			E('label', {}, _('Name') + ': '),
 			E('span', {'class': 'control-group'}, [
 				E('input', {
 					'type': 'text',
 					'name': 'keyName',
 					'value': 'id_ed25519',
-					'pattern': '^[a-zA-Z][a-zA-Z0-9_\.]+',
+					'pattern': '^[a-zA-Z][a-zA-Z0-9_.@\\-+]+',
 					'required': 'required',
 					'maxsize': '35',
 					'autocomplete': 'off',
@@ -97,13 +98,14 @@ function _renderSshKeys(sshKeys) {
 			_('In LuCI you can do that with <a %s>System / Administration / SSH-Keys</a>')
 				.format('href="/cgi-bin/luci/admin/system/admin/sshkeys"')
 		),
-		keyGenBtn, table
+		table, keyGenBtn,
 	]);
 }
 
 function _handleKeyGenSubmit(event) {
 	event.preventDefault();
 	var keyName = document.querySelector('input[name="keyName"]').value;
+	keyName = keyName.startsWith('id_') ? keyName : 'id_' + keyName;
 	if (allSshKeys[keyName]) {
 		document.body.scrollTop = document.documentElement.scrollTop = 0;
 		ui.addNotification(null, E('p', _('A key with that name already exists.'), 'error'));

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
@@ -129,27 +129,23 @@ return view.extend({
 });
 
 function _findAllPossibleIdKeys(entries) {
-	var sshKeyNames = [];
-	for (var item of entries) {
-		if (item.type !== 'file') {
-			continue
-		}
+	var sshKeyNames = new Set();
+	var fileNames = entries.filter(item => item.type === 'file').map(item => item.name);
+	for (var fileName of fileNames) {
 		// a key file should have a corresponding .pub file
-		if (item.name.endsWith('.pub')) {
-			var sshPubKeyName = item.name;
-			var sshKeyName = sshPubKeyName.substring(0, sshPubKeyName.length - 4);
-			if (!sshKeyNames.includes(sshKeyName)) {
-				sshKeyNames.push(sshKeyName)
+		if (fileName.endsWith('.pub')) {
+			var sshKeyName = fileName.slice(0, -4);
+			// if such a key exists then add it
+			if (fileNames.includes(sshKeyName)) {
+				sshKeyNames.add(sshKeyName);
 			}
 		} else {
 			// or at least it should start with id_ e.g. id_dropbear
-			if (item.name.startsWith('id_')) {
-				var sshKeyName = item.name;
-				if (!sshKeyNames.includes(sshKeyName)) {
-					sshKeyNames.push(sshKeyName)
-				}
+			if (fileName.startsWith('id_')) {
+				var sshKeyName = fileName;
+				sshKeyNames.add(sshKeyName);
 			}
 		}
 	}
-	return sshKeyNames;
+	return Array.from(sshKeyNames);
 }

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
@@ -46,9 +46,12 @@ return view.extend({
 		o = s.taboption('general', form.Value, 'user', _('User'));
 		o.default = 'root';
 
-		o = s.taboption('general', form.ListValue, 'IdentityFile', _('Key file'),
-			_('Private key file with authentication identity. ' +
-				'See <em>ssh_config IdentityFile</em>')
+		o = s.taboption('general', form.ListValue, 'IdentityFile', _('Identity Key'),
+			_('Private key file with authentication identity.') + '<br />' +
+			_('If not specified then a default will be used.') + '<br />' +
+			_('For Dropbear %s').format('<code>id_dropbear</code>') + '<br />' +
+			_('For OpenSSH %s').format('<code>id_rsa, id_ed25519, id_ecdsa</code>') +
+			_manSshConfig('IdentityFile')
 		);
 		o.value('');
 		for (var sshKeyName of sshKeyNames) {
@@ -57,7 +60,7 @@ return view.extend({
 		o.optional = true;
 
 
-		o = s.taboption('advanced', form.ListValue, 'LogLevel', _('Log level'), 'See <em>ssh_config LogLevel</em>');
+		o = s.taboption('advanced', form.ListValue, 'LogLevel', _('Log level'));
 		o.value('QUIET', 'QUIET');
 		o.value('FATAL', 'FATAL');
 		o.value('ERROR', 'ERROR');
@@ -70,8 +73,8 @@ return view.extend({
 		o.modalonly = true;
 
 		o = s.taboption('advanced', form.ListValue, 'Compression', _('Use compression'),
-			_('Compression may be useful on slow connections. ' +
-				'See <em>ssh_config Compression</em>')
+			_('Compression may be useful on slow connections.') +
+			_manSshConfig('Compression')
 		);
 		o.value('yes', _('Yes'));
 		o.value('no', _('No'));
@@ -87,18 +90,17 @@ return view.extend({
 		o.optional = true;
 		o.modalonly = true;
 
-		o = s.taboption('advanced', form.Value, 'ServerAliveCountMax', _('Server alive count max'),
-			_('The number of server alive messages which may be sent before SSH disconnects from the server. ' +
-				'See <em>ssh_config ServerAliveCountMax</em>')
+		o = s.taboption('advanced', form.Value, 'ServerAliveCountMax', _('Server keep alive attempts'),
+			_('The number of server alive messages which may be sent before SSH disconnects from the server.') +
+			_manSshConfig('ServerAliveCountMax')
 		);
 		o.placeholder = '3';
 		o.datatype = 'uinteger';
 		o.optional = true;
 		o.modalonly = true;
 
-		o = s.taboption('advanced', form.Value, 'ServerAliveInterval', _('Server alive interval'),
-			_('Keep-alive interval (seconds). ' +
-				'See <em>ssh_config ServerAliveInterval</em>')
+		o = s.taboption('advanced', form.Value, 'ServerAliveInterval', _('Server keep alive interval (seconds)'),
+			_manSshConfig('ServerAliveInterval')
 		);
 		o.optional = true;
 		o.default = '60';
@@ -106,9 +108,9 @@ return view.extend({
 		o.modalonly = true;
 
 		o = s.taboption('advanced', form.ListValue, 'CheckHostIP', _('Check host IP'),
-			_('Check the host IP address in the <code>known_hosts</code> file. ' +
-				'This allows ssh to detect whether a host key changed due to DNS spoofing. ' +
-				'See <em>ssh_config CheckHostIP</em>')
+			_('Check the host IP address in the %s file.').format('<code>known_hosts</code>') + '<br />' +
+			_('This allows SSH to detect whether a host key changed due to DNS spoofing.') +
+			_manSshConfig('CheckHostIP')
 		);
 		o.value('yes', _('Yes'));
 		o.value('no', _('No'));
@@ -116,8 +118,9 @@ return view.extend({
 		o.modalonly = true;
 
 		o = s.taboption('advanced', form.ListValue, 'StrictHostKeyChecking', _('Strict host key checking'),
-			_('Refuse to connect to hosts whose host key has changed. ' +
-				'See <em>ssh_config StrictHostKeyChecking</em>'));
+			_('Refuse to connect to hosts whose host key has changed.') +
+			_manSshConfig('StrictHostKeyChecking')
+		);
 		o.value('accept-new', _('Accept new and check if not changed'));
 		o.value('yes', _('Yes'));
 		o.value('no', _('No'));
@@ -149,3 +152,9 @@ function _findAllPossibleIdKeys(entries) {
 	}
 	return Array.from(sshKeyNames);
 }
+
+function _manSshConfig(opt) {
+	return '<br />' + _('See %s.')
+			.format('<a target="_blank" href="https://manpages.debian.org/testing/openssh-client/ssh_config.5#'+ opt + '">ssh_config ' + opt + '</a>');
+}
+

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
@@ -5,24 +5,17 @@
 'require ui';
 'require view';
 
-var allSshKeys = {};
-
 return view.extend({
 	load: function () {
 		return L.resolveDefault(fs.list('/root/.ssh/'), []).then(function (entries) {
-			var tasks = [];
-			for (var i = 0; i < entries.length; i++) {
-				if (entries[i].type === 'file' && entries[i].name.match(/\.pub$/)) {
-					tasks.push(Promise.resolve(entries[i].name));
-				}
-			}
-			return Promise.all(tasks);
+			var sshKeyNames = _findAllPossibleIdKeys(entries);
+			return Promise.resolve(sshKeyNames);
 		});
 	},
 
 	render: function (data) {
-		var sshKeys = _splitSshKeys(data);
-		if (sshKeys.length === 0) {
+		var sshKeyNames = data;
+		if (sshKeyNames.length === 0) {
 			ui.addNotification(null, E('p', _('No SSH keys found, <a %s>generate a new one</a>').format('href="./ssh_keys"')), 'warning');
 		}
 
@@ -58,9 +51,9 @@ return view.extend({
 				'See <em>ssh_config IdentityFile</em>')
 		);
 		o.value('');
-		Object.keys(sshKeys).forEach(function (keyName) {
-			o.value('/root/.ssh/' + keyName, keyName);
-		});
+		for (var sshKeyName of sshKeyNames) {
+			o.value('/root/.ssh/' + sshKeyName, sshKeyName);
+		}
 		o.optional = true;
 
 
@@ -135,13 +128,28 @@ return view.extend({
 	},
 });
 
-function _splitSshKeys(sshFiles) {
-	var sshKeys = {};
-	for (var i = 0; i < sshFiles.length; i++) {
-		var sshPubKeyName = sshFiles[i];
-		var sshKeyName = sshPubKeyName.substring(0, sshPubKeyName.length - 4);
-		sshKeys[sshKeyName] = '';
+function _findAllPossibleIdKeys(entries) {
+	var sshKeyNames = [];
+	for (var item of entries) {
+		if (item.type !== 'file') {
+			continue
+		}
+		// a key file should have a corresponding .pub file
+		if (item.name.endsWith('.pub')) {
+			var sshPubKeyName = item.name;
+			var sshKeyName = sshPubKeyName.substring(0, sshPubKeyName.length - 4);
+			if (!sshKeyNames.includes(sshKeyName)) {
+				sshKeyNames.push(sshKeyName)
+			}
+		} else {
+			// or at least it should start with id_ e.g. id_dropbear
+			if (item.name.startsWith('id_')) {
+				var sshKeyName = item.name;
+				if (!sshKeyNames.includes(sshKeyName)) {
+					sshKeyNames.push(sshKeyName)
+				}
+			}
+		}
 	}
-	allSshKeys = sshKeys;
-	return sshKeys;
+	return sshKeyNames;
 }

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
@@ -22,7 +22,7 @@ return view.extend({
 		var m, s, o;
 
 		m = new form.Map('sshtunnel', _('SSH Tunnels'),
-			_('This configures <a %s>SSH Tunnels</a>')
+			_('This configures <a %s>SSH Tunnels</a>.')
 				.format('href="https://openwrt.org/docs/guide-user/services/ssh/sshtunnel"')
 		);
 

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js
@@ -16,7 +16,7 @@ return view.extend({
 		var m, s, o;
 
 		m = new form.Map('sshtunnel', _('SSH Tunnels'),
-			_('This configures <a %s>SSH Tunnels</a>')
+			_('This configures <a %s>SSH Tunnels</a>.')
 				.format('href="https://openwrt.org/docs/guide-user/services/ssh/sshtunnel"')
 		);
 

--- a/applications/luci-app-sshtunnel/po/ru/sshtunnel.po
+++ b/applications/luci-app-sshtunnel/po/ru/sshtunnel.po
@@ -9,19 +9,19 @@ msgstr ""
 "<code>*</code> значит принимать соединения на всех интерфейсах <b>включая "
 "публичные</b>"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:109
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:142
 msgid "A key with that name already exists."
 msgstr "Ключ с таким именем уже существует."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:128
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:124
 msgid "Accept new and check if not changed"
 msgstr "Принимать новый и проверять что не изменился"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:95
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:127
 msgid "Add the pub key to %s or %s."
 msgstr "Добавьте этот публичный ключ в %s или в %s."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:42
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:35
 msgid "Advanced Settings"
 msgstr "Расширенные настройки"
 
@@ -37,32 +37,23 @@ msgstr ""
 "Принимающий соединения IP адрес н.п. <code>192.168.1.1</code> или имя хоста "
 "н.п. <code>localhost</code>"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:115
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:110
 msgid "Check host IP"
 msgstr "Проверять IP хоста"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:116
-msgid ""
-"Check the host IP address in the <code>known_hosts</code> file. This allows "
-"ssh to detect whether a host key changed due to DNS spoofing. See "
-"<em>ssh_config CheckHostIP</em>"
-msgstr ""
-"Проверять IP-адрес хоста в файле <code>known_hosts</code>. Это позволяет ssh "
-"определить, изменился ли ключ хоста из-за спуфинга DNS."
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:111
+msgid "Check the host IP address in the %s file."
+msgstr "Проверять IP-адрес хоста в файле %s."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:80
-msgid ""
-"Compression may be useful on slow connections. See <em>ssh_config "
-"Compression</em>"
-msgstr ""
-"Сжатие может быть полезным на медленном соединении. См. <em>ssh_config "
-"Compression</em>"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:76
+msgid "Compression may be useful on slow connections."
+msgstr "Сжатие может быть полезным на медленном соединении."
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:126
 msgid "Configure TUN/TAP devices for VPN tunnels."
 msgstr "Конифгурация устройств TUN/TAP VPN-туннелей."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:89
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:85
 msgid "Delay after a connection failure before trying to reconnect."
 msgstr "Задержка перед переподключением"
 
@@ -77,6 +68,18 @@ msgstr "Динамические туннели"
 msgid "Enabled"
 msgstr "Включен"
 
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:52
+msgid "For Dropbear %s"
+msgstr "Для Dropbear %s"
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:53
+msgid "For OpenSSH %s"
+msgstr "Для OpenSSH %s"
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:132
+msgid "For example, the following command would connect via an HTTP proxy:"
+msgstr ""
+
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:62
 msgid "Forward a port on the local host to a service on the remote host."
 msgstr "Перенаправить порт с локального хоста на сервис на удалённом хосте."
@@ -85,15 +88,15 @@ msgstr "Перенаправить порт с локального хоста �
 msgid "Forward a port on the remote host to a service on the local host."
 msgstr "Перенаправить порт с удалённого хоста на сервис на локальном хосте."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:41
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:34
 msgid "General Settings"
 msgstr "Общие настройки"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:88
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:120
 msgid "Generate"
 msgstr "Сгенерировать"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:73
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:101
 msgid "Generate a new key"
 msgstr "Сгенерировать новый ключ"
 
@@ -101,30 +104,27 @@ msgstr "Сгенерировать новый ключ"
 msgid "Grant UCI access for luci-app-sshtunnel"
 msgstr "Предоставить UCI доступ для luci-app-sshtunnel"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:35
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:44
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:39
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:37
 msgid "Hostname"
 msgstr "Имя хоста"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:97
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:49
+msgid "Identity Key"
+msgstr "Идентификационный ключ"
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:51
+msgid "If not specified then a default will be used."
+msgstr "Если не указан то используется ключ по умолчанию."
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:129
 msgid ""
 "In LuCI you can do that with <a %s>System / Administration / SSH-Keys</a>"
 msgstr ""
 "В LuCI вы можете это сделать через <a %s>Система / Администрирование / SSH "
 "ключи</a>"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:107
-msgid ""
-"Keep-alive interval (seconds). See <em>ssh_config ServerAliveInterval</em>"
-msgstr ""
-"Интервал проверки подключения (секунды). См. See <em>ssh_config "
-"ServerAliveInterval</em>"
-
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:56
-msgid "Key file"
-msgstr "Файл ключа"
-
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:46
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:50
 msgid "Keys of SSH servers found in %s."
 msgstr "Ключи SSH уже известных серверов из %s."
 
@@ -132,7 +132,7 @@ msgstr "Ключи SSH уже известных серверов из %s."
 msgid "Known Hosts"
 msgstr "Знакомые хосты"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:44
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:48
 msgid "Known hosts"
 msgstr "Знакомые хосты"
 
@@ -156,49 +156,45 @@ msgstr "Локальное устройство dev"
 msgid "Local port"
 msgstr "Локальный порт"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:67
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:63
 msgid "Log level"
 msgstr "Уровень логирования"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:61
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:92
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:105
 msgid "Name"
 msgstr "Название"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:84
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:121
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:130
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:80
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:116
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:126
 msgid "No"
 msgstr "Нет"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:26
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:19
 msgid "No SSH keys found, <a %s>generate a new one</a>"
-msgstr ""
-"Нет ни одного ключа, пожалуйста <a href=\"./ssh_keys\">сгенерируйте новый</"
-"a>."
+msgstr "Нет ни одного ключа, пожалуйста <a %s>сгенерируйте новый</a>."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:49
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:42
 msgid "Port"
 msgstr "Порт"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:57
-msgid ""
-"Private key file with authentication identity. See <em>ssh_config "
-"IdentityFile</em>"
-msgstr ""
-"Файл приватного ключа для авторизации. См. <em>ssh_config IdentityFile</em>"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:50
+msgid "Private key file with authentication identity."
+msgstr "Файл приватного ключа для авторизации."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:36
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:62
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:130
+msgid "Proxy tunnel command"
+msgstr "Команда прокси туннеля"
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:40
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:93
 msgid "Public Key"
 msgstr "Публичный ключ"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:126
-msgid ""
-"Refuse to connect to hosts whose host key has changed. See <em>ssh_config "
-"StrictHostKeyChecking</em>"
-msgstr ""
-"Отказывать в подключении к хосту если его ключ поменялся. См. <em>ssh_config "
-"StrictHostKeyChecking</em>"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:121
+msgid "Refuse to connect to hosts whose host key has changed."
+msgstr "Отказывать в подключении к хосту если его ключ поменялся."
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:23
 msgid "Remote Tunnels"
@@ -218,7 +214,7 @@ msgstr "Удалённое устройство dev"
 msgid "Remote port"
 msgstr "Удалённый порт"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:88
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:84
 msgid "Retry delay"
 msgstr "Задержка попытки"
 
@@ -226,65 +222,78 @@ msgstr "Задержка попытки"
 msgid "SOCKS proxy via remote host."
 msgstr "SOCKS прокси через удалённый хост."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:93
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:125
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:14
 msgid "SSH Keys"
 msgstr "SSH Ключи"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:20
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:33
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:31
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:24
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:39
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:24
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:18
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:3
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:30
 msgid "SSH Tunnels"
 msgstr "SSH туннели"
 
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:169
+msgid "See %s."
+msgstr "См. %s."
+
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:157
 msgid "Server"
 msgstr "Сервер"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:97
-msgid "Server alive count max"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:93
+msgid "Server keep alive attempts"
 msgstr "Попыток проверки соединения"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:106
-msgid "Server alive interval"
-msgstr "Интервал проверки соединения"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:102
+msgid "Server keep alive interval (seconds)"
+msgstr "Интервал проверки соединения (секунды)"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:36
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:29
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:22
 msgid "Servers"
 msgstr "Серверы"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:125
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:120
 msgid "Strict host key checking"
 msgstr "Строгая проверка ключа хоста"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:98
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:131
+msgid "The command to use to connect to the serve."
+msgstr ""
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:94
 msgid ""
 "The number of server alive messages which may be sent before SSH disconnects "
-"from the server. See <em>ssh_config ServerAliveCountMax</em>"
+"from the server."
 msgstr ""
-"Сколько проверочных сообщений на сервер отправить прежде чем отключиться.См. "
-"See <em>ssh_config ServerAliveCountMax</em>"
+"Сколько проверочных сообщений на сервер отправить прежде чем отключиться."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:21
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:34
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:32
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:112
+msgid ""
+"This allows SSH to detect whether a host key changed due to DNS spoofing."
+msgstr ""
+"Это позволяет ssh определить, изменился ли ключ хоста из-за подмены DNS."
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:25
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:40
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:25
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:19
-msgid "This configures <a %s>SSH Tunnels</a>"
+msgid "This configures <a %s>SSH Tunnels</a>."
 msgstr "Настройка <a %s>SSH туннелей</a>."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:128
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:161
 msgid "Unable to generate a key: %s"
 msgstr "Ошибка при генерации ключа: %s"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:79
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:75
 msgid "Use compression"
 msgstr "Использовать сжатие"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:53
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:46
 msgid "User"
 msgstr "Пользователь"
 
@@ -296,8 +305,8 @@ msgstr "VPN туннели"
 msgid "VPN type"
 msgstr "Тип VPN"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:83
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:120
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:129
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:79
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:115
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:125
 msgid "Yes"
 msgstr "Да"

--- a/applications/luci-app-sshtunnel/po/templates/sshtunnel.pot
+++ b/applications/luci-app-sshtunnel/po/templates/sshtunnel.pot
@@ -7,19 +7,19 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "<code>*</code> means to listen all interfaces <b>including public</b>."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:109
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:142
 msgid "A key with that name already exists."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:128
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:124
 msgid "Accept new and check if not changed"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:95
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:127
 msgid "Add the pub key to %s or %s."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:42
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:35
 msgid "Advanced Settings"
 msgstr ""
 
@@ -33,28 +33,23 @@ msgid ""
 "<code>localhost</code>."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:115
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:110
 msgid "Check host IP"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:116
-msgid ""
-"Check the host IP address in the <code>known_hosts</code> file. This allows "
-"ssh to detect whether a host key changed due to DNS spoofing. See "
-"<em>ssh_config CheckHostIP</em>"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:111
+msgid "Check the host IP address in the %s file."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:80
-msgid ""
-"Compression may be useful on slow connections. See <em>ssh_config "
-"Compression</em>"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:76
+msgid "Compression may be useful on slow connections."
 msgstr ""
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:126
 msgid "Configure TUN/TAP devices for VPN tunnels."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:89
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:85
 msgid "Delay after a connection failure before trying to reconnect."
 msgstr ""
 
@@ -69,6 +64,18 @@ msgstr ""
 msgid "Enabled"
 msgstr ""
 
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:52
+msgid "For Dropbear %s"
+msgstr ""
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:53
+msgid "For OpenSSH %s"
+msgstr ""
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:132
+msgid "For example, the following command would connect via an HTTP proxy:"
+msgstr ""
+
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:62
 msgid "Forward a port on the local host to a service on the remote host."
 msgstr ""
@@ -77,15 +84,15 @@ msgstr ""
 msgid "Forward a port on the remote host to a service on the local host."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:41
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:34
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:88
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:120
 msgid "Generate"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:73
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:101
 msgid "Generate a new key"
 msgstr ""
 
@@ -93,26 +100,25 @@ msgstr ""
 msgid "Grant UCI access for luci-app-sshtunnel"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:35
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:44
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:39
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:37
 msgid "Hostname"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:97
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:49
+msgid "Identity Key"
+msgstr ""
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:51
+msgid "If not specified then a default will be used."
+msgstr ""
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:129
 msgid ""
 "In LuCI you can do that with <a %s>System / Administration / SSH-Keys</a>"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:107
-msgid ""
-"Keep-alive interval (seconds). See <em>ssh_config ServerAliveInterval</em>"
-msgstr ""
-
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:56
-msgid "Key file"
-msgstr ""
-
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:46
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:50
 msgid "Keys of SSH servers found in %s."
 msgstr ""
 
@@ -120,7 +126,7 @@ msgstr ""
 msgid "Known Hosts"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:44
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:48
 msgid "Known hosts"
 msgstr ""
 
@@ -144,43 +150,44 @@ msgstr ""
 msgid "Local port"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:67
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:63
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:61
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:92
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:105
 msgid "Name"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:84
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:121
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:130
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:80
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:116
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:126
 msgid "No"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:26
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:19
 msgid "No SSH keys found, <a %s>generate a new one</a>"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:49
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:42
 msgid "Port"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:57
-msgid ""
-"Private key file with authentication identity. See <em>ssh_config "
-"IdentityFile</em>"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:50
+msgid "Private key file with authentication identity."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:36
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:62
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:130
+msgid "Proxy tunnel command"
+msgstr ""
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:40
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:93
 msgid "Public Key"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:126
-msgid ""
-"Refuse to connect to hosts whose host key has changed. See <em>ssh_config "
-"StrictHostKeyChecking</em>"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:121
+msgid "Refuse to connect to hosts whose host key has changed."
 msgstr ""
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:23
@@ -201,7 +208,7 @@ msgstr ""
 msgid "Remote port"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:88
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:84
 msgid "Retry delay"
 msgstr ""
 
@@ -209,63 +216,76 @@ msgstr ""
 msgid "SOCKS proxy via remote host."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:93
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:125
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:14
 msgid "SSH Keys"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:20
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:33
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:31
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:24
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:39
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:24
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:18
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:3
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:30
 msgid "SSH Tunnels"
 msgstr ""
 
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:169
+msgid "See %s."
+msgstr ""
+
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:157
 msgid "Server"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:97
-msgid "Server alive count max"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:93
+msgid "Server keep alive attempts"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:106
-msgid "Server alive interval"
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:102
+msgid "Server keep alive interval (seconds)"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:36
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:29
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:22
 msgid "Servers"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:125
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:120
 msgid "Strict host key checking"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:98
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:131
+msgid "The command to use to connect to the serve."
+msgstr ""
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:94
 msgid ""
 "The number of server alive messages which may be sent before SSH disconnects "
-"from the server. See <em>ssh_config ServerAliveCountMax</em>"
+"from the server."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:21
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:34
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:32
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:112
+msgid ""
+"This allows SSH to detect whether a host key changed due to DNS spoofing."
+msgstr ""
+
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:25
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:40
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:25
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:19
-msgid "This configures <a %s>SSH Tunnels</a>"
+msgid "This configures <a %s>SSH Tunnels</a>."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:128
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:161
 msgid "Unable to generate a key: %s"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:79
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:75
 msgid "Use compression"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:53
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:46
 msgid "User"
 msgstr ""
 
@@ -277,8 +297,8 @@ msgstr ""
 msgid "VPN type"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:83
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:120
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:129
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:79
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:115
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:125
 msgid "Yes"
 msgstr ""


### PR DESCRIPTION
Maintainer: me (?)
Tested: OpenWrt master on VirtualBox amd64
Description:

The luci-app-sshtunnel has a problem.
I made a button to generate an ssh key. Internally it calls ssh-keygen from openssh.
The ssh-keygen generates two files: an id key like id_ed25519 and its public key id_ed25519.pub.
Then the luci app shows the pub key to a user so it can be copied and pasted on a SSH server.

But then I added the dropbear support. The app checks if the openssh ssh-keygen is installed then calls it but if not then it will call the dropbearkey to generate a key. The problem is that the dropbearkey generates only a private key file without a `.pub`.

That's why luci app can't show the pub key and a user can't copy it. Still the dropbearkey provides a command `dropbearkey -y privatekey` that extracts and shows a public key. Things are getting worse because the luci app detects keys by presents of the pub key.

The key files may have any name and no any specific extension. But usually they starts with `id_` e.g. `id_rsa`. I made some workaround to show all files starting with `id_` and even call the `dropbearkey -y privatekey` to get a raw pubkey.

A screenshot of the new Keys page:
![sshtunnel_keys](https://github.com/openwrt/luci/assets/415502/7ac879c1-46ee-4ed7-9da9-5963a840f035)

Here you can see that for the id_dropbear its public key shown even when there is no the `id_dropbear.pub` file.
The `ed25519` key doesn't have the `id_` prefix but it has a `.pub` file so it was recognized as a key.
The `id_stokito+turris@gmail.com` file name contains my email so it's allowed now.
Also the "Generate" key moved to the bottom.

Additionally I sent a PR to the Dropbear to generate the pub file:  https://github.com/mkj/dropbear/pull/267


CC @nunojpg @stweil @kvuorine @kzyapkov @systemcrash @lars18th @marazmarci please have a look and test