### PR TITLE
Add CODEOWNERS and fix missing PKG_MAINTAINER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,131 @@
+applications/luci-app-acl @jow-
+applications/luci-app-acme @tohojo
+applications/luci-app-adblock @hnyman @dibdot
+applications/luci-app-adblock-fast @stangri
+applications/luci-app-advanced-reboot @stangri
+applications/luci-app-ahcp @jow-
+applications/luci-app-alist @1715173329
+applications/luci-app-apinger @jempatel
+applications/luci-app-aria2 @kuoruan
+applications/luci-app-attendedsysupgrade @aparcar
+applications/luci-app-babeld @PolynomialDivision
+applications/luci-app-banip @dibdot
+applications/luci-app-bcp38 @danrl
+applications/luci-app-bmx7 @rogerpueyo @p4u
+applications/luci-app-clamav @ratkaj @lperkov
+applications/luci-app-cloudflared @animegasan @stokito
+applications/luci-app-commands @jow-
+applications/luci-app-coovachilli @sbyx @jow-
+applications/luci-app-crowdsec-firewall-bouncer @ne20002
+applications/luci-app-cshark @lperkov
+applications/luci-app-dawn @PolynomialDivision
+applications/luci-app-dcwapd @csonsino
+applications/luci-app-ddns @Ansuel
+applications/luci-app-diag-core @jow-
+applications/luci-app-dnscrypt-proxy @dibdot
+applications/luci-app-dockerman @lisaac @feckert
+applications/luci-app-dump1090 @Noltari
+applications/luci-app-dynapoint @ascob
+applications/luci-app-email @stokito
+applications/luci-app-eoip @bogdik
+applications/luci-app-example @andibraeu @cricalix
+applications/luci-app-firewall @jow-
+applications/luci-app-frpc @ysc3839
+applications/luci-app-frps @ysc3839
+applications/luci-app-fwknopd @jp-bennett
+applications/luci-app-hd-idle @jow-
+applications/luci-app-https-dns-proxy @stangri
+applications/luci-app-irqbalance @ElaineR02
+applications/luci-app-keepalived @jempatel
+applications/luci-app-ksmbd @ysc3839
+applications/luci-app-ledtrig-rssi @jow-
+applications/luci-app-ledtrig-switch @jow-
+applications/luci-app-ledtrig-usbport @jow-
+applications/luci-app-libreswan @jempatel
+applications/luci-app-lorawan-basicstation @mars642
+applications/luci-app-ltqtapi @blogic
+applications/luci-app-lxc @dibdot
+applications/luci-app-minidlna @jow-
+applications/luci-app-mjpg-streamer @jow-
+applications/luci-app-mosquitto @karlp
+applications/luci-app-mwan3 @feckert
+applications/luci-app-natmap @ysc3839
+applications/luci-app-nextdns @rs
+applications/luci-app-nft-qos @rosysong
+applications/luci-app-nlbwmon @jow-
+applications/luci-app-nut @danielfdickinson
+applications/luci-app-ocserv @nmav
+applications/luci-app-olsr @mmunz @jow-
+applications/luci-app-olsr-services @andibraeu
+applications/luci-app-olsr-viz @znerol @Ayushmanwebdeveloper
+applications/luci-app-omcproxy @riverscn
+applications/luci-app-openvpn @sbyx @jow-
+applications/luci-app-openwisp @mips171
+applications/luci-app-opkg @jow-
+applications/luci-app-p910nd @systemcrash @jow-
+applications/luci-app-pagekitec @karlp
+applications/luci-app-pbr @stangri
+applications/luci-app-polipo @alekkrs
+applications/luci-app-privoxy @chris5560
+applications/luci-app-qos @sbyx
+applications/luci-app-radicale @chris5560
+applications/luci-app-radicale2 @danielfdickinson
+applications/luci-app-rp-pppoe-server @danielfdickinson
+applications/luci-app-samba4 @Andy2244
+applications/luci-app-ser2net @michyprima
+applications/luci-app-shadowsocks-libev @yousong @aa65535
+applications/luci-app-siitwizard @sbyx @jow-
+applications/luci-app-smartdns @pymumu
+applications/luci-app-snmpd @karlp
+applications/luci-app-softether @jow-
+applications/luci-app-splash @mmunz @jow-
+applications/luci-app-sqm @tohojo
+applications/luci-app-squid @ratkaj
+applications/luci-app-sshtunnel @stokito
+applications/luci-app-statistics @jow-
+applications/luci-app-strongswan-swanctl @mips171 @lvoegl
+applications/luci-app-tinyproxy @sbyx @jow-
+applications/luci-app-tor @stokito
+applications/luci-app-transmission @ysc3839
+applications/luci-app-travelmate @dibdot
+applications/luci-app-ttyd @dibdot
+applications/luci-app-udpxy @1715173329
+applications/luci-app-uhttpd @danielfdickinson
+applications/luci-app-unbound @EricLuehrsen
+applications/luci-app-upnp @jow-
+applications/luci-app-usteer @Ramon00
+applications/luci-app-vnstat @jow-
+applications/luci-app-vnstat2 @janh
+applications/luci-app-watchcat @jow- @mips171
+applications/luci-app-wifischedule @newkit
+applications/luci-app-wol @jow-
+applications/luci-app-xfrpc @liudf0716
+applications/luci-app-xinetd @he-ma
+
+protocols/luci-proto-3g @jow-
+protocols/luci-proto-autoip @jow-
+protocols/luci-proto-batman-adv @onemarcfifty
+protocols/luci-proto-bonding @he-ma
+protocols/luci-proto-external @oskarirauta
+protocols/luci-proto-gre @mbargo23
+protocols/luci-proto-hnet @sbyx
+protocols/luci-proto-ipip @rogerpueyo
+protocols/luci-proto-ipv6 @jow-
+protocols/luci-proto-mbim @hyc
+protocols/luci-proto-modemmanager @mips171
+protocols/luci-proto-ncm @lucize
+protocols/luci-proto-nebula @stangri
+protocols/luci-proto-openconnect @jow-
+protocols/luci-proto-openfortivpn @aaronjg
+protocols/luci-proto-ppp @jow-
+protocols/luci-proto-pppossh @yousong
+protocols/luci-proto-qmi @thornley-touchstar
+protocols/luci-proto-relay @jow-
+protocols/luci-proto-sstp @rkkoszewski
+protocols/luci-proto-unet @hnyman
+protocols/luci-proto-vpnc @danielfdickinson
+protocols/luci-proto-vti @jempatel
+protocols/luci-proto-vxlan @wjowsa
+protocols/luci-proto-wireguard @danrl
+protocols/luci-proto-xfrm @hgl
+protocols/luci-proto-yggdrasil @wfleurant

