### PR TITLE
luci-app-usteer: filter repeated SSIDs in config

### DIFF
--- a/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
+++ b/applications/luci-app-usteer/htdocs/luci-static/resources/view/usteer/usteer.js
@@ -611,7 +611,7 @@ return view.extend({
 
 		o = s.taboption('settings', form.DynamicList, 'ssid_list', _('SSID list'), _('List of SSIDs to enable steering on'));
 		WifiNetworks.forEach(function (wifiNetwork) {
-			if (wifiNetwork.getSSID()) {
+			if (wifiNetwork.getSSID() && (!o.keylist || o.keylist.indexOf(wifiNetwork.getSSID()) === -1)) {
 				o.value(wifiNetwork.getSSID())
 			}
 		});


### PR DESCRIPTION
When the SSID name was the same in different radio, they appear repeated in the options. This commit filter them.

Signed-off-by: Miguel Angel Mulero Martinez

This change was after a discussion in of https://github.com/openwrt/luci/pull/6908