### PR TITLE
luci-proto-ipv6: Add support for IPIP6(RFC2473) tunnel 

### DIFF
--- a/modules/luci-base/po/ja/base.po
+++ b/modules/luci-base/po/ja/base.po
@@ -2779,6 +2779,11 @@ msgstr ""
 msgid "Dual-Stack Lite (RFC6333)"
 msgstr "Dual-Stack Lite (RFC6333)"
 
+#: modules/luci-compat/luasrc/model/network/proto_4x6.lua:20
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:10
+msgid "IPv4 over IPv6 (RFC2473-IPIPv6)"
+msgstr "IPv4 over IPv6 (ipip6)"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:365
 msgid "Dump cache on SIGUSR1, include requesting IP."
 msgstr ""
@@ -5376,6 +5381,7 @@ msgstr "割り当てるローカル IPアドレス"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:46
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:46
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:44
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:44
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:40
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:39
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6to4.js:39
@@ -5393,6 +5399,7 @@ msgstr "ローカル IPv6 DNS サーバー"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:53
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:54
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:45
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:48
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:44
 msgid "Local IPv6 address"
 msgstr "ローカルIPv6アドレス"
@@ -7888,6 +7895,7 @@ msgstr "リモートIPv6アドレス"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:42
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:42
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:40
 msgid "Remote IPv6 address or FQDN"
 msgstr "リモートIPv6アドレスまたはFQDN"
 

--- a/modules/luci-base/po/zh_Hans/base.po
+++ b/modules/luci-base/po/zh_Hans/base.po
@@ -2769,6 +2769,11 @@ msgstr ""
 msgid "Dual-Stack Lite (RFC6333)"
 msgstr "轻型双栈（RFC6333）"
 
+#: modules/luci-compat/luasrc/model/network/proto_4x6.lua:20
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:10
+msgid "IPv4 over IPv6 (RFC2473-IPIPv6)"
+msgstr "IPv4 over IPv6 (RFC2473-IPIPv6)"
+
 #: modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js:365
 msgid "Dump cache on SIGUSR1, include requesting IP."
 msgstr "转储 SIGUSR1 缓存，包括请求 IP。"
@@ -5346,6 +5351,7 @@ msgstr "要分配的本地 IP 地址"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gre.js:46
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/gretap.js:46
 #: protocols/luci-proto-ipip/htdocs/luci-static/resources/protocol/ipip.js:44
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:44
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:40
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6rd.js:39
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6to4.js:39
@@ -5363,6 +5369,7 @@ msgstr "本地 IPV6 DNS 服务器"
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:53
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/6in4.js:54
 #: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/dslite.js:45
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:48
 #: protocols/luci-proto-vxlan/htdocs/luci-static/resources/protocol/vxlan6.js:44
 msgid "Local IPv6 address"
 msgstr "本机 IPv6 地址"
@@ -7839,6 +7846,7 @@ msgstr "远程 IPv6 地址"
 
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6.js:42
 #: protocols/luci-proto-gre/htdocs/luci-static/resources/protocol/grev6tap.js:42
+#: protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js:40
 msgid "Remote IPv6 address or FQDN"
 msgstr "远程 IPv6 地址或 FQDN"
 

--- a/modules/luci-compat/luasrc/model/network/proto_4x6.lua
+++ b/modules/luci-compat/luasrc/model/network/proto_4x6.lua
@@ -12,6 +12,8 @@ for _, p in ipairs({"dslite", "map", "464xlat"}) do
 	function proto.get_i18n(self)
 		if p == "dslite" then
 			return luci.i18n.translate("Dual-Stack Lite (RFC6333)")
+		elseif p == "ipip6" then
+			return luci.i18n.translate("IPv4 over IPv6 (RFC2473-IPIPv6)")
 		elseif p == "map" then
 			return luci.i18n.translate("MAP / LW4over6")
 		elseif p == "464xlat" then
@@ -24,7 +26,7 @@ for _, p in ipairs({"dslite", "map", "464xlat"}) do
 	end
 
 	function proto.opkg_package(self)
-		if p == "dslite" then
+		if p == "dslite" or p == "ipip6" then
 			return "ds-lite"
 		elseif p == "map" then
 			return "map-t"