--- a/applications/luci-app-acl/Makefile
+++ b/applications/luci-app-acl/Makefile
@@ -5,6 +5,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI account management module
 LUCI_DEPENDS:=+luci-base
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -7,6 +7,8 @@ LUCI_TITLE:=LuCI support for Adblock
 LUCI_DEPENDS:=+luci-base +adblock
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Hannu Nyman <hannu.nyman@iki.fi> \
+	Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-ahcp/Makefile
+++ b/applications/luci-app-ahcp/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for AHCPd
 LUCI_DEPENDS:=+luci-base +luci-compat +ahcpd
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-alist/Makefile
+++ b/applications/luci-app-alist/Makefile
@@ -7,6 +7,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI app for AList
 LUCI_DEPENDS:=+alist
 
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-attendedsysupgrade/Makefile
+++ b/applications/luci-app-attendedsysupgrade/Makefile
@@ -6,6 +6,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for attended sysupgrades
 LUCI_DEPENDS:=+luci-base +attendedsysupgrade-common +cgi-io
 
+PKG_MAINTAINER:=Paul Spooren <paul@spooren.de>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-babeld/Makefile
+++ b/applications/luci-app-babeld/Makefile
@@ -3,6 +3,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for babeld
 LUCI_DEPENDS:=+luci-base +babeld
 
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-banip/Makefile
+++ b/applications/luci-app-banip/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI support for banIP
 LUCI_DEPENDS:=+luci-base +banip
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-bcp38/Makefile
+++ b/applications/luci-app-bcp38/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=BCP38 LuCI interface
 LUCI_DEPENDS:=+luci-base +bcp38
 
