### PR TITLE
luci-proto-modemmanager: add new option keep_connected

### DIFF
--- a/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
+++ b/protocols/luci-proto-modemmanager/htdocs/luci-static/resources/protocol/modemmanager.js
@@ -48,6 +48,8 @@ return network.registerProtocol('modemmanager', {
 	renderFormOptions: function(s) {
 		var dev = this.getL3Device() || this.getDevice(), o;
 
+		s.taboption('general', form.Flag, 'keep_connected', _('Keep connected'));
+
 		o = s.taboption('general', form.ListValue, '_modem_device', _('Modem device'));
 		o.ucioption = 'device';
 		o.rmempty = false;


### PR DESCRIPTION
This option forces netifd to reconnect the modem if the connection was dropped.

This PR completes https://github.com/openwrt/packages/pull/23388 and is related to https://github.com/openwrt/packages/issues/19794.