### PR TITLE
luci-mod-status: Adding scroll buttons on syslog and kernellog status pages

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
@@ -16,16 +16,36 @@ return view.extend({
 			return line.replace(/^<\d+>/, '');
 		});
 
+		var scrollDownButton = E('button', { 
+				'id': 'scrollDownButton',
+				'class': 'cbi-button cbi-button-neutral',
+			}, _('Scroll to tail', 'scroll to bottom (the tail) of the log file')
+		);
+		scrollDownButton.addEventListener('click', function() {
+			window.scrollTo(0, document.body.scrollHeight);
+		});
+
+		var scrollUpButton = E('button', { 
+				'id' : 'scrollUpButton',
+				'class': 'cbi-button cbi-button-neutral',
+			}, _('Scroll to head', 'scroll to top (the head) of the log file')
+		);
+		scrollUpButton.addEventListener('click', function() {
+			window.scrollTo(0, 0);
+		});
+
 		return E([], [
 			E('h2', {}, [ _('Kernel Log') ]),
 			E('div', { 'id': 'content_syslog' }, [
+				E('div', {'style': 'padding-bottom: 20px'}, [scrollDownButton]),
 				E('textarea', {
 					'id': 'syslog',
 					'style': 'font-size:12px',
 					'readonly': 'readonly',
 					'wrap': 'off',
 					'rows': loglines.length + 1
-				}, [ loglines.join('\n') ])
+				}, [ loglines.join('\n') ]),
+				E('div', {'style': 'padding-bottom: 20px'}, [scrollUpButton])
 			])
 		]);
 	},

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
@@ -21,16 +21,37 @@ return view.extend({
 	render: function(logdata) {
 		var loglines = logdata.trim().split(/\n/);
 
+
+		var scrollDownButton = E('button', { 
+				'id': 'scrollDownButton',
+				'class': 'cbi-button cbi-button-neutral'
+			}, _('Scroll to tail', 'scroll to bottom (the tail) of the log file')
+		);
+		scrollDownButton.addEventListener('click', function() {
+			window.scrollTo(0, document.body.scrollHeight);
+		});
+
+		var scrollUpButton = E('button', { 
+				'id' : 'scrollUpButton',
+				'class': 'cbi-button cbi-button-neutral'
+			}, _('Scroll to head', 'scroll to top (the head) of the log file')
+		);
+		scrollUpButton.addEventListener('click', function() {
+			window.scrollTo(0, 0);
+		});
+
 		return E([], [
 			E('h2', {}, [ _('System Log') ]),
 			E('div', { 'id': 'content_syslog' }, [
+				E('div', {'style': 'padding-bottom: 20px'}, [scrollDownButton]),
 				E('textarea', {
 					'id': 'syslog',
 					'style': 'font-size:12px',
 					'readonly': 'readonly',
 					'wrap': 'off',
 					'rows': loglines.length + 1
-				}, [ loglines.join('\n') ])
+				}, [ loglines.join('\n') ]),
+				E('div', {'style': 'padding-bottom: 20px'}, [scrollUpButton])
 			])
 		]);
 	},


### PR DESCRIPTION
My log files can grow rather big, typically if i look at the log files then i want to look at the bottom, not the top, so I was missing a scroll down button. 

So I added these:
![image](https://github.com/openwrt/luci/assets/18365965/1e470b16-9e61-4b0b-836d-8c23d9404cf9)


![image](https://github.com/openwrt/luci/assets/18365965/b7eba14d-f7aa-4dd0-a7ae-59f278a28f3e)

Please let me know if you have any comments or suggestions. 