-PKG_MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
+PKG_MAINTAINER:=Dan Luedtke <mail@danrl.com>
 PKG_LICENSE:=Apache-2.0
 
 include ../../luci.mk

--- a/applications/luci-app-commands/Makefile
+++ b/applications/luci-app-commands/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=LuCI Shell Command Module
 LUCI_DEPENDS:=+luci-base
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/applications/luci-app-coovachilli/Makefile
+++ b/applications/luci-app-coovachilli/Makefile
@@ -9,6 +9,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Coova Chilli
 LUCI_DEPENDS:=+luci-base +luci-compat @BROKEN
 
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-dawn/Makefile
+++ b/applications/luci-app-dawn/Makefile
@@ -3,6 +3,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for DAWN
 LUCI_DEPENDS:=+luci-base +dawn
 
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-dcwapd/Makefile
+++ b/applications/luci-app-dcwapd/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Dual Channel Wi-Fi AP Daemon configuration module
 LUCI_DEPENDS:=+luci-base +luci-compat +dcwapd
 
+PKG_MAINTAINER:=Carey Sonsino <csonsino@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-diag-core/Makefile
+++ b/applications/luci-app-diag-core/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Diagnostics Tools (Core)
 LUCI_DEPENDS:=+luci-base
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-dnscrypt-proxy/Makefile
+++ b/applications/luci-app-dnscrypt-proxy/Makefile
@@ -7,6 +7,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for DNSCrypt-Proxy
 LUCI_DEPENDS:=+luci-base +luci-compat +uclient-fetch +dnscrypt-proxy +luci-lib-httpprotoutils
 
+PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-dump1090/Makefile
+++ b/applications/luci-app-dump1090/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for dump1090
 LUCI_DEPENDS:=+luci-base +luci-compat +dump1090
 
+PKG_MAINTAINER:=Alvaro Fernandez Rojas <noltari@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-example/Makefile
+++ b/applications/luci-app-example/Makefile
@@ -7,6 +7,9 @@ LUCI_TITLE:=LuCI example app for js based luci
 LUCI_DEPENDS:=+luci-base
 LUCI_PKGARCH:=all
 
+PKG_MAINTAINER:=Andreas Brau <ab@andi95.de> \
+	Duncan Hill <github.com@cricalix.net>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-firewall/Makefile
+++ b/applications/luci-app-firewall/Makefile
@@ -6,10 +6,11 @@
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=Firewall and Portforwarding application
+LUCI_TITLE:=Firewall and port forwarding application
 LUCI_DEPENDS:=+luci-base +uci-firewall
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/applications/luci-app-hd-idle/Makefile
+++ b/applications/luci-app-hd-idle/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Hard Disk Idle Spin-Down module
 LUCI_DEPENDS:=+luci-base +hd-idle +lsblk
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-irqbalance/Makefile
+++ b/applications/luci-app-irqbalance/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI support for irqbalance
 LUCI_DEPENDS:=+luci-base +irqbalance
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Puran Lyu <pl2355@nyu.edu>
 
 include ../../luci.mk
 

--- a/applications/luci-app-ksmbd/Makefile
+++ b/applications/luci-app-ksmbd/Makefile
@@ -5,6 +5,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Network Shares - Ksmbd the SMB kernel fileserver
 LUCI_DEPENDS:=+luci-base +ksmbd-server
 
+PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-rssi/Makefile
+++ b/applications/luci-app-ledtrig-rssi/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger rssi
 LUCI_DEPENDS:=+luci-base +rssileds
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-switch/Makefile
+++ b/applications/luci-app-ledtrig-switch/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger switch
 LUCI_DEPENDS:=+luci-base
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-usbport/Makefile
+++ b/applications/luci-app-ledtrig-usbport/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger usbport
 LUCI_DEPENDS:=+luci-base +kmod-usb-ledtrig-usbport
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ltqtapi/Makefile
+++ b/applications/luci-app-ltqtapi/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Lantiq Devices
 LUCI_DEPENDS:=+luci-base +luci-compat @BROKEN
 
+PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-lxc/Makefile
+++ b/applications/luci-app-lxc/Makefile
@@ -13,7 +13,8 @@ define Package/luci-app-lxc/conffiles
 /etc/config/lxc
 endef
 
