### PR TITLE
luci-base: extend Expires directive to prevent caching

### DIFF
--- a/modules/luci-base/root/www/index.html
+++ b/modules/luci-base/root/www/index.html
@@ -4,7 +4,8 @@
 	<head>
 		<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
 		<meta http-equiv="Pragma" content="no-cache" />
-                <meta http-equiv="Expires" content="0" />
+		<meta http-equiv="Expires" content="0" />
+		<meta http-equiv="Expires" content="Thu, 01 Jan 1970 00:00:00 GMT" />
 		<meta http-equiv="refresh" content="0; URL=cgi-bin/luci/" />
 		<style type="text/css">
 			body { background: white; font-family: arial, helvetica, sans-serif; }


### PR DESCRIPTION
Some browsers apparently act on fixed dates only, so add that too.
Tested on firefox.

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
