### PR TITLE
luci-proto-openconnect: add option for array ssl vpn

### DIFF
--- a/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
+++ b/protocols/luci-proto-openconnect/htdocs/luci-static/resources/protocol/openconnect.js
@@ -99,6 +99,7 @@ return network.registerProtocol('openconnect', {
 		o.value('nc', 'Juniper Network Connect');
 		o.value('gp', 'GlobalProtect SSL VPN');
 		o.value('pulse', 'Pulse Connect Secure SSL VPN');
+		o.value('array', 'Array Networks SSL VPN');
 
 		o = s.taboption('general', form.Value, 'server', _('VPN Server'));
 		o.validate = function(section_id, value) {


### PR DESCRIPTION
Changes:
* Add an option for 'Array Network SSL VPN' in the protocol select