### PR TITLE
luci-mod-network: put each IPv6 address on a separate line

### DIFF
--- a/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
+++ b/modules/luci-mod-network/htdocs/luci-static/resources/view/network/dhcp.js
@@ -1155,7 +1155,7 @@ return view.extend({
 
 								return [
 									host || '-',
-									lease.ip6addrs ? lease.ip6addrs.join(' ') : lease.ip6addr,
+									lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
 									lease.duid,
 									exp
 								];

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/40_dhcp.js
@@ -161,7 +161,7 @@ return baseclass.extend({
 
 			rows = [
 				host || '-',
-				lease.ip6addrs ? lease.ip6addrs.join(' ') : lease.ip6addr,
+				lease.ip6addrs ? lease.ip6addrs.join('<br />') : lease.ip6addr,
 				lease.duid,
 				exp
 			];


### PR DESCRIPTION
Right now, when there's active DHCPv6 leases and more than one address per host (e.g. because ULA is used together with GUA prefixes), the two IPv6 addresses will be printed on one line (which may or may not get broken up depending on the length of the addresses, which also looks inconsistent).

Putting each address on a separate line makes it much easier to read the addresses (IMHO).