### PR TITLE
luci-mod-network: add disabled option for interface

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -4539,7 +4539,8 @@ var UI = baseclass.extend(/** @lends LuCI.ui.prototype */ {
 						for (var j = 0; this.changes && this.changes.network && j < this.changes.network.length; j++) {
 							var chg = this.changes.network[j];
 
-							if (chg[0] == 'set' && chg[1] == iif && (chg[2] == 'proto' || chg[2] == 'ipaddr' || chg[2] == 'netmask'))
+							if (chg[0] == 'set' && chg[1] == iif &&
+								((chg[2] == 'disabled' && chg[3] == '1') || chg[2] == 'proto' || chg[2] == 'ipaddr' || chg[2] == 'netmask'))
 								return iif;
 						}
 					}

--- a/modules/luci-base/po/ar/base.po
+++ b/modules/luci-base/po/ar/base.po
@@ -2435,6 +2435,10 @@ msgstr "تعطيل التشفير"
 msgid "Disable Inactivity Polling"
 msgstr "تعطيل أخذ عينات الخمول"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "تعطيل الواجهة"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "تعطيل هذه الشبكة"

--- a/modules/luci-base/po/bg/base.po
+++ b/modules/luci-base/po/bg/base.po
@@ -2399,6 +2399,10 @@ msgstr "Деактивиране на криптирането"
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Забраняване на тази интерфейс"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Забраняване на тази мрежа"

--- a/modules/luci-base/po/bn_BD/base.po
+++ b/modules/luci-base/po/bn_BD/base.po
@@ -2376,6 +2376,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/ca/base.po
+++ b/modules/luci-base/po/ca/base.po
@@ -2451,6 +2451,10 @@ msgstr "Deshabilita el xifrat"
 msgid "Disable Inactivity Polling"
 msgstr "Deshabilita la comprovació d'inactivitat"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Inhabilita la interfície"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Deshabilita aquesta xarxa"

--- a/modules/luci-base/po/cs/base.po
+++ b/modules/luci-base/po/cs/base.po
@@ -2462,6 +2462,10 @@ msgstr "Zakázat šifrování"
 msgid "Disable Inactivity Polling"
 msgstr "Zakázat dotazování na nečinnost"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Vypnout tuto síť"

--- a/modules/luci-base/po/da/base.po
+++ b/modules/luci-base/po/da/base.po
@@ -2508,6 +2508,10 @@ msgstr "Deaktiver kryptering"
 msgid "Disable Inactivity Polling"
 msgstr "Deaktivere opsamling af inaktivitet"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Deaktivere interface"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Deaktivere dette netværk"

--- a/modules/luci-base/po/de/base.po
+++ b/modules/luci-base/po/de/base.po
@@ -2531,6 +2531,10 @@ msgstr "Verschlüsselung deaktivieren"
 msgid "Disable Inactivity Polling"
 msgstr "Inaktivitäts-Proben deaktivieren"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Schnittstelle deaktivieren"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Dieses Netzwerk deaktivieren"

--- a/modules/luci-base/po/el/base.po
+++ b/modules/luci-base/po/el/base.po
@@ -2439,6 +2439,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Απενεργοποίηση διεπαφή"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/en/base.po
+++ b/modules/luci-base/po/en/base.po
@@ -2381,6 +2381,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/es/base.po
+++ b/modules/luci-base/po/es/base.po
@@ -2553,6 +2553,10 @@ msgstr "Desactivar encriptación"
 msgid "Disable Inactivity Polling"
 msgstr "Desactivar sondeo de inactividad"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Desactivar esta interfaz"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Desactivar esta red"

--- a/modules/luci-base/po/fi/base.po
+++ b/modules/luci-base/po/fi/base.po
@@ -2447,6 +2447,10 @@ msgstr "Poista salaus käytöstä"
 msgid "Disable Inactivity Polling"
 msgstr "Poista käyttämättömyyskyselyt käytöstä"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Poista tämä sovitinta käytöstä"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Poista tämä verkko käytöstä"

--- a/modules/luci-base/po/fr/base.po
+++ b/modules/luci-base/po/fr/base.po
@@ -2537,6 +2537,10 @@ msgstr "Désactiver le chiffrement"
 msgid "Disable Inactivity Polling"
 msgstr "Désactiver l'interrogation d'inactivité"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Désactiver cette interface"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Désactiver ce réseau"

--- a/modules/luci-base/po/he/base.po
+++ b/modules/luci-base/po/he/base.po
@@ -2396,6 +2396,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "בטל"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/hi/base.po
+++ b/modules/luci-base/po/hi/base.po
@@ -2378,6 +2378,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/hu/base.po
+++ b/modules/luci-base/po/hu/base.po
@@ -2451,6 +2451,10 @@ msgstr "Titkosítás letiltása"
 msgid "Disable Inactivity Polling"
 msgstr "Inaktivitás lekérdezésének letiltása"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Letiltás"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Hálózat letiltása"

--- a/modules/luci-base/po/it/base.po
+++ b/modules/luci-base/po/it/base.po
@@ -2550,6 +2550,10 @@ msgstr "Disattiva crittografia"
 msgid "Disable Inactivity Polling"
 msgstr "Disattiva il polling di inattività"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Disattiva questa interfaccia"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Disattiva questa rete"

--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -2454,6 +2454,10 @@ msgstr "暗号化を無効化"
 msgid "Disable Inactivity Polling"
 msgstr "非アクティブ状態のポーリングを無効化"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "無効"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "このネットワークを無効化"

--- a/modules/luci-base/po/ko/base.po
+++ b/modules/luci-base/po/ko/base.po
@@ -2433,6 +2433,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "비활성화"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/lt/base.po
+++ b/modules/luci-base/po/lt/base.po
@@ -2505,6 +2505,10 @@ msgstr "Išjungti šifravimas"
 msgid "Disable Inactivity Polling"
 msgstr "Išjungti neaktyvumo apklausinėjimą/stebėjimą"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Išjungti"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Išjungti šį tinklą"

--- a/modules/luci-base/po/mr/base.po
+++ b/modules/luci-base/po/mr/base.po
@@ -2376,6 +2376,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "अक्षम करा"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/ms/base.po
+++ b/modules/luci-base/po/ms/base.po
@@ -2381,6 +2381,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/nb_NO/base.po
+++ b/modules/luci-base/po/nb_NO/base.po
@@ -2418,6 +2418,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Slå av grensesnittet"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/nl/base.po
+++ b/modules/luci-base/po/nl/base.po
@@ -2507,6 +2507,10 @@ msgstr "Encryptie uitschakelen"
 msgid "Disable Inactivity Polling"
 msgstr "Inactiviteitspolling uitschakelen"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Uitschakelen deze interface"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Dit netwerk uitschakelen"

--- a/modules/luci-base/po/pl/base.po
+++ b/modules/luci-base/po/pl/base.po
@@ -2531,6 +2531,10 @@ msgstr "Wyłącz szyfrowanie"
 msgid "Disable Inactivity Polling"
 msgstr "Wyłącz badanie nieaktywności"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Wyłącz interfejs"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Wyłącz tę sieć"

--- a/modules/luci-base/po/pt/base.po
+++ b/modules/luci-base/po/pt/base.po
@@ -2529,6 +2529,10 @@ msgstr "Desativar encriptação"
 msgid "Disable Inactivity Polling"
 msgstr "Desactivar a Polling de Inactividade"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Desativar esta interface"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Desativar esta rede"

--- a/modules/luci-base/po/pt_BR/base.po
+++ b/modules/luci-base/po/pt_BR/base.po
@@ -2533,6 +2533,10 @@ msgstr "Desabilitar Cifragem"
 msgid "Disable Inactivity Polling"
 msgstr "Desative a sondagem de inatividade"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Desativar esta interface"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Desabilitar esta rede"

--- a/modules/luci-base/po/ro/base.po
+++ b/modules/luci-base/po/ro/base.po
@@ -2526,6 +2526,10 @@ msgstr "Dezactivați Criptarea"
 msgid "Disable Inactivity Polling"
 msgstr "Dezactivați verificarea inactivității"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Dezactivați interfața"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Dezactivați această rețea"

--- a/modules/luci-base/po/ru/base.po
+++ b/modules/luci-base/po/ru/base.po
@@ -2544,6 +2544,10 @@ msgstr "Отключить шифрование"
 msgid "Disable Inactivity Polling"
 msgstr "Отключить отслеживание неактивности клиентов"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Отключить этот интерфейс"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Отключить данную сеть"

--- a/modules/luci-base/po/sk/base.po
+++ b/modules/luci-base/po/sk/base.po
@@ -2479,6 +2479,10 @@ msgstr "Zakázať šifrovanie"
 msgid "Disable Inactivity Polling"
 msgstr "Zakázať dotazovanie na nečinnosť"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Zakázať túto rozhranie"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Zakázať túto sieť"

--- a/modules/luci-base/po/sv/base.po
+++ b/modules/luci-base/po/sv/base.po
@@ -2403,6 +2403,10 @@ msgstr "Inaktivera kryptering"
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Stäng av gränssnitt"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Inaktivera det här nätverket"

--- a/modules/luci-base/po/templates/base.pot
+++ b/modules/luci-base/po/templates/base.pot
@@ -2367,6 +2367,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/tr/base.po
+++ b/modules/luci-base/po/tr/base.po
@@ -2507,6 +2507,10 @@ msgstr "Şifrelemeyi Devre Dışı Bırak"
 msgid "Disable Inactivity Polling"
 msgstr "Hareketsizlik Yoklamasını Devre Dışı Bırak"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Devre dışı bırak"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Bu ağı devre dışı bırak"

--- a/modules/luci-base/po/uk/base.po
+++ b/modules/luci-base/po/uk/base.po
@@ -2529,6 +2529,10 @@ msgstr "Вимкнути шифрування"
 msgid "Disable Inactivity Polling"
 msgstr "Вимкнути опитування неактивності"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Вимкнути цей інтерфейс"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Вимкнути цю мережу"

--- a/modules/luci-base/po/ur/base.po
+++ b/modules/luci-base/po/ur/base.po
@@ -2375,6 +2375,10 @@ msgstr ""
 msgid "Disable Inactivity Polling"
 msgstr ""
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr ""
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr ""

--- a/modules/luci-base/po/vi/base.po
+++ b/modules/luci-base/po/vi/base.po
@@ -2495,6 +2495,10 @@ msgstr "Vô hiệu hóa mã hóa"
 msgid "Disable Inactivity Polling"
 msgstr "Vô hiệu hóa thăm dò tín hiệu không hoạt động"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "Vô hiệu hóa"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "Vô hiệu hóa mạng này"

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -2433,6 +2433,10 @@ msgstr "禁用加密"
 msgid "Disable Inactivity Polling"
 msgstr "禁用不活动轮询"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "禁用此接口"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "禁用此网络"

--- a/modules/luci-base/po/zh_Hant/base.po
+++ b/modules/luci-base/po/zh_Hant/base.po
@@ -2438,6 +2438,10 @@ msgstr "停用加密"
 msgid "Disable Inactivity Polling"
 msgstr "停用非活動輪詢"
 
+#: modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js:598
+msgid "Disable this interface"
+msgstr "斷開接口"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/wireless.js:889
 msgid "Disable this network"
 msgstr "停用此網路"

--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/interfaces.js
@@ -595,6 +595,9 @@ return view.extend({
 				o.network = ifc.getName();
 				o.exclude = '@' + ifc.getName();
 
+				o = s.taboption('general', form.Flag, 'disabled', _('Disable this interface'));
+				o.modalonly = true;
+
 				o = s.taboption('general', form.Flag, 'auto', _('Bring up on boot'));
 				o.modalonly = true;
 				o.default = o.enabled;


### PR DESCRIPTION
The PR adds a UI option to disable a network interface.
E.g. I have two ISPs with different WAN config  (PPPoE with creds and just DHCP) and if one is not working I switching to another and enabling it's interface.
