### PR TITLE
luci-proto-ipv6: Add DHCPv6 norelease menu option

### DIFF
--- a/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js
+++ b/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dhcpv6.js
@@ -29,6 +29,8 @@ return network.registerProtocol('dhcpv6', {
 		o.value('60');
 		o.value('64');
 		o.default = 'auto';
+		o = s.taboption('general', form.Flag, 'norelease', _('Do not send a Release when restarting'),
+						_('Enable to minimise the chance of prefix change after a restart'));
 
 		o = s.taboption('advanced', form.Value, 'clientid', _('Client ID to send when requesting DHCP'));
 		o.datatype  = 'hexstring';


### PR DESCRIPTION
Resubmitting #6764 without the change of default behaviour.