@@ -56,6 +58,7 @@ end
 
 netmod:register_pattern_virtual("^464%-%w")
 netmod:register_pattern_virtual("^ds%-%w")
+netmod:register_pattern_virtual("^ipip6%-%w")
 netmod:register_pattern_virtual("^map%-%w")
 
 netmod:register_error_code("AFTR_DNS_FAIL",		luci.i18n.translate("Unable to resolve AFTR host name"))

--- a/protocols/luci-proto-ipv6/Makefile
+++ b/protocols/luci-proto-ipv6/Makefile
@@ -6,7 +6,7 @@
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=Support for DHCPv6/6in4/6to4/6rd/DS-Lite
+LUCI_TITLE:=Support for DHCPv6/6in4/6to4/6rd/DS-Lite/IPIP6
 LUCI_DEPENDS:=@IPV6
 
 PKG_LICENSE:=Apache-2.0

--- a/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js
+++ b/protocols/luci-proto-ipv6/htdocs/luci-static/resources/protocol/ipip6.js
@@ -1,0 +1,82 @@
+'use strict';
+'require form';
+'require network';
+'require tools.widgets as widgets';
+
+network.registerPatternVirtual(/^ipip6-.+$/);
+
+return network.registerProtocol('ipip6', {
+	getI18n: function () {
+		return _('IPv4 over IPv6 (RFC2473-IPIPv6)');
+	},
+
+	getIfname: function () {
+		return this._ubus('l3_device') || 'ipip6-%s'.format(this.sid);
+	},
+
+	getOpkgPackage: function () {
+		return 'ds-lite';
+	},
+
+	isFloating: function () {
+		return true;
+	},
+
+	isVirtual: function () {
+		return true;
+	},
+
+	getDevices: function () {
+		return null;
+	},
+
+	containsDevice: function (ifname) {
+		return (network.getIfnameOf(ifname) == this.getIfname());
+	},
+
+	renderFormOptions: function (s) {
+		var o;
+
+		o = s.taboption('general', form.Value, 'peeraddr', _('Remote IPv6 address or FQDN'));
+		o.rmempty = false;
+		o.datatype = 'or(hostname,ip6addr("nomask"))';
+
+		o = s.taboption('general', form.Value, 'ip4ifaddr', _('Local IPv4 address'));
+		o.rmempty = false;
+		o.datatype = 'ip4addr("nomask")';
+
+		o = s.taboption('general', form.Value, 'ip6addr', _('Local IPv6 address'), _('Leave empty to use the current WAN address'));
+		o.datatype = 'ip6addr("nomask")';
+		o.load = function (section_id) {
+			return network.getWAN6Networks().then(L.bind(function (nets) {
+				if (Array.isArray(nets) && nets.length)
+					this.placeholder = nets[0].getIP6Addr();
+				return form.Value.prototype.load.apply(this, [section_id]);
+			}, this));
+		};
+
+		o = s.taboption('advanced', widgets.NetworkSelect, 'tunlink', _('Tunnel Link'));
+		o.nocreate = true;
+		o.exclude = s.section;
+
+		o = s.taboption('advanced', form.ListValue, 'encaplimit', _('Encapsulation limit'));
+		o.rmempty = false;
+		o.default = 'ignore';
+		o.datatype = 'or("ignore",range(0,255))';
+		o.value('ignore', _('ignore'));
+		for (var i = 0; i < 256; i++)
+			o.value(i);
+
+		o = s.taboption('advanced', form.Flag, 'defaultroute', _('Default gateway'), _('If unchecked, no default route is configured'));
+		o.default = o.enabled;
+
+		o = s.taboption('advanced', form.Value, 'metric', _('Use gateway metric'));
+		o.placeholder = '0';
+		o.datatype = 'uinteger';
+		o.depends('defaultroute', '1');
+
+		o = s.taboption('advanced', form.Value, 'mtu', _('Use MTU on tunnel interface'));
+		o.placeholder = '1280';
+		o.datatype = 'max(9200)';
+	}
+});


### PR DESCRIPTION
Add Generic Packet Tunneling in IPv6 Specification (RFC 2473) support.
(For NTT Broadband V6Plus/transix/Xpass Fixed IP)

[depends on other PRs: openwrt/openwrt](https://github.com/openwrt/openwrt/pull/14516)