-PKG_MAINTAINER:=Petar Koretic <petar.koretic@sartura.hr>
+PKG_MAINTAINER:=Petar Koretic <petar.koretic@sartura.hr> \
+	Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-minidlna/Makefile
+++ b/applications/luci-app-minidlna/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for miniDLNA
 LUCI_DEPENDS:=+luci-base +minidlna
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-mjpg-streamer/Makefile
+++ b/applications/luci-app-mjpg-streamer/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=MJPG-Streamer service configuration module
 LUCI_DEPENDS:=+luci-base +mjpg-streamer
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nextdns/Makefile
+++ b/applications/luci-app-nextdns/Makefile
@@ -6,6 +6,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for NextDNS
 LUCI_DEPENDS:=+luci-base +nextdns
 
+PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nft-qos/Makefile
+++ b/applications/luci-app-nft-qos/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=QoS over Nftables
 LUCI_DEPENDS:=+luci-base +luci-compat +nft-qos
 
+PKG_MAINTAINER:=Rosy Song <rosysong@rosinson.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nlbwmon/Makefile
+++ b/applications/luci-app-nlbwmon/Makefile
@@ -3,6 +3,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Netlink based bandwidth accounting
 LUCI_DEPENDS:=+luci-base +nlbwmon
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nut/Makefile
+++ b/applications/luci-app-nut/Makefile
@@ -11,6 +11,8 @@ LUCI_TITLE:=Network UPS Tools Configuration
 LUCI_DEPENDS:=+luci-base +luci-compat
 PKG_RELEASE:=1
 
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua
+++ b/applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local m, s, o

--- a/applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua
+++ b/applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local m, s, o

--- a/applications/luci-app-nut/luasrc/model/cbi/nut_server.lua
+++ b/applications/luci-app-nut/luasrc/model/cbi/nut_server.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local m, s, o

--- a/applications/luci-app-ocserv/Makefile
+++ b/applications/luci-app-ocserv/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for OpenConnect VPN
 LUCI_DEPENDS:=+luci-base +luci-compat +ocserv +certtool
 
+PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-olsr-services/Makefile
+++ b/applications/luci-app-olsr-services/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Show services announced with the nameservice plugin
 LUCI_DEPENDS:=+luci-base +luci-app-olsr +olsrd +olsrd-mod-nameservice
 
+PKG_MAINTAINER:=Andreas Brau <ab@andi95.de>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-olsr-viz/Makefile
+++ b/applications/luci-app-olsr-viz/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=OLSR Visualisation
 LUCI_DEPENDS:=+luci-base +luci-app-olsr +olsrd +olsrd-mod-txtinfo
 
+PKG_MAINTAINER:=Lorenz Schori <lo@znerol.ch>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-olsr/Makefile
+++ b/applications/luci-app-olsr/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=OLSR configuration and status module
 LUCI_DEPENDS:=+luci-base +olsrd
 
+PKG_MAINTAINER:=Manuel Munz <munz@comuno.net>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-openvpn/Makefile
+++ b/applications/luci-app-openvpn/Makefile
@@ -10,6 +10,8 @@ LUCI_TITLE:=LuCI Support for OpenVPN
 LUCI_DEPENDS:=+luci-base +luci-compat
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+	Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/applications/luci-app-opkg/Makefile
+++ b/applications/luci-app-opkg/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=OPKG package management application
 LUCI_DEPENDS:=+luci-base +opkg
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-p910nd/Makefile
+++ b/applications/luci-app-p910nd/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=p910nd - Printer server module
 LUCI_DEPENDS:=+luci-base +luci-compat +p910nd
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-polipo/Makefile
+++ b/applications/luci-app-polipo/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for the Polipo Proxy
 LUCI_DEPENDS:=+luci-base +luci-compat +polipo
 
+PKG_MAINTAINER:=Aleksandar Krsteski <alekrsteski@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-privoxy/Makefile
+++ b/applications/luci-app-privoxy/Makefile
@@ -8,18 +8,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-privoxy
 
-# Version == major.minor.patch
-# increase "minor" on new functionality and "patch" on patches/optimization
 PKG_VERSION:=1.0.6
 
