### PR TITLE
[23.05] luci-app-adblock-fast: bugfix: prevent runtime errors on empty strings

### DIFF
--- a/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
+++ b/applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js
@@ -201,8 +201,11 @@ var status = baseclass.extend({
 					);
 					var text = "";
 					reply.status.warnings.forEach((element) => {
-						text +=
-							warningTable[element.id].format(element.extra || " ") + "<br />";
+						if (element.id && warningTable[element.id])
+							text +=
+								warningTable[element.id].format(element.extra || " ") +
+								"<br />";
+						else text += _("Unknown warning") + "<br />";
 					});
 					var warningsText = E("div", {}, text);
 					var warningsField = E(
@@ -292,8 +295,10 @@ var status = baseclass.extend({
 					);
 					var text = "";
 					reply.status.errors.forEach((element) => {
-						text +=
-							errorTable[element.id].format(element.extra || " ") + "!<br />";
+						if (element.id && errorTable[element.id])
+							text +=
+								errorTable[element.id].format(element.extra || " ") + "!<br />";
+						else text += _("Unknown error") + "<br />";
 					});
 					text += _("Errors encountered, please check the %sREADME%s").format(
 						'<a href="' + pkg.URL + '" target="_blank">',

--- a/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
+++ b/applications/luci-app-adblock-fast/po/templates/adblock-fast.pot
@@ -1,7 +1,7 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:225
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:228
 msgid "%s is currently disabled"
 msgstr ""
 
@@ -137,7 +137,7 @@ msgstr ""
 msgid "Compressed cache file found."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:223
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:226
 msgid "Config (%s) validation failure!"
 msgstr ""
 
@@ -171,7 +171,7 @@ msgid ""
 "Directory for compressed cache file of block-list in the persistent memory."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:424
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:429
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:356
 msgid "Disable"
 msgstr ""
@@ -184,7 +184,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:418
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:423
 msgid "Disabling %s service"
 msgstr ""
 
@@ -213,7 +213,7 @@ msgstr ""
 msgid "Downloading lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:405
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:410
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:357
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:511
 msgid "Enable"
@@ -228,7 +228,7 @@ msgstr ""
 msgid "Enables debug output to /tmp/adblock-fast.log."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:399
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:404
 msgid "Enabling %s service"
 msgstr ""
 
@@ -236,7 +236,7 @@ msgstr ""
 msgid "Error"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:298
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:303
 msgid "Errors encountered, please check the %sREADME%s"
 msgstr ""
 
@@ -244,83 +244,83 @@ msgstr ""
 msgid "Fail"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:248
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:251
 msgid "Failed to access shared memory"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:244
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:247
 msgid "Failed to create '%s' file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:266
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:269
 msgid "Failed to create block-list or restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:257
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:260
 msgid "Failed to create compressed cache"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:243
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:246
 msgid "Failed to create directory for %s file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:278
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:281
 msgid "Failed to create output/cache/gzip file directory"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:280
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:283
 msgid "Failed to detect format %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:273
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:276
 msgid "Failed to download %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:271
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:274
 msgid "Failed to download Config Update file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:252
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:255
 msgid "Failed to format data file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:261
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:264
 msgid "Failed to move '%s' to '%s'"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:254
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:257
 msgid "Failed to move temporary data file to '%s'"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:250
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:253
 msgid "Failed to optimize data file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:275
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:278
 msgid "Failed to parse %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:274
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:277
 msgid "Failed to parse Config Update file"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:251
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:254
 msgid "Failed to process allow-list"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:269
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:272
 msgid "Failed to reload/restart DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:259
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:262
 msgid "Failed to remove temporary files"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:247
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:250
 msgid "Failed to restart/reload DNS resolver"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:249
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:252
 msgid "Failed to sort data file"
 msgstr ""
 
@@ -328,11 +328,11 @@ msgstr ""
 msgid "Failed to start"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:268
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:271
 msgid "Failed to stop %s"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:260
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:263
 msgid "Failed to unpack compressed cache"
 msgstr ""
 
@@ -357,7 +357,7 @@ msgstr ""
 msgid "Force Router DNS server to all local devices"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:346
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:351
 msgid "Force redownloading %s block lists"
 msgstr ""
 
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Forces Router DNS use on local devices, also known as DNS Hijacking."
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:285
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:288
 msgid "Free ram (%s) is not enough to process all enabled block-lists"
 msgstr ""
 
@@ -423,11 +423,11 @@ msgstr ""
 msgid "No AdBlock on dnsmasq"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:276
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:279
 msgid "No HTTPS/SSL support on device"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:282
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:285
 msgid "No blocked list URLs nor blocked-domains enabled"
 msgstr ""
 
@@ -439,11 +439,11 @@ msgstr ""
 msgid "Output Verbosity Setting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:367
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:372
 msgid "Pause"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:362
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:367
 msgid "Pausing %s"
 msgstr ""
 
@@ -481,7 +481,7 @@ msgstr ""
 msgid "Processing lists"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:352
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:357
 msgid "Redownload"
 msgstr ""
 
@@ -490,11 +490,11 @@ msgstr ""
 msgid "Restarting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:465
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:470
 msgid "Service Control"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:291
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:294
 msgid "Service Errors"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Some recommended packages are missing"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:333
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:338
 msgid "Start"
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "Starting"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:327
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:332
 msgid "Starting %s service"
 msgstr ""
 
@@ -543,7 +543,7 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:386
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:391
 msgid "Stop"
 msgstr ""
 
@@ -556,7 +556,7 @@ msgstr ""
 msgid "Stopped"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:380
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:385
 msgid "Stopping %s service"
 msgstr ""
 
@@ -572,29 +572,29 @@ msgstr ""
 msgid "Suppress output"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:241
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:244
 msgid "The %s failed to discover WAN gateway"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:229
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:232
 msgid ""
 "The dnsmasq ipset support is enabled, but dnsmasq is either not installed or "
 "installed dnsmasq does not support ipset"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:232
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:235
 msgid ""
 "The dnsmasq ipset support is enabled, but ipset is either not installed or "
 "installed ipset does not support '%s' type"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:235
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:238
 msgid ""
 "The dnsmasq nft set support is enabled, but dnsmasq is either not installed "
 "or installed dnsmasq does not support nft set"
 msgstr ""
 
-#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:238
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:241
 msgid "The dnsmasq nft sets support is enabled, but nft is not installed"
 msgstr ""
 
@@ -614,6 +614,14 @@ msgstr ""
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:502
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/status/include/70_adblock-fast.js:95
 msgid "Unknown"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:301
+msgid "Unknown error"
+msgstr ""
+
+#: applications/luci-app-adblock-fast/htdocs/luci-static/resources/adblock-fast/status.js:208
+msgid "Unknown warning"
 msgstr ""
 
 #: applications/luci-app-adblock-fast/htdocs/luci-static/resources/view/adblock-fast/overview.js:253


### PR DESCRIPTION

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 00960d522d3ee296db58960560a177fd8e6a688a)
