### PR TITLE
luci-app-cloudflared: configure Cloudlfare Zero Trust Tunnel

### DIFF
--- a/applications/luci-app-cloudflared/Makefile
+++ b/applications/luci-app-cloudflared/Makefile
@@ -1,0 +1,17 @@
+# This is free software, licensed under the Apache License, Version 2.0
+#
+# Copyright (C) 2024 Hilman Maulana <hilman0.0maulana@gmail.com>
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI for Cloudflared
+LUCI_DEPENDS:=+cloudflared
+LUCI_DESCRIPTION:=LuCI support for Cloudflare Zero Trust Tunnels
+
+PKG_MAINTAINER:=Hilman Maulana <hilman0.0maulana@gmail.com>, Sergey Ponomarev <stokito@gmail.com>
+PKG_VERSION:=1.0
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js
+++ b/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js
@@ -1,0 +1,118 @@
+/* This is free software, licensed under the Apache License, Version 2.0
+ *
+ * Copyright (C) 2024 Hilman Maulana <hilman0.0maulana@gmail.com>
+ */
+
+'use strict';
+'require form';
+'require poll';
+'require rpc';
+'require uci';
+'require view';
+
+var callServiceList = rpc.declare({
+	object: 'service',
+	method: 'list',
+	params: ['name'],
+	expect: { '': {} }
+});
+
+function getServiceStatus() {
+	return L.resolveDefault(callServiceList('cloudflared'), {}).then(function (res) {
+		var isRunning = false;
+		try {
+			isRunning = res['cloudflared']['instances']['cloudflared']['running'];
+		} catch (ignored) {}
+		return isRunning;
+	});
+}
+
+function renderStatus(isRunning) {
+	var spanTemp = '<label class="cbi-value-title">Status</label><div class="cbi-value-field"><em><span style="color:%s">%s</span></em></div>';
+	var renderHTML;
+	if (isRunning) {
+		renderHTML = String.format(spanTemp, 'green', _('Running'));
+	} else {
+		renderHTML = String.format(spanTemp, 'red', _('Not Running'));
+	}
+
+	return renderHTML;
+}
+
+return view.extend({
+	load: function () {
+		return Promise.all([
+			uci.load('cloudflared')
+		]);
+	},
+
+	render: function (data) {
+		var m, s, o;
+
+		m = new form.Map('cloudflared', _('Cloudflare Zero Trust Tunnel'),
+			_('Cloudflare Zero Trust Security services help you get maximum security both from outside and within the network.') + '<br />' +
+			_('Create and manage your network on the <a %s>Cloudflare Zero Trust</a> dashboard.')
+				.format('href="https://one.dash.cloudflare.com" target="_blank"') + '<br />' +
+			_('See <a %s>documentation</a>.')
+				.format('href="https://openwrt.org/docs/guide-user/services/vpn/cloudfare_tunnel" target="_blank"')
+		);
+
+		s = m.section(form.NamedSection, 'config', 'cloudflared');
+
+		o = s.option(form.DummyValue, 'service_status', _('Status'));
+		o.load = function () {
+			poll.add(function () {
+				return L.resolveDefault(getServiceStatus()).then(function (res) {
+					var view = document.getElementById('cbi-cloudflared-config-service_status');
+					if (view) {
+						view.innerHTML = renderStatus(res);
+					}
+				});
+			});
+		};
+		o.value = _('Collecting data...');
+
+		o = s.option(form.Flag, 'enabled', _('Enable'));
+		o.rmempty = false;
+
+		o = s.option(form.TextValue, 'token', _('Token'),
+			_('The tunnel token is shown in the dashboard once you create a tunnel.')
+		);
+		o.optional = true;
+		o.rmempty = false;
+		o.monospace = true;
+
+		o = s.option(form.FileUpload, 'config', _('Config file path'),
+			_('See <a %s>documentation</a>.')
+				.format('href="https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/configure-tunnels/local-management/configuration-file/" target="_blank"')
+		);
+		o.default = '/etc/cloudflared/config.yml';
+		o.root_directory = '/etc/cloudflared/';
+		o.optional = true;
+
+		o = s.option(form.FileUpload, 'origincert', _('Certificate of Origin'),
+			_('The account certificate for your zones authorizing the client to serve as an Origin for that zone') + '<br />' +
+			_('Obtain a certificate <a %s>here</a>.')
+				.format('href="https://dash.cloudflare.com/argotunnel" target="_blank"')
+		);
+		o.default = '/etc/cloudflared/cert.pem';
+		o.root_directory = '/etc/cloudflared/';
+		o.optional = true;
+
+		o = s.option(form.ListValue, 'region', _('Region'),
+			_('The region to which connections are established.')
+		);
+		o.value('us', _('United States'));
+		o.optional = true;
+
+		o = s.option(form.ListValue, 'loglevel', _('Debug level'));
+		o.value('fatal', _('Fatal'));
+		o.value('error', _('Error'));
+		o.value('warn', _('Warning'));
+		o.value('info', _('Info'));
+		o.value('debug', _('Debug'));
+		o.default = 'info';
+
+		return m.render();
+	}
+});