-# Release == build
-# increase on changes of translation files
 PKG_RELEASE:=2
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=
+PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
-# LuCI specific settings
 LUCI_TITLE:=LuCI Support for Privoxy WEB proxy
 LUCI_DEPENDS:=+luci-compat +luci-lib-ipkg +luci-base +privoxy
 

--- a/applications/luci-app-qos/Makefile
+++ b/applications/luci-app-qos/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Quality of Service configuration module
 LUCI_DEPENDS:=+luci-base +luci-compat +qos-scripts
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-radicale/Makefile
+++ b/applications/luci-app-radicale/Makefile
@@ -8,18 +8,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-radicale
 
-# Version == major.minor.patch
-# increase "minor" on new functionality and "patch" on patches/optimization
 PKG_VERSION:=1.1.0
 
-# Release == build
-# increase on changes of translation files
 PKG_RELEASE:=2
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=
+PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
-# LuCI specific settings
 LUCI_TITLE:=LuCI Support for Radicale CardDAV/CalDAV
 LUCI_DEPENDS:=+luci-compat +luci-lib-ipkg +luci-base
 

--- a/applications/luci-app-radicale2/Makefile
+++ b/applications/luci-app-radicale2/Makefile
@@ -4,6 +4,7 @@ LUCI_TITLE:=Radicale v2.x CalDAV/CardDAV Server
 LUCI_DEPENDS:=+luci-base +luci-compat +radicale2 +rpcd-mod-rad2-enc
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 
 LUA_TARGET:=source
 

--- a/applications/luci-app-rp-pppoe-server/Makefile
+++ b/applications/luci-app-rp-pppoe-server/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Roaring Penguin PPPoE Server
 LUCI_DEPENDS:=+luci-base +luci-compat +rp-pppoe-server
 
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
+++ b/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local m, s, o

--- a/applications/luci-app-samba4/Makefile
+++ b/applications/luci-app-samba4/Makefile
@@ -5,6 +5,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Network Shares - Samba 4 SMB/CIFS fileserver
 LUCI_DEPENDS:=+luci-base +samba4-server
 
+PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ser2net/Makefile
+++ b/applications/luci-app-ser2net/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=LuCI Support for ser2net
 LUCI_DEPENDS:=+luci-base +ser2net
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Michele Primavera <primavera@elmod.it>
 
 include ../../luci.mk
 

--- a/applications/luci-app-shadowsocks-libev/Makefile
+++ b/applications/luci-app-shadowsocks-libev/Makefile
@@ -10,6 +10,8 @@ LUCI_TITLE:=LuCI Support for shadowsocks-libev
 LUCI_DEPENDS:=+luci-base
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com> \
+	Jian Chang <aa65535@live.com>
 
 include ../../luci.mk
 

--- a/applications/luci-app-siitwizard/Makefile
+++ b/applications/luci-app-siitwizard/Makefile
@@ -9,6 +9,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=SIIT IPv4-over-IPv6 configuration wizard
 LUCI_DEPENDS:=+luci-base +luci-compat +kmod-siit
 
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-softether/Makefile
+++ b/applications/luci-app-softether/Makefile
@@ -7,6 +7,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Softether management application
 LUCI_DEPENDS:=+luci-base +softethervpn5-client
 
+PKG_MAINTAINER:=BERENYI Balazs <balazs@wee.hu> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-splash/Makefile
+++ b/applications/luci-app-splash/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Freifunk DHCP-Splash application
 LUCI_DEPENDS:=+luci-base +luci-compat +luci-lib-nixio +luci-lib-iptparser +luci-lua-runtime +tc +kmod-sched +iptables-mod-nat-extra +iptables-mod-ipopt
 
+PKG_MAINTAINER:=Manuel Munz <munz@comuno.net>
+
 define Package/luci-app-splash/conffiles
 /etc/config/luci_splash
 /usr/lib/luci-splash/splashtext.html

--- a/applications/luci-app-statistics/Makefile
+++ b/applications/luci-app-statistics/Makefile
@@ -19,6 +19,8 @@ LUCI_DEPENDS:= \
 	+collectd-mod-load \
 	+collectd-mod-network
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 define Package/luci-app-statistics/conffiles
 /etc/config/luci_statistics
 endef

