### PR TITLE
luci-app-tor: allow to upload custom config

### DIFF
--- a/applications/luci-app-tor/Makefile
+++ b/applications/luci-app-tor/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI app to configure Tor
 LUCI_DEPENDS:=+luci-base +tor +tor-hs
-PKG_VERSION:=1.0.0
+PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Sergey Ponomarev <stokito@gmail.com>
 

--- a/applications/luci-app-tor/htdocs/luci-static/resources/view/tor/tor.js
+++ b/applications/luci-app-tor/htdocs/luci-static/resources/view/tor/tor.js
@@ -1,0 +1,36 @@
+'use strict';
+'require view';
+'require form';
+'require uci';
+
+
+return view.extend({
+	render: function () {
+		var m, s, o;
+
+		m = new form.Map('tor', _('Tor onion router'),
+			_('For further information <a %s>check the documentation</a>')
+				.format('href="https://openwrt.org/docs/guide-user/services/tor/client" target="_blank" rel="noreferrer"')
+		);
+
+		s = m.section(form.NamedSection, 'conf', 'tor');
+
+		o = s.option(form.DynamicList, 'tail_include', _('Include configs'));
+		o.datatype = 'list(string)';
+
+		o = s.option(form.FileUpload, '_custom_config', _('Custom config'));
+		o.default = '/etc/tor/torrc_custom';
+		o.root_directory = '/etc/tor/';
+		o.optional = true;
+		o.write = function(section_id, formvalue) {
+			let tail_include = uci.get('tor', section_id, 'tail_include');
+			if (!tail_include.includes(formvalue)) {
+				tail_include.push(formvalue);
+				return uci.set('tor', section_id, 'tail_include', tail_include);
+			}
+		};
+
+
+		return m.render();
+	},
+});

--- a/applications/luci-app-tor/root/usr/share/luci/menu.d/luci-app-tor.json
+++ b/applications/luci-app-tor/root/usr/share/luci/menu.d/luci-app-tor.json
@@ -19,5 +19,13 @@
 			"type": "view",
 			"path": "tor/tor-hs"
 		}
+	},
+	"admin/services/tor/tor": {
+		"title": "Tor Onion router",
+		"order": 30,
+		"action": {
+			"type": "view",
+			"path": "tor/tor"
+		}
 	}
 }

--- a/applications/luci-app-tor/root/usr/share/rpcd/acl.d/luci-app-tor.json
+++ b/applications/luci-app-tor/root/usr/share/rpcd/acl.d/luci-app-tor.json
@@ -3,7 +3,7 @@
 		"description": "Grant UCI access for luci-app-tor",
 		"read": {
 			"ubus": {
-				"tor_rpcd.sh": [
+				"tor-hs-rpc": [
 					"list-hs"
 				]
 			},

--- a/applications/luci-app-tor/root/usr/share/rpcd/acl.d/luci-app-tor.json
+++ b/applications/luci-app-tor/root/usr/share/rpcd/acl.d/luci-app-tor.json
@@ -16,7 +16,10 @@
 			"uci": [
 				"tor",
 				"tor-hs"
-			]
+			],
+			"file": {
+				"/etc/tor/*": [ "write" ]
+			}
 		}
 	}
 }


### PR DESCRIPTION
Maintainer: me
CC: @ja-pa

The PR contains a fix for luci-app-tor when list of hidden services didn't worked well.
For a user it just didn't show an onion domain.

Additionally I added a separate tab to configure the Tor itself.
But we have only one option: list of configs to include.
Let's configure at least this.

Additionally I added an upload field to upload a custom config and add it to a list of includes.

![luci-app-tor upload custom config](https://github.com/openwrt/luci/assets/415502/9c07cfde-6f42-4c2d-b05a-00bae10b901c)


This will allow to a user to change the Tor settings without SSH.
For example by just downloading a sample conf from a tutorial, edit and upload. Still this is not convenient but at least something for today.

 

