### PR TITLE
[23.05 luci-app-https-dns-proxy: bugfix: editing providers with options

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2023-10-25-5
+PKG_VERSION:=2023-11-19-1
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
@@ -297,8 +297,8 @@ return view.extend({
 						section_id,
 						"resolver_url"
 					);
-					if (_paramList.template !== template) return 0;
-					let resolver = pkg.templateToResolver(template, {
+					if (!formvalue && _paramList.template !== template) return 0;
+					let resolver = pkg.templateToResolver(_paramList.template, {
 						option: formvalue || "",
 					});
 					L.uci.set(pkg.Name, section_id, "resolver_url", resolver);
@@ -335,8 +335,8 @@ return view.extend({
 						section_id,
 						"resolver_url"
 					);
-					if (_paramText.template !== template) return 0;
-					let resolver = pkg.templateToResolver(template, {
+					if (!formvalue && _paramText.template !== template) return 0;
+					let resolver = pkg.templateToResolver(_paramText.template, {
 						option: formvalue || "",
 					});
 					L.uci.set(pkg.Name, section_id, "resolver_url", resolver);


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
Run tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2

Description:
* fixes https://github.com/openwrt/luci/issues/6811
* previously editing existing provider instance with options would not result in the correct saving of edited parameters

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit a83427fefe497fcda92a3f9b59701dc91a6f1df1)