### PR TITLE
luci-app-ksmbd: update kmod version to vermagic

### DIFF
--- a/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
+++ b/applications/luci-app-ksmbd/htdocs/luci-static/resources/view/ksmbd.js
@@ -11,7 +11,7 @@ return view.extend({
 			L.resolveDefault(fs.stat('/sbin/block'), null),
 			L.resolveDefault(fs.stat('/etc/config/fstab'), null),
 			L.resolveDefault(fs.exec('/usr/sbin/ksmbd.mountd', ['-V']), {}).then(function(res) { return L.toArray((res.stdout || '').match(/version : (\S+)/))[1] }),
-			L.resolveDefault(fs.exec('/sbin/modinfo', ['ksmbd']), {}).then(function(res) { return L.toArray((res.stdout || '').match(/version:\t(\S+)/))[1] }),
+			L.resolveDefault(fs.exec('/sbin/modinfo', ['ksmbd']), {}).then(function(res) { return L.toArray((res.stdout || '').match(/vermagic:\t(\S+)/))[1] }),
 		]);
 	},
 	render: function(stats) {


### PR DESCRIPTION
ksmbd now is inside on kernel, switch to vermagic to load the correct kmod version