### PR TITLE
luci-app-usteer: Fix no wireless defined setup

### DIFF
--- a/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
+++ b/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
@@ -609,7 +609,7 @@ return view.extend({
 		o.optional = true;
 		o.datatype = 'list(string)';
 
-		o = s.taboption('settings', form.MultiValue, 'ssid_list', _('SSID list'), _('List of SSIDs to enable steering on'));
+		o = s.taboption('settings', form.DynamicList, 'ssid_list', _('SSID list'), _('List of SSIDs to enable steering on'));
 		WifiNetworks.forEach(function (wifiNetwork) {
 			if (wifiNetwork.getSSID()) {
 				o.value(wifiNetwork.getSSID())


### PR DESCRIPTION
Some users use the usteer app in a "non wireless" device. With the current code it crashes because there is no SSID defined. Making the ui element a DynamicList fixes the issue because it allows free text input.