--- a/applications/luci-app-tinyproxy/Makefile
+++ b/applications/luci-app-tinyproxy/Makefile
@@ -9,6 +9,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Tinyproxy - HTTP(S)-Proxy configuration
 LUCI_DEPENDS:=+luci-base +luci-compat +tinyproxy
 
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-transmission/Makefile
+++ b/applications/luci-app-transmission/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Transmission
 LUCI_DEPENDS:=+luci-base +transmission-daemon
 
+PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-travelmate/Makefile
+++ b/applications/luci-app-travelmate/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI support for Travelmate
 LUCI_DEPENDS:=+luci-base +travelmate
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-ttyd/Makefile
+++ b/applications/luci-app-ttyd/Makefile
@@ -5,6 +5,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=ttyd - Command-line tool for sharing terminal over the web
 LUCI_DEPENDS:=+luci-base +ttyd
 
+PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-udpxy/Makefile
+++ b/applications/luci-app-udpxy/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for udpxy
 LUCI_DEPENDS:=+luci-base +udpxy
 
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-uhttpd/Makefile
+++ b/applications/luci-app-uhttpd/Makefile
@@ -11,7 +11,7 @@ LUCI_TITLE:=uHTTPd Webserver Configuration
 LUCI_DEPENDS:=+luci-base +uhttpd
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 
 include ../../luci.mk
 

--- a/applications/luci-app-unbound/Makefile
+++ b/applications/luci-app-unbound/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Unbound Recursive DNS Resolver Configuration
 LUCI_DEPENDS:=+luci-base +luci-compat +unbound-daemon
 
+PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@hotmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-upnp/Makefile
+++ b/applications/luci-app-upnp/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Universal Plug & Play configuration module
 LUCI_DEPENDS:=+luci-base +miniupnpd +rpcd-mod-ucode
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-usteer/Makefile
+++ b/applications/luci-app-usteer/Makefile
@@ -6,6 +6,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI usteer app for js based luci
 LUCI_DEPENDS:=+luci-base +usteer
 
+PKG_MAINTAINER:=Ramon Van Gorkom <github@flightfoil.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-vnstat/Makefile
+++ b/applications/luci-app-vnstat/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for VnStat
 LUCI_DEPENDS:=+luci-base +luci-compat +vnstat +vnstati
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-watchcat/Makefile
+++ b/applications/luci-app-watchcat/Makefile
@@ -5,6 +5,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Watchcat
 LUCI_DEPENDS:=+luci-base +watchcat
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io> \
+	Nicholas Smith <nicholas@nbembedded.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-wifischedule/Makefile
+++ b/applications/luci-app-wifischedule/Makefile
@@ -17,6 +17,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Turns WiFi on and off according to a schedule
 LUCI_DEPENDS:=+luci-base +luci-compat +wifischedule
 
+PKG_MAINTAINER:=Nils Koenig <openwrt@newk.it>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-wol/Makefile
+++ b/applications/luci-app-wol/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Wake-on-LAN
 LUCI_DEPENDS:=+luci-base +etherwake
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/modules/luci-compat/luasrc/model/network/proto_vpnc.lua
+++ b/modules/luci-compat/luasrc/model/network/proto_vpnc.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local netmod = luci.model.network

--- a/protocols/luci-proto-3g/Makefile
+++ b/protocols/luci-proto-3g/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for 3G
 LUCI_DEPENDS:=+comgt
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-autoip/Makefile
+++ b/protocols/luci-proto-autoip/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for Avahi IPv4LL configuration
 LUCI_DEPENDS:=+avahi-autoipd
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-batman-adv/Makefile
+++ b/protocols/luci-proto-batman-adv/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for the batman-adv protocol
 LUCI_DEPENDS:=+kmod-batman-adv
 
+PKG_MAINTAINER:=Marc Ahlgrim <marc@onemarcfifty.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-external/Makefile
+++ b/protocols/luci-proto-external/Makefile
@@ -3,6 +3,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for externally managed protocol
 LUCI_DEPENDS:=+external-protocol
 
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-ipv6/Makefile
+++ b/protocols/luci-proto-ipv6/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for DHCPv6/6in4/6to4/6rd/DS-Lite
 LUCI_DEPENDS:=@IPV6
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-mbim/Makefile
+++ b/protocols/luci-proto-mbim/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for MBIM
 LUCI_DEPENDS:=+umbim
 
