### PR TITLE
luci-app-attendedsysupgrade: Fix logic error in EFI image selection

### DIFF
--- a/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
+++ b/applications/luci-app-attendedsysupgrade/htdocs/luci-static/resources/view/attendedsysupgrade/overview.js
@@ -85,24 +85,24 @@ return view.extend({
 	},
 
 	selectImage: function (images) {
-		let image;
-		for (image of images) {
-			if (this.firmware.filesystem == image.filesystem) {
+		let firmware = this.firmware;
+		let data = this.data;
+		var filesystemFilter = function(e) {
+			return (e.filesystem == firmware.filesystem);
+		}
+		var typeFilter = function(e) {
+			if (firmware.target.indexOf("x86") != -1) {
 				// x86 images can be combined-efi (EFI) or combined (BIOS)
-				if(this.firmware.target.indexOf("x86") != -1) {
-					if (this.data.efi && image.type == 'combined-efi') {
-						return image;
-					} else if (image.type == 'combined') {
-						return image;
-					}
+				if (data.efi) {
+					return (e.type == 'combined-efi');
 				} else {
-					if (image.type == 'sysupgrade' || image.type == 'combined') {
-						return image;
-					}
+					return (e.type == 'combined');
 				}
+			} else {
+				return (e.type == 'sysupgrade' || e.type == 'combined');
 			}
 		}
-		return null;
+		return images.filter(filesystemFilter).filter(typeFilter)[0];
 	},
 
 	handle200: function (response) {


### PR DESCRIPTION
If a non-EFI image comes first in the list of images, it would have been selected even on an EFI system.

Closes: openwrt/luci#6884

@aparcar

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (x86-64, 23.0.5.2, Firefox) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [x] Description: (describe the changes proposed in this PR)
