### PR TITLE
luci-theme-openwrt-2020: fix anchor decorations

### DIFF
--- a/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
+++ b/themes/luci-theme-openwrt-2020/htdocs/luci-static/openwrt2020/cascade.css
@@ -1123,6 +1123,19 @@ textarea {
 	padding: .2em 0;
 }
 
+.cbi-map-descr a,
+.cbi-value-description a {
+	color: var(--main-bright-color);
+	text-decoration: none;
+	outline: 0;
+}
+.cbi-map-descr a:hover,
+.cbi-value-description a:hover {
+	color: var(--main-bright-color);
+	text-decoration: underline;
+	outline: 0;
+}
+
 .cbi-map-descr,
 .cbi-tab-descr,
 .cbi-section-descr,


### PR DESCRIPTION
* add the decorations for when the links are included in the field descriptions

Thanks @dibdot!