+PKG_MAINTAINER:=Howard Chu <hyc@symas.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-modemmanager/Makefile
+++ b/protocols/luci-proto-modemmanager/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for ModemManager
 LUCI_DEPENDS:=+modemmanager
 
+PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-ncm/Makefile
+++ b/protocols/luci-proto-ncm/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for NCM
 LUCI_DEPENDS:=+comgt-ncm
 
+PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-openconnect/Makefile
+++ b/protocols/luci-proto-openconnect/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for OpenConnect VPN
 LUCI_DEPENDS:=+openconnect +luci-lua-runtime
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-openfortivpn/Makefile
+++ b/protocols/luci-proto-openfortivpn/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for OpenFortivpn
 LUCI_DEPENDS:=+openfortivpn +luci-lua-runtime
 
+PKG_MAINTAINER:=Aaron Goodman <aaronjg@stanford.edu>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-ppp/Makefile
+++ b/protocols/luci-proto-ppp/Makefile
@@ -7,9 +7,9 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for PPP/PPPoE/PPPoA/PPtP
-LUCI_DEPENDS:=
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-qmi/Makefile
+++ b/protocols/luci-proto-qmi/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for QMI
 LUCI_DEPENDS:=+uqmi
 
+PKG_MAINTAINER:=David Thornley <david.thornley@touchstargroup.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-relay/Makefile
+++ b/protocols/luci-proto-relay/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for relayd pseudo bridges
 LUCI_DEPENDS:=+relayd
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-sstp/Makefile
+++ b/protocols/luci-proto-sstp/Makefile
@@ -10,6 +10,8 @@ LUCI_TITLE:=Support for SSTP
 LUCI_DEPENDS:=+sstp-client
 LUCI_PKGARCH:=all
 
+PKG_MAINTAINER:=Robert Koszewski <rkkoszewski@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-unet/Makefile
+++ b/protocols/luci-proto-unet/Makefile
@@ -10,6 +10,8 @@ LUCI_TITLE:=Support for unetd VPN
 LUCI_DEPENDS:=+unetd +unet-cli
 LUCI_PKGARCH:=all
 
+PKG_MAINTAINER:=Hannu Nyman <hannu.nyman@iki.fi>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/protocols/luci-proto-vpnc/Makefile
+++ b/protocols/luci-proto-vpnc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for VPNC VPN
 LUCI_DEPENDS:=+vpnc
 
-PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=Apache-2.0
 
 include ../../luci.mk

--- a/protocols/luci-proto-wireguard/Makefile
+++ b/protocols/luci-proto-wireguard/Makefile
@@ -11,6 +11,7 @@ LUCI_DEPENDS:=+wireguard-tools +ucode
 LUCI_PKGARCH:=all
 
 PKG_PROVIDES:=luci-app-wireguard
+PKG_MAINTAINER:=Dan Luedtke <mail@danrl.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-yggdrasil/Makefile
+++ b/protocols/luci-proto-yggdrasil/Makefile
@@ -12,6 +12,7 @@ LUCI_PKGARCH:=all
 PKG_VERSION:=1.0.0
 
 PKG_PROVIDES:=luci-proto-yggdrasil
+PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>
 
 include ../../luci.mk
 


### PR DESCRIPTION
The CODEOWNERS will request for a reviewer automatically by a path.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

The luci-app-bcp38 had a maintainer from luci-app-acme and that looks like a copy-paste error. So it's maintainer was changed to an author @danrl

Daniel F. Dickinson changed email address to <dfdpublic@wildtechgarden.ca>

luci-all-lxl has a maintainer Petar Koretic <petar.koretic@sartura.hr> but there is no corresponding GitHub account. So Dirk Brenken was added as a second maintainer: he answered on an issue of the app.

When maintainer wasn't set the initial author was used, or most contributor or Jo-Philipp Wich as a default.

If anyone can't be a maintainer he or she should create an issue and the CODEOWNERS file will be updated with a new one.