### PR TITLE
 luci-app-upnp: fix name of access-control-list

### DIFF
--- a/applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json
+++ b/applications/luci-app-upnp/root/usr/share/luci/menu.d/luci-app-upnp.json
@@ -6,7 +6,7 @@
 			"path": "upnp/upnp"
 		},
 		"depends": {
-			"acl": [ "luci-app-ddns" ],
+			"acl": [ "luci-app-upnp" ],
 			"uci": { "upnpd": true }
 		}
 	}

--- a/applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json
+++ b/applications/luci-app-upnp/root/usr/share/rpcd/acl.d/luci-app-upnp.json
@@ -1,5 +1,5 @@
 {
-	"luci-app-ddns": {
+	"luci-app-upnp": {
 		"description": "Grant access to upnp procedures",
 		"read": {
 			"ubus": {


### PR DESCRIPTION
give upnp a unique acl name that does not conflict with the one of ddns.