--- a/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js
+++ b/applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js
@@ -1,0 +1,125 @@
+/* This is free software, licensed under the Apache License, Version 2.0
+ *
+ * Copyright (C) 2024 Hilman Maulana <hilman0.0maulana@gmail.com>
+ */
+
+'use strict';
+'require fs';
+'require ui';
+'require view';
+'require poll';
+
+function formatLogEntry(logObj) {
+	var formattedTime = new Date(logObj.time).toISOString().replace('T', ' ').split('.')[0];
+	var tunnelIDMessage = logObj.tunnelID ? ', ID: ' + logObj.tunnelID : '';
+	var errorMessage = logObj.error ? ', Error: ' + logObj.error : '';
+	var ipMessage = logObj.ip ? ', IP: ' + logObj.ip : '';
+	var configMessage = logObj.config ? ', Config: ' + JSON.stringify(logObj.config) : '';
+	var connectionMessage = logObj.connection ? ', Connection: ' + JSON.stringify(logObj.connection) : '';
+	var locationMessage = logObj.location ? ', Location: ' + logObj.location : '';
+	var protocolMessage = logObj.protocol ? ', Protocol: ' + logObj.protocol : '';
+
+	return '[' + formattedTime + '] [' + logObj.level + '] : ' + logObj.message + ipMessage + tunnelIDMessage + errorMessage + configMessage + connectionMessage + locationMessage + protocolMessage;
+}
+
+return view.extend({
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null,
+	load: function() {
+		poll.add(function () {
+			return fs.read('/var/log/cloudflared.log').then(function(res) {
+				if (!res || res.trim() === '') {
+					ui.addNotification(null, E('p', {}, _('Unable to read the interface info from /var/log/cloudflared.log.')));
+					return '';
+				}
+
+				var logs = res.trim().split('\n').map(function(entry) {
+					try {
+						var logObj = JSON.parse(entry);
+						return logObj.time && logObj.message && logObj.level
+							? formatLogEntry(logObj)
+							: '';
+					} catch (error) {
+						console.error('Error parsing log entry:', error);
+						return '';
+					}
+				});
+
+				logs = logs.filter(function(entry) {
+					return entry.trim() !== '';
+				});
+
+				var info = logs.join('\n');
+				var view = document.getElementById('syslog');
+				var filterLevel = document.getElementById('filter-level').value;
+				var logDirection = document.getElementById('log-direction').value;
+
+				if (view) {
+					var filteredLogs;
+					if (filterLevel !== 'all') {
+						filteredLogs = logs.filter(function(entry) {
+							var logLevel = entry.match(/\[.*\] \[(.*)\]/)[1].toLowerCase();
+							return logLevel.includes(filterLevel.toLowerCase());
+						});
+					} else {
+						filteredLogs = logs;
+					}
+
+					if (logDirection === 'up') {
+						filteredLogs = filteredLogs.reverse();
+					}
+
+					info = filteredLogs.join('\n');
+					view.innerHTML = info;
+				}
+
+				return info;
+			});
+		});
+
+		return Promise.resolve('');
+	},
+	render: function(info) {
+		return E([], [
+			E('h2', { 'class': 'section-title' }, _('Log')),
+			E('div', { 'id': 'logs' }, [
+				E('label', { 'for': 'filter-level', 'style': 'margin-right: 8px;' }, _('Filter Level:')),
+				E('select', { 'id': 'filter-level', 'style': 'margin-right: 8px;' }, [
+					E('option', { 'value': 'all', 'selected': 'selected' }, _('All')),
+					E('option', { 'value': 'info' }, _('Info')),
+					E('option', { 'value': 'warn' }, _('Warn')),
+					E('option', { 'value': 'error' }, _('Error')),
+				]),
+				E('label', { 'for': 'log-direction', 'style': 'margin-right: 8px;' }, _('Log Direction:')),
+				E('select', { 'id': 'log-direction', 'style': 'margin-right: 8px;' }, [
+					E('option', { 'value': 'down', 'selected': 'selected' }, _('Down')),
+					E('option', { 'value': 'up' }, _('Up')),
+				]),
+				E('button', {
+					'id': 'download-log',
+					'class': 'cbi-button cbi-button-save',
+					'click': L.bind(this.handleDownloadLog, this),
+					'style': 'margin-bottom: 8px;'
+				}, _('Download Log')),
+				E('textarea', {
+					'id': 'syslog',
+					'class': 'cbi-input-textarea',
+					'style': 'height: 500px; overflow-y: scroll;',
+					'readonly': 'readonly',
+					'wrap': 'off',
+					'rows': 1
+				}, [ info ])
+			])
+		]);
+	},
+
+	handleDownloadLog: function() {
+		var logs = document.getElementById('syslog').value;
+		var blob = new Blob([logs], { type: 'text/plain' });
+		var link = document.createElement('a');
+		link.href = window.URL.createObjectURL(blob);
+		link.download = 'cloudflared.log';
+		link.click();
+	}
+});

