### PR TITLE
luci-app-sshtunnel: servers: ProxyCommand option

### DIFF
--- a/applications/luci-app-sshtunnel/Makefile
+++ b/applications/luci-app-sshtunnel/Makefile
@@ -7,7 +7,7 @@ LUCI_TITLE:=LuCI support for SSH Tunnels (sshtunnel package)
 
 PKG_MAINTAINER:=Sergey Ponomarev <stokito@gmail.com>
 LUCI_DEPENDS:=+luci-base +sshtunnel
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 
 include ../../luci.mk

--- a/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
+++ b/applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js
@@ -127,6 +127,14 @@ return view.extend({
 		o.default = 'accept-new';
 		o.modalonly = true;
 
+		o = s.taboption('advanced', form.Value, 'ProxyCommand', _('Proxy tunnel command'),
+			_('The command to use to connect to the server.') + '<br />' +
+			_('For example, the following command would connect via an HTTP proxy:') + '<br />' +
+			'<code>ncat --proxy-type http --proxy-auth alice:secret --proxy 192.168.1.2:8080 %h %p</code>' +
+			_manSshConfig('ProxyCommand')
+		);
+		o.modalonly = true;
+
 		return m.render();
 	},
 });

--- a/applications/luci-app-sshtunnel/po/ru/sshtunnel.po
+++ b/applications/luci-app-sshtunnel/po/ru/sshtunnel.po
@@ -9,7 +9,7 @@ msgstr ""
 "<code>*</code> значит принимать соединения на всех интерфейсах <b>включая "
 "публичные</b>"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:142
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:138
 msgid "A key with that name already exists."
 msgstr "Ключ с таким именем уже существует."
 
@@ -17,7 +17,7 @@ msgstr "Ключ с таким именем уже существует."
 msgid "Accept new and check if not changed"
 msgstr "Принимать новый и проверять что не изменился"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:127
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:123
 msgid "Add the pub key to %s or %s."
 msgstr "Добавьте этот публичный ключ в %s или в %s."
 
@@ -78,7 +78,7 @@ msgstr "Для OpenSSH %s"
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:132
 msgid "For example, the following command would connect via an HTTP proxy:"
-msgstr ""
+msgstr "Например с помощью этой команады подключаться через HTTP прокси:"
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_tunnels.js:62
 msgid "Forward a port on the local host to a service on the remote host."
@@ -92,11 +92,11 @@ msgstr "Перенаправить порт с удалённого хоста �
 msgid "General Settings"
 msgstr "Общие настройки"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:120
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:116
 msgid "Generate"
 msgstr "Сгенерировать"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:101
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:97
 msgid "Generate a new key"
 msgstr "Сгенерировать новый ключ"
 
@@ -117,7 +117,7 @@ msgstr "Идентификационный ключ"
 msgid "If not specified then a default will be used."
 msgstr "Если не указан то используется ключ по умолчанию."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:129
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:125
 msgid ""
 "In LuCI you can do that with <a %s>System / Administration / SSH-Keys</a>"
 msgstr ""
@@ -160,8 +160,8 @@ msgstr "Локальный порт"
 msgid "Log level"
 msgstr "Уровень логирования"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:92
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:105
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:88
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:101
 msgid "Name"
 msgstr "Название"
 
@@ -188,7 +188,7 @@ msgid "Proxy tunnel command"
 msgstr "Команда прокси туннеля"
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:40
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:93
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:89
 msgid "Public Key"
 msgstr "Публичный ключ"
 
@@ -222,7 +222,7 @@ msgstr "Задержка попытки"
 msgid "SOCKS proxy via remote host."
 msgstr "SOCKS прокси через удалённый хост."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:125
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:121
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:14
 msgid "SSH Keys"
 msgstr "SSH Ключи"
@@ -236,7 +236,7 @@ msgstr "SSH Ключи"
 msgid "SSH Tunnels"
 msgstr "SSH туннели"
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:169
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:165
 msgid "See %s."
 msgstr "См. %s."
 
@@ -262,8 +262,8 @@ msgid "Strict host key checking"
 msgstr "Строгая проверка ключа хоста"
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:131
-msgid "The command to use to connect to the serve."
-msgstr ""
+msgid "The command to use to connect to the server."
+msgstr "Комманда через которую подключатся к серверу."
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:94
 msgid ""
@@ -285,7 +285,7 @@ msgstr ""
 msgid "This configures <a %s>SSH Tunnels</a>."
 msgstr "Настройка <a %s>SSH туннелей</a>."
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:161
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:157
 msgid "Unable to generate a key: %s"
 msgstr "Ошибка при генерации ключа: %s"
 

--- a/applications/luci-app-sshtunnel/po/templates/sshtunnel.pot
+++ b/applications/luci-app-sshtunnel/po/templates/sshtunnel.pot
@@ -7,7 +7,7 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "<code>*</code> means to listen all interfaces <b>including public</b>."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:142
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:138
 msgid "A key with that name already exists."
 msgstr ""
 
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Accept new and check if not changed"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:127
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:123
 msgid "Add the pub key to %s or %s."
 msgstr ""
 
@@ -88,11 +88,11 @@ msgstr ""
 msgid "General Settings"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:120
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:116
 msgid "Generate"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:101
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:97
 msgid "Generate a new key"
 msgstr ""
 
@@ -113,7 +113,7 @@ msgstr ""
 msgid "If not specified then a default will be used."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:129
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:125
 msgid ""
 "In LuCI you can do that with <a %s>System / Administration / SSH-Keys</a>"
 msgstr ""
@@ -154,8 +154,8 @@ msgstr ""
 msgid "Log level"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:92
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:105
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:88
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:101
 msgid "Name"
 msgstr ""
 
@@ -182,7 +182,7 @@ msgid "Proxy tunnel command"
 msgstr ""
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_hosts.js:40
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:93
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:89
 msgid "Public Key"
 msgstr ""
 
@@ -216,7 +216,7 @@ msgstr ""
 msgid "SOCKS proxy via remote host."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:125
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:121
 #: applications/luci-app-sshtunnel/root/usr/share/luci/menu.d/luci-app-sshtunnel.json:14
 msgid "SSH Keys"
 msgstr ""
@@ -230,7 +230,7 @@ msgstr ""
 msgid "SSH Tunnels"
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:169
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:165
 msgid "See %s."
 msgstr ""
 
@@ -256,7 +256,7 @@ msgid "Strict host key checking"
 msgstr ""
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:131
-msgid "The command to use to connect to the serve."
+msgid "The command to use to connect to the server."
 msgstr ""
 
 #: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_servers.js:94
@@ -277,7 +277,7 @@ msgstr ""
 msgid "This configures <a %s>SSH Tunnels</a>."
 msgstr ""
 
-#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:161
+#: applications/luci-app-sshtunnel/htdocs/luci-static/resources/view/sshtunnel/ssh_keys.js:157
 msgid "Unable to generate a key: %s"
 msgstr ""
 


### PR DESCRIPTION
A leftover from #6772
Since the https://github.com/openwrt/packages/pull/22975 was merged we can now add the ProxyCommand to the Luci app.

cc @systemcrash 