### PR TITLE
Opkg: search all dest installed packages instead of root only

### DIFF
--- a/applications/luci-app-opkg/root/usr/libexec/opkg-call
+++ b/applications/luci-app-opkg/root/usr/libexec/opkg-call
@@ -7,7 +7,19 @@ shift
 
 case "$action" in
 	list-installed)
-		cat /usr/lib/opkg/status
+		failback="1"
+		dest_dirs=$(sed -rne 's#^dest \S+ (\S+)#\1#p' /etc/opkg.conf /etc/opkg/*.conf 2>/dev/null)
+
+		for dest_dir in ${dest_dirs}; do
+			if [ -f "${dest_dir}/usr/lib/opkg/status" ]; then
+				cat ${dest_dir}/usr/lib/opkg/status
+				failback=""
+			fi
+		done
+
+		if [ ! -z "${failback}" ]; then
+			cat /usr/lib/opkg/status
+		fi
 	;;
 	list-available)
 		lists_dir=$(sed -rne 's#^lists_dir \S+ (\S+)#\1#p' /etc/opkg.conf /etc/opkg/*.conf 2>/dev/null | tail -n 1)


### PR DESCRIPTION
Opkg: search all dest installed packages instead of root only
origin [#6632](https://github.com/openwrt/luci/pull/6632)