--- a/applications/luci-app-cloudflared/po/ar/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/ar/cloudflared.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ar\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/bg/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/bg/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: bg\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/bn_BD/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/bn_BD/cloudflared.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: bn_BD\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/ca/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/ca/cloudflared.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/cs/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/cs/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/da/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/da/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: da\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/de/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/de/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/el/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/el/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: el\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/es/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/es/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/fi/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/fi/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fi\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/fr/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/fr/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/he/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/he/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/hi/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/hi/cloudflared.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hi\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/hu/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/hu/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: hu\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/it/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/it/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/ja/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/ja/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/ko/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/ko/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ko\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/lt/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/lt/cloudflared.po
@@ -1,0 +1,168 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: lt\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"(n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/mr/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/mr/cloudflared.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: mr\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/ms/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/ms/cloudflared.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ms\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/nb_NO/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/nb_NO/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: nb\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/nl/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/nl/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/pl/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/pl/cloudflared.po
@@ -1,0 +1,168 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/pt/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/pt/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/pt_BR/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/pt_BR/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: pt_BR\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/ro/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/ro/cloudflared.po
@@ -1,0 +1,168 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < "
+"20)) ? 1 : 2;\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/ru/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/ru/cloudflared.po
@@ -1,0 +1,168 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/sk/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/sk/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/sv/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/sv/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/templates/cloudflared.pot
+++ b/applications/luci-app-cloudflared/po/templates/cloudflared.pot
@@ -1,0 +1,159 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/tr/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/tr/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: tr\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/uk/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/uk/cloudflared.po
@@ -1,0 +1,168 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/vi/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/vi/cloudflared.po
@@ -1,0 +1,167 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: vi\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/zh_Hans/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/zh_Hans/cloudflared.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_Hans\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/po/zh_Hant/cloudflared.po
+++ b/applications/luci-app-cloudflared/po/zh_Hant/cloudflared.po
@@ -1,0 +1,166 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: zh_Hant\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:89
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:93
+msgid "Certificate of Origin"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:53
+msgid ""
+"Cloudflare Zero Trust Security services help you get maximum security both "
+"from outside and within the network."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:52
+msgid "Cloudflare Zero Trust Tunnel"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:3
+msgid "Cloudflared"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:73
+msgid "Collecting data..."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:85
+msgid "Config file path"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:14
+msgid "Configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:54
+msgid ""
+"Create and manage your network on the <a %s>Cloudflare Zero Trust</a> "
+"dashboard."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:113
+msgid "Debug"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:108
+msgid "Debug level"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:96
+msgid "Down"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:104
+msgid "Download Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:75
+msgid "Enable"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:110
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:92
+msgid "Error"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:109
+msgid "Fatal"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:87
+msgid "Filter Level:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json:3
+msgid "Grant access to Cloudflared configuration"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:112
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:90
+msgid "Info"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:85
+msgid "Log"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:94
+msgid "Log Direction:"
+msgstr ""
+
+#: applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json:22
+msgid "Logs"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:36
+msgid "Not Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:95
+msgid "Obtain a certificate <a %s>here</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:102
+msgid "Region"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:34
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:56
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:86
+msgid "See <a %s>documentation</a>."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:62
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:94
+msgid ""
+"The account certificate for your zones authorizing the client to serve as an "
+"Origin for that zone"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:103
+msgid "The region to which connections are established."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:79
+msgid "The tunnel token is shown in the dashboard once you create a tunnel."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:78
+msgid "Token"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:33
+msgid "Unable to read the interface info from /var/log/cloudflared.log."
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:105
+msgid "United States"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:97
+msgid "Up"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/log.js:91
+msgid "Warn"
+msgstr ""
+
+#: applications/luci-app-cloudflared/htdocs/luci-static/resources/view/cloudflared/config.js:111
+msgid "Warning"
+msgstr ""

