### PR TITLE
luci-theme-bootstrap: allow network interfaces to line break

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2144,6 +2144,10 @@ th[data-sort-direction="desc"]::after { content: "\a0\25bc"; }
 	padding: .25em;
 }
 
+#cbi-network-interface .ifacebox-body {
+	white-space: normal;
+}
+
 .ifacebadge {
 	display: inline-block;
 	flex-direction: row;


### PR DESCRIPTION
Fixes #6922 

The inherited nowrap of white-space causes the interface boxes to not line break, resulting in a horizontal scroll bar when many interfaces are present.

Tested on Chrome and Firefox.

Before:
![before](https://github.com/openwrt/luci/assets/7290072/9f85bf96-4be8-4b3b-8ea7-84b9bb573057)

After:
![after](https://github.com/openwrt/luci/assets/7290072/453cfe23-de7d-4129-a5f8-09cad804c9c5)

Another solution I found was to remove the `white-space: nowrap` from the [ifacebox](https://github.com/openwrt/luci/blob/master/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css#L2111) and [ifacebadge](https://github.com/openwrt/luci/blob/master/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css#L2150) classes, however I'm not familiar enough with the code base to know what side-effects this might have so I added a specific CSS selector override for the fix.

First contribution so any and all feedback is greatly appreciated! 