### PR TITLE
[23.05] luci-app-https-dns-proxy: remove unnecessary translation call

### DIFF
--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js
@@ -129,7 +129,7 @@ return view.extend({
 				key = element[".name"];
 				description = element[".name"];
 			}
-			o.value(key, _("%s").format(description));
+			o.value(key, description);
 		});
 		o.depends("dnsmasq_config_update_option", "+");
 		o.retain = true;

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -1,10 +1,6 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:132
-msgid "%s"
-msgstr ""
-
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:258
 msgid "%s%s%s proxy at %s on port %s.%s"
 msgstr ""


### PR DESCRIPTION
Thank you @hnyman!

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit f162289fe4de00bf228ab66aaccff1235b41cfd9)