--- a/applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json
+++ b/applications/luci-app-cloudflared/root/usr/share/luci/menu.d/luci-app-cloudflared.json
@@ -1,0 +1,29 @@
+{
+	"admin/vpn/cloudflared": {
+		"title": "Cloudflared",
+		"order": 80,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-app-cloudflared" ],
+			"uci": { "cloudflared": true }
+		}
+	},
+	"admin/vpn/cloudflared/config": {
+		"title": "Configuration",
+		"order": 10,
+		"action": {
+			"type": "view",
+			"path": "cloudflared/config"
+		}
+	},
+	"admin/vpn/cloudflared/log": {
+		"title": "Logs",
+		"order": 20,
+		"action": {
+			"type": "view",
+			"path": "cloudflared/log"
+		}
+	}
+}

--- a/applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json
+++ b/applications/luci-app-cloudflared/root/usr/share/rpcd/acl.d/luci-app-cloudflared.json
@@ -1,0 +1,16 @@
+{
+	"luci-app-cloudflared": {
+		"description": "Grant access to Cloudflared configuration",
+		"read": {
+			"uci": [ "cloudflared" ],
+			"ubus": {
+				"service": [ "list" ]
+			},
+			"file": [ "/var/log/cloudflared.log" ]
+		},
+		"write": {
+			"uci": [ "cloudflared" ],
+			"file": [ "/etc/cloudflared/" ]
+		}
+	}
+}


### PR DESCRIPTION
Configure a tunnel and see logs of the daemon.

![Screenshot luci-app-cloudflared](https://github.com/openwrt/luci/assets/415502/0714a7b1-6362-4625-9974-7b993eb5508e)


Replaces #6834