### PR TITLE
luci-app-opkg: add warning about modifying packages

### DIFF
--- a/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
+++ b/applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js
@@ -1129,6 +1129,14 @@ return view.extend({
 
 			E('h2', {}, _('Software')),
 
+			E('div', { 'class': 'cbi-map-descr' }, [
+				E('span', _('Install additional software and upgrade existing packages with opkg.')),
+				E('br'),
+				E('span', _('<strong>Warning!</strong> Package operations can <a %s>break your system</a>.').format(
+					'href="https://openwrt.org/meta/infobox/upgrade_packages_warning" target="_blank" rel="noreferrer"'
+				))
+			]),
+
 			E('div', { 'class': 'controls' }, [
 				E('div', {}, [
 					E('label', {}, _('Disk space') + ':'),

--- a/applications/luci-app-opkg/po/ar/opkg.po
+++ b/applications/luci-app-opkg/po/ar/opkg.po
@@ -15,7 +15,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "إجراءات"
 
@@ -27,7 +32,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr "قم بإزالة التبعيات غير المستخدمة تلقائيًا"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "متاح"
 
@@ -51,11 +56,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "إلغاء"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "إجلاء"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "تكوين opkg …"
 
@@ -65,7 +70,7 @@ msgstr "التبعيات"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "الوصف"
 
@@ -73,7 +78,7 @@ msgstr "الوصف"
 msgid "Details for package <em>%h</em>"
 msgstr "تفاصيل الحزمة <em>%h </em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -81,15 +86,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "إلغاء"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -99,7 +104,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "عرض d% -%d من %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "قم بتنزيل الحزمة وتثبيتها"
 
@@ -111,7 +116,7 @@ msgstr "أخطاء"
 msgid "Executing package manager"
 msgstr "تنفيذ مدير الحزم"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "مصفي"
 
@@ -119,7 +124,7 @@ msgstr "مصفي"
 msgid "Grant access to opkg management"
 msgstr "منح حقوق الدخول لإدارة opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -129,13 +134,17 @@ msgstr ""
 msgid "Install"
 msgstr "تثبيت"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "مثبت"
 
@@ -173,8 +182,8 @@ msgstr "قم بتثبيت الحزمة يدويًا"
 msgid "Needs upgrade"
 msgstr "يحتاج إلى ترقية"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "الصفحة التالية"
 
@@ -198,7 +207,7 @@ msgstr "غير متوفر"
 msgid "Not installed"
 msgstr "غير مثبت"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "موافق"
 
@@ -208,16 +217,16 @@ msgstr "موافق"
 msgid "OPKG Configuration"
 msgstr "تكوين OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "اسم الحزمة"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "اسم الحزمة أو URL …"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "الصفحة السابقة"
 
@@ -277,7 +286,7 @@ msgstr "جارٍ حفظ بيانات التكوين …"
 msgid "Size"
 msgstr "مقاس"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "الحجم (.ipk)"
 
@@ -316,7 +325,7 @@ msgid ""
 msgstr ""
 "إصدار المستودع للحزمة <em>%h </em> غير متوافق ، يتطلب %s ولكن يتوفر%s فقط."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "اكتب للتصفية …"
 
@@ -332,11 +341,11 @@ msgstr "غير قادر على قراءة٪ s: %s%"
 msgid "Unable to save %s: %s"
 msgstr "غير قادر على حفظ٪ %s% : s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "تحديث القوائم …"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "التحديثات"
 
@@ -345,13 +354,13 @@ msgstr "التحديثات"
 msgid "Upgrade…"
 msgstr "تحديث النظام…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "تحميل الحزمة …"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "الإصدار"
 
@@ -364,24 +373,24 @@ msgstr "الإصدار غير متوافق"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "في انتظار إكمال أمر <em> opkg %h </em> …"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "غير معروف"
 

--- a/applications/luci-app-opkg/po/bg/opkg.po
+++ b/applications/luci-app-opkg/po/bg/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Действия"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr "Автоматично премахни неизползвани зависимости"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Налични"
 
@@ -54,11 +59,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отмени"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Изчисти"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Конфигуриране opkg…"
 
@@ -68,7 +73,7 @@ msgstr "Зависимости"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Описание"
 
@@ -76,7 +81,7 @@ msgstr "Описание"
 msgid "Details for package <em>%h</em>"
 msgstr "Детайли за пакет <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -84,15 +89,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Затвори"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -102,7 +107,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Показване %d-%d of %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Свали и инсталирай пакет"
 
@@ -114,7 +119,7 @@ msgstr "Грешки"
 msgid "Executing package manager"
 msgstr "Стартиране на пакетния мениджър"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Филтър"
 
@@ -122,7 +127,7 @@ msgstr "Филтър"
 msgid "Grant access to opkg management"
 msgstr "Разрешаване достъп до opkg менажиране"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -132,13 +137,17 @@ msgstr ""
 msgid "Install"
 msgstr "Инсталирай"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Инсталирани"
 
@@ -176,8 +185,8 @@ msgstr "Ръчно инсталирай пакет"
 msgid "Needs upgrade"
 msgstr "Нуждаещ се от ъпгрейд"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Следваща страница"
 
@@ -201,7 +210,7 @@ msgstr "Липсва"
 msgid "Not installed"
 msgstr "Не е инсталиран"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "ОК"
 
@@ -211,16 +220,16 @@ msgstr "ОК"
 msgid "OPKG Configuration"
 msgstr "OPKG Конфигурация"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Име на пакет"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Име на пакет или URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Предишна страница"
 
@@ -280,7 +289,7 @@ msgstr "Запазване на конфигурация…"
 msgid "Size"
 msgstr "Размер"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Размер (.ipk)"
 
@@ -321,7 +330,7 @@ msgstr ""
 "Версията на пакета в хранилището <em>%h</em> не е свъместима, изисква се %s "
 "но само %s е налична."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Пиши за филтър…"
 
@@ -337,11 +346,11 @@ msgstr "Не може да се прочете %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Не може да се запази %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Обновяване на списъци…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Обновления"
 
@@ -350,13 +359,13 @@ msgstr "Обновления"
 msgid "Upgrade…"
 msgstr "Надстройване…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Качване пакет…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Версия"
 
@@ -369,24 +378,24 @@ msgstr "Несъвместима версия"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Изчкаване <em>opkg %h</em> команда да приключи…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "неизвестен"
 

--- a/applications/luci-app-opkg/po/bn_BD/opkg.po
+++ b/applications/luci-app-opkg/po/bn_BD/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "ক্রিয়া"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr ""
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "বাতিল করুন"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr ""
 
@@ -64,7 +69,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "বর্ণনা"
 
@@ -72,7 +77,7 @@ msgstr "বর্ণনা"
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -80,15 +85,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "বাতিল"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -98,7 +103,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr ""
 
@@ -110,7 +115,7 @@ msgstr ""
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "ছাঁকনি"
 
@@ -118,7 +123,7 @@ msgstr "ছাঁকনি"
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -128,13 +133,17 @@ msgstr ""
 msgid "Install"
 msgstr ""
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr ""
 
@@ -170,8 +179,8 @@ msgstr ""
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -195,7 +204,7 @@ msgstr ""
 msgid "Not installed"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr ""
 
@@ -205,16 +214,16 @@ msgstr ""
 msgid "OPKG Configuration"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -274,7 +283,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -311,7 +320,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -327,11 +336,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -340,13 +349,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "সংস্করণ"
 
@@ -359,24 +368,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "অজ্ঞাত"
 

--- a/applications/luci-app-opkg/po/ca/opkg.po
+++ b/applications/luci-app-opkg/po/ca/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Accions"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Disponible"
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancel•lar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 #, fuzzy
 msgid "Configure opkg…"
 msgstr "Configuració"
@@ -65,7 +70,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Descripció"
 
@@ -73,7 +78,7 @@ msgstr "Descripció"
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -81,15 +86,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Oblida-ho"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -99,7 +104,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Descarrega i instal·la el paquet"
 
@@ -112,7 +117,7 @@ msgstr "Error"
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtre"
 
@@ -120,7 +125,7 @@ msgstr "Filtre"
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -130,13 +135,17 @@ msgstr ""
 msgid "Install"
 msgstr "Instal·la"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 #, fuzzy
 msgid "Installed"
 msgstr "Instal·la"
@@ -176,8 +185,8 @@ msgstr "Descarrega i instal·la el paquet"
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -204,7 +213,7 @@ msgstr "Total disponible"
 msgid "Not installed"
 msgstr "No connectat"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "D'acord"
 
@@ -215,17 +224,17 @@ msgstr "D'acord"
 msgid "OPKG Configuration"
 msgstr "Configuració d&#39;OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Nom del paquet"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 #, fuzzy
 msgid "Package name or URL…"
 msgstr "Nom del paquet"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -286,7 +295,7 @@ msgstr "Configuració de dispositiu"
 msgid "Size"
 msgstr "Mida"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Mida (.ipk)"
 
@@ -323,7 +332,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -339,12 +348,12 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 #, fuzzy
 msgid "Update lists…"
 msgstr "Actualitza les llistes"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 #, fuzzy
 msgid "Updates"
 msgstr "Actualitza les llistes"
@@ -354,13 +363,13 @@ msgstr "Actualitza les llistes"
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versió"
 
@@ -374,24 +383,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Esperant que s'acabi l'ordre..."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "desconegut"
 

--- a/applications/luci-app-opkg/po/cs/opkg.po
+++ b/applications/luci-app-opkg/po/cs/opkg.po
@@ -17,7 +17,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Akce"
 
@@ -29,7 +34,7 @@ msgstr "Povolit přepsání souborů konfliktních balíčků"
 msgid "Automatically remove unused dependencies"
 msgstr "Automatické odstranění nepoužívaných závislostí"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "K dispozici"
 
@@ -53,11 +58,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Prázdný"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Nakonfigurujte opkg…"
 
@@ -67,7 +72,7 @@ msgstr "Závislosti"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Popis"
 
@@ -75,7 +80,7 @@ msgstr "Popis"
 msgid "Details for package <em>%h</em>"
 msgstr "Podrobnosti o balíčku <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -83,15 +88,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Zahodit"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Zobrazit balíčky překladů LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Zobrazit všechny dostupné balíčky překladů"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -103,7 +108,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Zobrazuji %d-%d z %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Stáhnout a nainstalovat balíček"
 
@@ -115,7 +120,7 @@ msgstr "Chyby"
 msgid "Executing package manager"
 msgstr "Spuštění správce balíčků"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtr"
 
@@ -123,7 +128,7 @@ msgstr "Filtr"
 msgid "Grant access to opkg management"
 msgstr "Udělit přístup ke správě opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Skrýt všechny balíčky překladů"
 
@@ -133,13 +138,17 @@ msgstr "Skrýt všechny balíčky překladů"
 msgid "Install"
 msgstr "Instalovat"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Instalovat také navrhované balíčky překladů"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Instalováno"
 
@@ -177,8 +186,8 @@ msgstr "Ručně nainstalujte balíček"
 msgid "Needs upgrade"
 msgstr "Vyžaduje upgrade"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Další stránka"
 
@@ -202,7 +211,7 @@ msgstr "Není dostupný"
 msgid "Not installed"
 msgstr "Není instalován"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -212,16 +221,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Konfigurace OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Název balíčku"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Název balíčku nebo adresa URLL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Předchozí stránka"
 
@@ -282,7 +291,7 @@ msgstr "Ukládání konfiguračních dat…"
 msgid "Size"
 msgstr "Velikost"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Velikost (.ipk)"
 
@@ -323,7 +332,7 @@ msgstr ""
 "Verze balíčku <em>%h</em> není kompatibilní, vyžaduje %s, ale k dispozici je "
 "pouze %s."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Začněte psát pro filtrování…"
 
@@ -339,11 +348,11 @@ msgstr "Nelze přečíst %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Nelze uložit %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Aktualizovat seznamy…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Aktualizace"
 
@@ -352,13 +361,13 @@ msgstr "Aktualizace"
 msgid "Upgrade…"
 msgstr "Přechod na novější verzi…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Nahrát balíček…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Verze"
 
@@ -371,24 +380,24 @@ msgstr "Verze nekompatibilní"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Čekání na dokončení příkazu <em>opkg %h</em> …"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "vše"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtrovaný"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "žádný"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "neznámý"
 

--- a/applications/luci-app-opkg/po/da/opkg.po
+++ b/applications/luci-app-opkg/po/da/opkg.po
@@ -14,7 +14,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Handlinger"
 
@@ -26,7 +31,7 @@ msgstr "Tillad overskrivning af modstridende pakkefiler"
 msgid "Automatically remove unused dependencies"
 msgstr "Fjern automatisk ubrugte dependencies"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Tilgængelig"
 
@@ -51,11 +56,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuller"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Ryd"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Konfigurer opkg…"
 
@@ -65,7 +70,7 @@ msgstr "Dependencies"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Beskrivelse"
 
@@ -73,7 +78,7 @@ msgstr "Beskrivelse"
 msgid "Details for package <em>%h</em>"
 msgstr "Detaljer for pakke <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -81,15 +86,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Afvis"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Vis LuCI-oversættelsespakker"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Vis alle tilgængelige oversættelsespakker"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -101,7 +106,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Viser %d-%d af %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Download og installer pakken"
 
@@ -113,7 +118,7 @@ msgstr "Fejl"
 msgid "Executing package manager"
 msgstr "Udførelse af pakkeadministrator"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filter"
 
@@ -121,7 +126,7 @@ msgstr "Filter"
 msgid "Grant access to opkg management"
 msgstr "Giv adgang til opkg administration"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Skjul alle oversættelsespakker"
 
@@ -131,13 +136,17 @@ msgstr "Skjul alle oversættelsespakker"
 msgid "Install"
 msgstr "Installer"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Installer også de foreslåede oversættelsespakker"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Installeret"
 
@@ -175,8 +184,8 @@ msgstr "Installer pakke manuelt"
 msgid "Needs upgrade"
 msgstr "Skal opgraderes"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Næste side"
 
@@ -200,7 +209,7 @@ msgstr "Ikke tilgængelig"
 msgid "Not installed"
 msgstr "Ikke installeret"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -210,16 +219,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "OPKG konfiguration"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Pakkenavn"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Pakkenavn eller URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Forrige side"
 
@@ -280,7 +289,7 @@ msgstr "Gemmer konfigurationsdata…"
 msgid "Size"
 msgstr "Størrelse"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Størrelse (.ipk)"
 
@@ -322,7 +331,7 @@ msgstr ""
 "repository version af pakken <em>%h</em> er ikke kompatibel, kræver %s, men "
 "kun %s er tilgængelig."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Skriv for at filtrere…"
 
@@ -338,11 +347,11 @@ msgstr "Kan ikke læse %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Kan ikke gemme %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Opdater lister…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Opdateringer"
 
@@ -351,13 +360,13 @@ msgstr "Opdateringer"
 msgid "Upgrade…"
 msgstr "Opgrader…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Upload pakke…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Version"
 
@@ -370,24 +379,24 @@ msgstr "Version inkompatibel"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Venter på at kommandoen <em>opkg %h</em> afsluttes…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "alle"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtreret"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "ingen"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "ukendt"
 

--- a/applications/luci-app-opkg/po/de/opkg.po
+++ b/applications/luci-app-opkg/po/de/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s benutzt (%1024mB von %1024mB benutzt, %1024mB frei)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Aktionen"
 
@@ -30,7 +35,7 @@ msgstr "Überschreiben von Dateien bei Konflikten mit anderen Paketen erlauben"
 msgid "Automatically remove unused dependencies"
 msgstr "Unbenutzte Abhängigkeiten automatisch entfernen"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Verfügbar"
 
@@ -56,11 +61,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Zurücksetzen"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Konfiguriere opkg…"
 
@@ -70,7 +75,7 @@ msgstr "Abhängigkeiten"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Beschreibung"
 
@@ -78,7 +83,7 @@ msgstr "Beschreibung"
 msgid "Details for package <em>%h</em>"
 msgstr "Details für Paket <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Plattenplatz"
 
@@ -86,15 +91,15 @@ msgstr "Plattenplatz"
 msgid "Dismiss"
 msgstr "Verwerfen"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "LuCI Sprachpakete anzeigen"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Alle verfügbaren Sprachpakete anzeigen"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -106,7 +111,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Einträge %d-%d von %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Paket herunterladen und installieren"
 
@@ -118,7 +123,7 @@ msgstr "Fehler"
 msgid "Executing package manager"
 msgstr "Paketmanager ausführen"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filter"
 
@@ -126,7 +131,7 @@ msgstr "Filter"
 msgid "Grant access to opkg management"
 msgstr "Zugriff auf die opkg-Verwaltung gewähren"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Alle Sprachpakete ausblenden"
 
@@ -136,13 +141,17 @@ msgstr "Alle Sprachpakete ausblenden"
 msgid "Install"
 msgstr "Installieren"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Vorgeschlagene Sprachpakete auch installieren"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Installiert"
 
@@ -181,8 +190,8 @@ msgstr "Paket manuell installieren"
 msgid "Needs upgrade"
 msgstr "Aktualisierung benötigt"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Nächste Seite"
 
@@ -206,7 +215,7 @@ msgstr "Nicht verfügbar"
 msgid "Not installed"
 msgstr "Nicht installiert"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -216,16 +225,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "OPKG-Konfiguration"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Paketname"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Paketname oder URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Vorige Seite"
 
@@ -287,7 +296,7 @@ msgstr "Speichere Konfigurationsdaten…"
 msgid "Size"
 msgstr "Größe"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Größe (.ipk)"
 
@@ -332,7 +341,7 @@ msgstr ""
 "Die Repository-Version von Paket <em>%h</em> ist nicht kompatibel, benötige "
 "Version %s aber nur %s ist verfügbar."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Tippen zum Filtern…"
 
@@ -348,11 +357,11 @@ msgstr "Kann %s nicht lesen: %s"
 msgid "Unable to save %s: %s"
 msgstr "%s kann nicht gespeichert werden: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Listen aktualisieren…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Aktualisierungen"
 
@@ -361,13 +370,13 @@ msgstr "Aktualisierungen"
 msgid "Upgrade…"
 msgstr "Aktualisieren…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Paket hochladen…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Version"
 
@@ -380,24 +389,24 @@ msgstr "Version inkompatibel"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Warte auf das <em>opkg %h</em> Kommando…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "alle"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "gefiltert"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "keine"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "unbekannt"
 

--- a/applications/luci-app-opkg/po/el/opkg.po
+++ b/applications/luci-app-opkg/po/el/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Ενέργειες"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Διαθέσιμο"
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Ακύρωση"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 #, fuzzy
 msgid "Configure opkg…"
 msgstr "Παραμετροποίηση"
@@ -65,7 +70,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Περιγραφή"
 
@@ -73,7 +78,7 @@ msgstr "Περιγραφή"
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -81,15 +86,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -99,7 +104,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Κατέβασμα και εγκατάσταση πακέτου"
 
@@ -112,7 +117,7 @@ msgstr "Σφάλμα"
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Φίλτρο"
 
@@ -120,7 +125,7 @@ msgstr "Φίλτρο"
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -130,13 +135,17 @@ msgstr ""
 msgid "Install"
 msgstr "Εγκατάσταση"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 #, fuzzy
 msgid "Installed"
 msgstr "Εγκατάσταση"
@@ -176,8 +185,8 @@ msgstr "Κατέβασμα και εγκατάσταση πακέτου"
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -204,7 +213,7 @@ msgstr "Διαθέσιμο Συνολικά"
 msgid "Not installed"
 msgstr "Εγκατάσταση"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "Εντάξει"
 
@@ -215,17 +224,17 @@ msgstr "Εντάξει"
 msgid "OPKG Configuration"
 msgstr "Παραμετροποίηση OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Όνομα πακέτου"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 #, fuzzy
 msgid "Package name or URL…"
 msgstr "Όνομα πακέτου"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -286,7 +295,7 @@ msgstr "Παραμετροποίηση Συσκευής"
 msgid "Size"
 msgstr "Μέγεθος"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -323,7 +332,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -339,11 +348,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -352,13 +361,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Έκδοση"
 
@@ -371,24 +380,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr ""
 

--- a/applications/luci-app-opkg/po/en/opkg.po
+++ b/applications/luci-app-opkg/po/en/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr ""
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr ""
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancel"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr ""
 
@@ -64,7 +69,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr ""
 
@@ -72,7 +77,7 @@ msgstr ""
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -80,15 +85,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -98,7 +103,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr ""
 
@@ -110,7 +115,7 @@ msgstr ""
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr ""
 
@@ -118,7 +123,7 @@ msgstr ""
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -128,13 +133,17 @@ msgstr ""
 msgid "Install"
 msgstr ""
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr ""
 
@@ -170,8 +179,8 @@ msgstr ""
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -195,7 +204,7 @@ msgstr ""
 msgid "Not installed"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr ""
 
@@ -205,16 +214,16 @@ msgstr ""
 msgid "OPKG Configuration"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -274,7 +283,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -311,7 +320,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -327,11 +336,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -340,13 +349,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Version"
 
@@ -359,24 +368,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr ""
 

--- a/applications/luci-app-opkg/po/es/opkg.po
+++ b/applications/luci-app-opkg/po/es/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s usados (%1024mB usados de %1024mB, %1024mB libres)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Acciones"
 
@@ -30,7 +35,7 @@ msgstr "Permitir sobrescribir archivos de paquetes en conflicto"
 msgid "Automatically remove unused dependencies"
 msgstr "Eliminar automáticamente las dependencias no utilizadas"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Disponible"
 
@@ -55,11 +60,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Limpiar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Configurar opkg…"
 
@@ -69,7 +74,7 @@ msgstr "Dependencias"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Descripción"
 
@@ -77,7 +82,7 @@ msgstr "Descripción"
 msgid "Details for package <em>%h</em>"
 msgstr "Detalles para el paquete <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Espacio del disco"
 
@@ -85,15 +90,15 @@ msgstr "Espacio del disco"
 msgid "Dismiss"
 msgstr "Descartar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Mostrar paquetes de traducción de LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Mostrar todos los paquetes de traducción disponibles"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -105,7 +110,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Mostrando %d-%d de %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Descargar e instalar paquete"
 
@@ -117,7 +122,7 @@ msgstr "Errores"
 msgid "Executing package manager"
 msgstr "Ejecutando el gestor de paquetes"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtrar"
 
@@ -125,7 +130,7 @@ msgstr "Filtrar"
 msgid "Grant access to opkg management"
 msgstr "Conceder acceso a la gestión de opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Ocultar todos los paquetes de traducción"
 
@@ -135,13 +140,17 @@ msgstr "Ocultar todos los paquetes de traducción"
 msgid "Install"
 msgstr "Instalar"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Instalar también los paquetes de traducción sugeridos"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Instalado"
 
@@ -179,8 +188,8 @@ msgstr "Instalar manualmente el paquete"
 msgid "Needs upgrade"
 msgstr "Necesita actualización"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Página siguiente"
 
@@ -204,7 +213,7 @@ msgstr "No disponible"
 msgid "Not installed"
 msgstr "No instalado"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "Aceptar"
 
@@ -214,16 +223,16 @@ msgstr "Aceptar"
 msgid "OPKG Configuration"
 msgstr "Configuración de OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Nombre del paquete"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Nombre de paquete o URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Página anterior"
 
@@ -285,7 +294,7 @@ msgstr "Guardando datos de configuración…"
 msgid "Size"
 msgstr "Tamaño"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Tamaño (.ipk)"
 
@@ -328,7 +337,7 @@ msgstr ""
 "La versión de repositorio del paquete <em>%h</em> no es compatible, requiere "
 "%s pero solo %s está disponible."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Escriba para filtrar…"
 
@@ -344,11 +353,11 @@ msgstr "No se puede leer %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "No se puede guardar %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Actualizar listas…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Actualizaciones"
 
@@ -357,13 +366,13 @@ msgstr "Actualizaciones"
 msgid "Upgrade…"
 msgstr "Actualizar…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Subir paquete…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versión"
 
@@ -376,24 +385,24 @@ msgstr "Versión incompatible"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Esperando a que el comando <em>opkg %h</em> finalice…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "todos"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtrado"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "ninguno"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "desconocido"
 

--- a/applications/luci-app-opkg/po/fa/opkg.po
+++ b/applications/luci-app-opkg/po/fa/opkg.po
@@ -14,7 +14,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "اقدام ها"
 
@@ -26,7 +31,7 @@ msgstr "بازنویسی فایل های بسته متضاد را مجاز کن�
 msgid "Automatically remove unused dependencies"
 msgstr "حذف اتوماتیک پیش نیازهای بدون استفاده"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "در دسترس"
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "لغو"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "پاک کردن"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "پیکربندی opkg…"
 
@@ -64,7 +69,7 @@ msgstr "وابستگی ها"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "شرح"
 
@@ -72,7 +77,7 @@ msgstr "شرح"
 msgid "Details for package <em>%h</em>"
 msgstr "جزئیات مربوط به بسته بندی <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -80,15 +85,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "رد کردن"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "نمایش بسته های ترجمه LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "نمایش همه موارد موجود در بسته های ترجمه"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -99,7 +104,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "نمایش %d-%d از %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "دانلود و نصب بسته"
 
@@ -111,7 +116,7 @@ msgstr "خطاها"
 msgid "Executing package manager"
 msgstr "در حال اجرای مدیر بسته"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "فیلتر"
 
@@ -119,7 +124,7 @@ msgstr "فیلتر"
 msgid "Grant access to opkg management"
 msgstr "اعطای دسترسی به مدیریت opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "پنهان کردن تمام بسته های ترجمه"
 
@@ -129,13 +134,17 @@ msgstr "پنهان کردن تمام بسته های ترجمه"
 msgid "Install"
 msgstr "نصب"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "بسته های ترجمه پیشنهادی را نیز نصب کنید"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "نصب شد"
 
@@ -173,8 +182,8 @@ msgstr "بسته را به صورت دستی نصب کنید"
 msgid "Needs upgrade"
 msgstr "نیاز به ارتقا دارد"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "صفحه بعد"
 
@@ -198,7 +207,7 @@ msgstr "در دسترس نیست"
 msgid "Not installed"
 msgstr "نصب نشده است"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "تایید"
 
@@ -208,16 +217,16 @@ msgstr "تایید"
 msgid "OPKG Configuration"
 msgstr "پیکربندی OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "نام بسته"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "نام بسته یا نشانی وب…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "صفحه قبلی"
 
@@ -277,7 +286,7 @@ msgstr "در حال ذخیره داده های پیکربندی…"
 msgid "Size"
 msgstr "اندازه"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "اندازه (ipk.)"
 
@@ -317,7 +326,7 @@ msgid ""
 msgstr ""
 "نسخه مخزن بسته <em>%h</em> سازگار نیست، به %s نیاز دارد اما فقط %s موجود است."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "برای فیلتر کردن تایپ کنید …"
 
@@ -333,11 +342,11 @@ msgstr "قادر به خواندن %s: %s نیست"
 msgid "Unable to save %s: %s"
 msgstr "قادر به ذخیره %s: %s نیست"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "به روز رسانی لیست ها…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "به روز رسانی ها"
 
@@ -346,13 +355,13 @@ msgstr "به روز رسانی ها"
 msgid "Upgrade…"
 msgstr "ارتقا…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "آپلود بسته…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "نسخه"
 
@@ -365,24 +374,24 @@ msgstr "نسخه ناسازگار است"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "در انتظار تکمیل شدن دستور <em>opkg %h</em>…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "همه"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "فیلتر شده"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "هیچکدام"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "ناشناخته"
 

--- a/applications/luci-app-opkg/po/fi/opkg.po
+++ b/applications/luci-app-opkg/po/fi/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Toiminnot"
 
@@ -30,7 +35,7 @@ msgstr "Salli ristiriitoja aiheuttavien pakettien ylikirjoittaminen"
 msgid "Automatically remove unused dependencies"
 msgstr "Poista tarpeettomat riippuvuudet automaattisesti"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Saatavilla"
 
@@ -55,11 +60,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Peruuta"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Tyhjennä"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Määritä opkg…"
 
@@ -69,7 +74,7 @@ msgstr "Riippuvuudet"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Kuvaus"
 
@@ -77,7 +82,7 @@ msgstr "Kuvaus"
 msgid "Details for package <em>%h</em>"
 msgstr "Paketin <em>%h</em> tiedot"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -85,15 +90,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Hylkää"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Näytä LuCI:n kielikäännöspaketit"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Näytä kaikki saatavilla olevat kielikäännöspaketit"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -103,7 +108,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Näytetään %d-%d / %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Lataa ja asenna paketti"
 
@@ -115,7 +120,7 @@ msgstr "Virheet"
 msgid "Executing package manager"
 msgstr "Suoritetaan paketinhallintaa"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Suodatin"
 
@@ -123,7 +128,7 @@ msgstr "Suodatin"
 msgid "Grant access to opkg management"
 msgstr "Salli pääsy pakettiasennusten hallintaan (opkg)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Piilota kaikki kielikäännöspaketit"
 
@@ -133,13 +138,17 @@ msgstr "Piilota kaikki kielikäännöspaketit"
 msgid "Install"
 msgstr "Asenna"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Asenna myös ehdotetut kielikäännöspaketit"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Asennettu"
 
@@ -177,8 +186,8 @@ msgstr "Asenna paketti käsin"
 msgid "Needs upgrade"
 msgstr "Tarvitsee päivityksen"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Seuraava sivu"
 
@@ -202,7 +211,7 @@ msgstr "Ei saatavilla"
 msgid "Not installed"
 msgstr "Ei asennettu"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -212,16 +221,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "OPKG-määritys"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Paketin nimi"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Paketin nimi tai URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Edellinen sivu"
 
@@ -283,7 +292,7 @@ msgstr "Tallennetaan määritystietoja…"
 msgid "Size"
 msgstr "Koko"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Koko (.ipk)"
 
@@ -326,7 +335,7 @@ msgstr ""
 "Ohjelmistolähteen versio paketista <em>%h</em> ei ole yhteensopiva, "
 "vaaditaan %s mutta vain %s on saatavilla."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Kirjoita suodattaaksesi…"
 
@@ -342,11 +351,11 @@ msgstr "Ei voida lukea %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Ei voida tallentaa %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Päivitä luettelot…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Päivitykset"
 
@@ -355,13 +364,13 @@ msgstr "Päivitykset"
 msgid "Upgrade…"
 msgstr "Päivitys…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Lähetä paketti…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versio"
 
@@ -374,24 +383,24 @@ msgstr "Versio ei ole yhteensopiva"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Odotetaan <em>opkg %h</em> -komennon valmistumista…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "kaikki"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "tuntematon"
 

--- a/applications/luci-app-opkg/po/fr/opkg.po
+++ b/applications/luci-app-opkg/po/fr/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Actions"
 
@@ -30,7 +35,7 @@ msgstr "Autoriser l'écrasement des fichiers en conflit du package"
 msgid "Automatically remove unused dependencies"
 msgstr "Supprimez automatiquement les dépendances inutilisées"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Disponible"
 
@@ -55,11 +60,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annuler"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Nettoyer"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Configuration opkg…"
 
@@ -69,7 +74,7 @@ msgstr "Dépendances"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Description"
 
@@ -77,7 +82,7 @@ msgstr "Description"
 msgid "Details for package <em>%h</em>"
 msgstr "Détails du package <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -85,15 +90,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Annuler"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Afficher les paquets de traduction LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Afficher tous les paquets de traduction disponibles"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -105,7 +110,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Affichage de %d-%d sur %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Télécharge et installe le paquet"
 
@@ -117,7 +122,7 @@ msgstr "Erreurs"
 msgid "Executing package manager"
 msgstr "Exécution du gestionnaire de packages"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtrer"
 
@@ -125,7 +130,7 @@ msgstr "Filtrer"
 msgid "Grant access to opkg management"
 msgstr "Permettre l'accès complet à la gestion des opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Masquer tous les paquets de traduction"
 
@@ -135,13 +140,17 @@ msgstr "Masquer tous les paquets de traduction"
 msgid "Install"
 msgstr "Installer"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Installer également les paquets de traduction suggérés"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Installé"
 
@@ -179,8 +188,8 @@ msgstr "Installer manuellement le package"
 msgid "Needs upgrade"
 msgstr "Besoin de mise à niveau"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Page suivante"
 
@@ -204,7 +213,7 @@ msgstr "Indisponible"
 msgid "Not installed"
 msgstr "Pas installé"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -214,16 +223,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Configuration OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Nom du paquet"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Nom ou URL du package…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Page précédente"
 
@@ -285,7 +294,7 @@ msgstr "Enregistrement des données de configuration…"
 msgid "Size"
 msgstr "Taille"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Taille (.ipk)"
 
@@ -329,7 +338,7 @@ msgstr ""
 "La version du référentiel du package <em>%h</em> n'est pas compatible, "
 "nécessite %s mais seulement %s est disponible."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Type à filtrer…"
 
@@ -345,11 +354,11 @@ msgstr "Impossible de lire %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Impossible d'enregistrer %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Mettre à jour les listes…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Mises à jour"
 
@@ -358,13 +367,13 @@ msgstr "Mises à jour"
 msgid "Upgrade…"
 msgstr "Mettre à jour…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Télécharger le package…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Version"
 
@@ -377,24 +386,24 @@ msgstr "Version incompatible"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "En attente de la fin de la commande <em>opkg %h</em>…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "tout"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtrée"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "aucun"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "inconnu"
 

--- a/applications/luci-app-opkg/po/he/opkg.po
+++ b/applications/luci-app-opkg/po/he/opkg.po
@@ -16,7 +16,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "פעולות"
 
@@ -28,7 +33,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr "להסיר אוטומטית תלויות שאינן בשימוש"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "זמין"
 
@@ -48,11 +53,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "ביטול"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "הגדר opkg…"
 
@@ -62,7 +67,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "תיאור"
 
@@ -70,7 +75,7 @@ msgstr "תיאור"
 msgid "Details for package <em>%h</em>"
 msgstr "פרטים על החבילה <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -78,15 +83,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "התעלמות"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -96,7 +101,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "מוצגים %d-%d מתוך %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "הורדת והתקנת חבילות"
 
@@ -108,7 +113,7 @@ msgstr "שגיאות"
 msgid "Executing package manager"
 msgstr "מנהל החבילות מופעל"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "מסנן"
 
@@ -116,7 +121,7 @@ msgstr "מסנן"
 msgid "Grant access to opkg management"
 msgstr "הענקת גישה לניהול opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -126,13 +131,17 @@ msgstr ""
 msgid "Install"
 msgstr "התקנה"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "מותקנת"
 
@@ -142,8 +151,8 @@ msgid ""
 "Installing packages from untrusted sources is a potential security risk! "
 "Really attempt to install <em>%h</em>?"
 msgstr ""
-"התקנת חבילות ממקורות מפוקפקים היא הזמנה לסיכון אבטחה! לנסות להתקין את "
-"<em>%h</em>?"
+"התקנת חבילות ממקורות מפוקפקים היא הזמנה לסיכון אבטחה! לנסות להתקין את <em>"
+"%h</em>?"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:288
 msgid "Install…"
@@ -170,8 +179,8 @@ msgstr "התקנת חבילה באופן ידני"
 msgid "Needs upgrade"
 msgstr "נדרש שדרוג"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "העמוד הבא"
 
@@ -195,7 +204,7 @@ msgstr "לא זמין"
 msgid "Not installed"
 msgstr "לא מותקן"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr ""
 
@@ -205,16 +214,16 @@ msgstr ""
 msgid "OPKG Configuration"
 msgstr "תצורת OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "שם החבילה"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "שם החבילה או URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -274,7 +283,7 @@ msgstr "שומר נתוני תצורה…"
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -311,7 +320,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -327,11 +336,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -340,13 +349,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "גרסה"
 
@@ -359,24 +368,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "לא ידוע"
 

--- a/applications/luci-app-opkg/po/hi/opkg.po
+++ b/applications/luci-app-opkg/po/hi/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "चाल-चलन"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr ""
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr ""
 
@@ -64,7 +69,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr ""
 
@@ -72,7 +77,7 @@ msgstr ""
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -80,15 +85,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -98,7 +103,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr ""
 
@@ -110,7 +115,7 @@ msgstr ""
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr ""
 
@@ -118,7 +123,7 @@ msgstr ""
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -128,13 +133,17 @@ msgstr ""
 msgid "Install"
 msgstr ""
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr ""
 
@@ -170,8 +179,8 @@ msgstr ""
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -195,7 +204,7 @@ msgstr ""
 msgid "Not installed"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr ""
 
@@ -205,16 +214,16 @@ msgstr ""
 msgid "OPKG Configuration"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -274,7 +283,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -311,7 +320,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -327,11 +336,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -340,13 +349,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr ""
 
@@ -359,24 +368,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr ""
 

--- a/applications/luci-app-opkg/po/hu/opkg.po
+++ b/applications/luci-app-opkg/po/hu/opkg.po
@@ -16,7 +16,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Műveletek"
 
@@ -28,7 +33,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr "Nem használt függőségek automatikus eltávolítása"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Elérhető"
 
@@ -53,11 +58,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Mégse"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Törlés"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Az opkg beállítása…"
 
@@ -67,7 +72,7 @@ msgstr "Függőségek"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Leírás"
 
@@ -75,7 +80,7 @@ msgstr "Leírás"
 msgid "Details for package <em>%h</em>"
 msgstr "A(z) <em>%h</em> csomag részletei"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -83,15 +88,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Eltüntetés"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -101,7 +106,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "%d-%d / %d megjelenítése"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Csomag letöltése és telepítése"
 
@@ -113,7 +118,7 @@ msgstr "Hibák"
 msgid "Executing package manager"
 msgstr "Csomagkezelő végrehajtása"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Szűrő"
 
@@ -121,7 +126,7 @@ msgstr "Szűrő"
 msgid "Grant access to opkg management"
 msgstr "Hozzáférés megadása az opkg kezelőnek"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -131,13 +136,17 @@ msgstr ""
 msgid "Install"
 msgstr "Telepítés"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Telepítve"
 
@@ -176,8 +185,8 @@ msgstr "Csomag kézi telepítése"
 msgid "Needs upgrade"
 msgstr "Frissítés szükséges"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Következő oldal"
 
@@ -201,7 +210,7 @@ msgstr "Nem érhető el"
 msgid "Not installed"
 msgstr "Nincs telepítve"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "Rendben"
 
@@ -211,16 +220,16 @@ msgstr "Rendben"
 msgid "OPKG Configuration"
 msgstr "OPKG beállításai"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Csomagnév"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Csomagnév vagy URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Előző oldal"
 
@@ -281,7 +290,7 @@ msgstr "Beállítási adatok mentése…"
 msgid "Size"
 msgstr "Méret"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Méret (.ipk)"
 
@@ -323,7 +332,7 @@ msgstr ""
 "A(z) <em>%h</em> csomag tárolóban lévő verziója nem megfelelő. %s szükséges, "
 "de csak %s érhető el."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Gépeljen a szűréshez…"
 
@@ -339,11 +348,11 @@ msgstr "Nem sikerült beolvasni: %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Nem sikerült elmenteni: %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Listák frissítése…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Frissítések"
 
@@ -352,13 +361,13 @@ msgstr "Frissítések"
 msgid "Upgrade…"
 msgstr "Frissítés…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Csomag feltöltése…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Verzió"
 
@@ -371,24 +380,24 @@ msgstr "Nem megfelelő verzió"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Várakozás az <em>opkg %h</em> parancs befejeződésére…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "ismeretlen"
 

--- a/applications/luci-app-opkg/po/it/opkg.po
+++ b/applications/luci-app-opkg/po/it/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s usato (%1024mB usati di %1024mB, %1024mB liberi)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Azioni"
 
@@ -30,7 +35,7 @@ msgstr "Consenti la sovrascrittura dei pacchetti in conflitto"
 msgid "Automatically remove unused dependencies"
 msgstr "Rimuovi automaticamente le dipendenze inutilizzate"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Disponibili"
 
@@ -55,11 +60,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Annulla"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Cancella"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Configura opkg…"
 
@@ -69,7 +74,7 @@ msgstr "Dipendenze"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Descrizione"
 
@@ -77,7 +82,7 @@ msgstr "Descrizione"
 msgid "Details for package <em>%h</em>"
 msgstr "Dettagli per il pacchetto <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Spazio su disco"
 
@@ -85,15 +90,15 @@ msgstr "Spazio su disco"
 msgid "Dismiss"
 msgstr "Chiudi"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Mostra pacchetti traduzione di LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Mostra tutti i pacchetti traduzione disponibili"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -105,7 +110,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Mostrando %d-%d di %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Scarica e installa il pacchetto"
 
@@ -117,7 +122,7 @@ msgstr "Errori"
 msgid "Executing package manager"
 msgstr "Esecuzione del gestore pacchetti"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtro"
 
@@ -125,7 +130,7 @@ msgstr "Filtro"
 msgid "Grant access to opkg management"
 msgstr "Concedi l'accesso alla gestione di opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Nascondi tutti i pacchetti di traduzione"
 
@@ -135,13 +140,17 @@ msgstr "Nascondi tutti i pacchetti di traduzione"
 msgid "Install"
 msgstr "Installa"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Installa anche i pacchetti di traduzione suggeriti"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Installati"
 
@@ -179,8 +188,8 @@ msgstr "Installa pacchetto manualmente"
 msgid "Needs upgrade"
 msgstr "Richiede aggiornamento"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Pagina successiva"
 
@@ -204,7 +213,7 @@ msgstr "Non disponibile"
 msgid "Not installed"
 msgstr "Non installato"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -214,16 +223,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Configurazione OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Nome pacchetto"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Nome pacchetto o URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Pagina precedente"
 
@@ -285,7 +294,7 @@ msgstr "Salvataggio dati di configurazione…"
 msgid "Size"
 msgstr "Dimensione"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Dimensione (.ipk)"
 
@@ -327,7 +336,7 @@ msgstr ""
 "La versione del repository del pacchetto <em>%h</em> non è compatibile, "
 "richiede %s ma è disponibile solo %s."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Scrivi per filtrare…"
 
@@ -343,11 +352,11 @@ msgstr "Impossibile leggere %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Impossibile salvare %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Aggiorna liste…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Aggiornamenti"
 
@@ -356,13 +365,13 @@ msgstr "Aggiornamenti"
 msgid "Upgrade…"
 msgstr "Aggiorna…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Carica pacchetto…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versione"
 
@@ -375,24 +384,24 @@ msgstr "Versione incompatibile"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "In attesa del completamento del comando <em>opkg %h</em>…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "tutto"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtrato"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "nessuno"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "sconosciuto"
 

--- a/applications/luci-app-opkg/po/ja/opkg.po
+++ b/applications/luci-app-opkg/po/ja/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "操作"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr "使用されない依存パッケージを自動的に削除"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "利用可能"
 
@@ -54,11 +59,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "クリア"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "opkg設定…"
 
@@ -68,7 +73,7 @@ msgstr "依存関係"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "説明"
 
@@ -76,7 +81,7 @@ msgstr "説明"
 msgid "Details for package <em>%h</em>"
 msgstr "<em>%h</em> パッケージの詳細"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -84,15 +89,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "閉じる"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -102,7 +107,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "%d - %d 個を表示中（全 %d 個）"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "パッケージのダウンロードとインストール"
 
@@ -114,7 +119,7 @@ msgstr "エラー"
 msgid "Executing package manager"
 msgstr "パッケージマネージャーが実行中"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "フィルター"
 
@@ -122,7 +127,7 @@ msgstr "フィルター"
 msgid "Grant access to opkg management"
 msgstr "opkg 管理へのアクセスを許可"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -132,13 +137,17 @@ msgstr ""
 msgid "Install"
 msgstr "インストール"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "インストール済"
 
@@ -176,8 +185,8 @@ msgstr "パッケージの手動インストール"
 msgid "Needs upgrade"
 msgstr "要アップグレード"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "次のページ"
 
@@ -201,7 +210,7 @@ msgstr "利用不可"
 msgid "Not installed"
 msgstr "未インストール"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -211,16 +220,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "OPKG 設定"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "パッケージ名"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "パッケージ名または URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "前のページ"
 
@@ -282,7 +291,7 @@ msgstr "設定データを保存中…"
 msgid "Size"
 msgstr "サイズ"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "サイズ (.ipk)"
 
@@ -323,7 +332,7 @@ msgstr ""
 "<em>%h</em> パッケージのリポジトリ バージョンは互換性がありません。 %s が必要"
 "ですが、 %s のみ利用可能です。"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "検索…"
 
@@ -339,11 +348,11 @@ msgstr "%s を読み取れません: %s"
 msgid "Unable to save %s: %s"
 msgstr "%s を保存できません: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "リストを更新…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "アップデート"
 
@@ -352,13 +361,13 @@ msgstr "アップデート"
 msgid "Upgrade…"
 msgstr "アップグレード…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "パッケージをアップロード…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "バージョン"
 
@@ -371,24 +380,24 @@ msgstr "互換性の無いバージョン"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "<em>opkg %h</em> コマンドが完了するのを待っています…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "不明"
 

--- a/applications/luci-app-opkg/po/ko/opkg.po
+++ b/applications/luci-app-opkg/po/ko/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "관리 도구"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "사용 가능"
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "취소"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "opkg 설정…"
 
@@ -64,7 +69,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "설명"
 
@@ -72,7 +77,7 @@ msgstr "설명"
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -80,15 +85,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "닫기"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -98,7 +103,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "패키지 다운로드 후 설치"
 
@@ -110,7 +115,7 @@ msgstr ""
 msgid "Executing package manager"
 msgstr "패키지 관리자 실행 중"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "필터"
 
@@ -118,7 +123,7 @@ msgstr "필터"
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -128,13 +133,17 @@ msgstr ""
 msgid "Install"
 msgstr "설치"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "설치됨"
 
@@ -171,8 +180,8 @@ msgstr "패키지 다운로드 후 설치"
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -199,7 +208,7 @@ msgstr "총 이용 가능한 양"
 msgid "Not installed"
 msgstr "연결되지 않음"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr ""
 
@@ -210,16 +219,16 @@ msgstr ""
 msgid "OPKG Configuration"
 msgstr "OPKG-설정"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "패키지 이름"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "패키지 이름 또는 URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -280,7 +289,7 @@ msgstr "장치 설정 저장중…"
 msgid "Size"
 msgstr "크기"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "크기 (.ipk)"
 
@@ -317,7 +326,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -333,11 +342,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -346,13 +355,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "버전"
 
@@ -366,24 +375,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "실행한 명령이 끝나기를 기다리는 중입니다..."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "알 수 없는"
 

--- a/applications/luci-app-opkg/po/lt/opkg.po
+++ b/applications/luci-app-opkg/po/lt/opkg.po
@@ -17,7 +17,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s naudota (%1024mB naudojama iš %1024mB, %1024mB laisva)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Veiksmai"
 
@@ -29,7 +34,7 @@ msgstr "Leisti perrašymą konfliktuojamų paketų failus"
 msgid "Automatically remove unused dependencies"
 msgstr "Automatiškai pašalinti nenaudojamas priklausomybes"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Pasiekiamas"
 
@@ -54,11 +59,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Atšaukti"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Išvalyti"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Konfigūruoti „opkg“…"
 
@@ -68,7 +73,7 @@ msgstr "Priklausomybės"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Aprašymas"
 
@@ -76,7 +81,7 @@ msgstr "Aprašymas"
 msgid "Details for package <em>%h</em>"
 msgstr "Išsami informacija paketui <em>„%h“</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Disko talpa/vietovė"
 
@@ -84,15 +89,15 @@ msgstr "Disko talpa/vietovė"
 msgid "Dismiss"
 msgstr "Nepaisyti"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Rodyti „LuCI“ vertimo/kalbos paketus"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Rodyti visus galimus vertimo/kalbos paketus"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -104,7 +109,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Rodoma %d-%d iš %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Atsisiųsti ir įdiegti paketą"
 
@@ -116,7 +121,7 @@ msgstr "Klaidos"
 msgid "Executing package manager"
 msgstr "Paleidžiama paketų tvarkyklė"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtras/Filtruoti"
 
@@ -124,7 +129,7 @@ msgstr "Filtras/Filtruoti"
 msgid "Grant access to opkg management"
 msgstr "Suteikti prieigą „opkg management“"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Slėpti visus vertimo/kalbos paketus"
 
@@ -134,13 +139,17 @@ msgstr "Slėpti visus vertimo/kalbos paketus"
 msgid "Install"
 msgstr "Įdiegti"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Įdiegti pritaikytus pasiūlomus vertimo/kalbos paketus"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Įdiegta"
 
@@ -178,8 +187,8 @@ msgstr "Savarankiškai įdiegti paketą"
 msgid "Needs upgrade"
 msgstr "Reikia aukštutinio atnaujinimo"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Kitas puslapis"
 
@@ -203,7 +212,7 @@ msgstr "Nėra pasiekiama"
 msgid "Not installed"
 msgstr "Nėra įdiegta"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "Gerai"
 
@@ -213,16 +222,16 @@ msgstr "Gerai"
 msgid "OPKG Configuration"
 msgstr "„OPKG“ konfigūracija"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Paketo pavadinimas"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Paketo pavadinimas arba „URL – Saitas“…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Praeitas puslapis"
 
@@ -285,7 +294,7 @@ msgstr "Saugoma konfigūracijos duomenis…"
 msgid "Size"
 msgstr "Dydis"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Dydis („*.ipk“)"
 
@@ -329,7 +338,7 @@ msgstr ""
 "Atsisiuntimo vietovės paketo versija „<em>%h</em>“ nėra palaikomas/-a, nes "
 "reikalinga „%s“, bet tik „%s“ yra pasiekiamas."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Rašykite, kad filtruotumėte…"
 
@@ -345,11 +354,11 @@ msgstr "Negalima nuskaityti %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Negalima išsaugoti %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Atnaujinti sąrašus (Reikalingą)…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Atnaujinimai"
 
@@ -358,13 +367,13 @@ msgstr "Atnaujinimai"
 msgid "Upgrade…"
 msgstr "Aukštutinis atnaujinimas…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Įkelti paketą…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versija"
 
@@ -377,24 +386,24 @@ msgstr "Versija nesutampa/nepalaikoma"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Laukiama kol <em>„opkg %h“</em> komanda bus atlikta…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "Visi"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtruotas"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "Jokie"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "nežinoma"
 

--- a/applications/luci-app-opkg/po/mr/opkg.po
+++ b/applications/luci-app-opkg/po/mr/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "क्रिया"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr ""
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "रद्द करा"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr ""
 
@@ -64,7 +69,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "वर्णन"
 
@@ -72,7 +77,7 @@ msgstr "वर्णन"
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -80,15 +85,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "डिसमिस करा"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -98,7 +103,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr ""
 
@@ -110,7 +115,7 @@ msgstr ""
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "फिल्टर करा"
 
@@ -118,7 +123,7 @@ msgstr "फिल्टर करा"
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -128,13 +133,17 @@ msgstr ""
 msgid "Install"
 msgstr ""
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr ""
 
@@ -170,8 +179,8 @@ msgstr ""
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -195,7 +204,7 @@ msgstr ""
 msgid "Not installed"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr ""
 
@@ -205,16 +214,16 @@ msgstr ""
 msgid "OPKG Configuration"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -274,7 +283,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -311,7 +320,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -327,11 +336,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -340,13 +349,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr ""
 
@@ -359,24 +368,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr ""
 

--- a/applications/luci-app-opkg/po/ms/opkg.po
+++ b/applications/luci-app-opkg/po/ms/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Tindakkan"
 
@@ -30,7 +35,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Boleh didapati"
 
@@ -50,11 +55,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Batal"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 #, fuzzy
 msgid "Configure opkg…"
 msgstr "Konfigurasi"
@@ -65,7 +70,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Keterangan"
 
@@ -73,7 +78,7 @@ msgstr "Keterangan"
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -81,15 +86,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -99,7 +104,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Turun dan memasang pakej"
 
@@ -111,7 +116,7 @@ msgstr "Ralat"
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Penapis"
 
@@ -119,7 +124,7 @@ msgstr "Penapis"
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -129,13 +134,17 @@ msgstr ""
 msgid "Install"
 msgstr "Memasang"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 #, fuzzy
 msgid "Installed"
 msgstr "Memasang"
@@ -175,8 +184,8 @@ msgstr "Turun dan memasang pakej"
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -203,7 +212,7 @@ msgstr "(%s sedia)"
 msgid "Not installed"
 msgstr "Memasang"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "Baik"
 
@@ -214,17 +223,17 @@ msgstr "Baik"
 msgid "OPKG Configuration"
 msgstr "OPKG-Konfigurasi"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Nama pakej"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 #, fuzzy
 msgid "Package name or URL…"
 msgstr "Nama pakej"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -284,7 +293,7 @@ msgstr ""
 msgid "Size"
 msgstr "Saiz"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -321,7 +330,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -337,11 +346,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -350,13 +359,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versi"
 
@@ -369,24 +378,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "tidak diketahui"
 

--- a/applications/luci-app-opkg/po/nb_NO/opkg.po
+++ b/applications/luci-app-opkg/po/nb_NO/opkg.po
@@ -14,7 +14,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Handlinger"
 
@@ -26,7 +31,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr "Fjern ubrukte avhengigheter automatisk"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Tilgjengelig"
 
@@ -46,11 +51,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Tøm"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 #, fuzzy
 msgid "Configure opkg…"
 msgstr "Sett opp opkg…"
@@ -61,7 +66,7 @@ msgstr "Avhengigheter"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Beskrivelse"
 
@@ -69,7 +74,7 @@ msgstr "Beskrivelse"
 msgid "Details for package <em>%h</em>"
 msgstr "Detaljer for pakken <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -77,15 +82,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Avslå"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -95,7 +100,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Viser %d-%d av %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Last ned og installer pakken"
 
@@ -108,7 +113,7 @@ msgstr "Feil"
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 #, fuzzy
 msgid "Filter"
 msgstr "Filter"
@@ -117,7 +122,7 @@ msgstr "Filter"
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -127,13 +132,17 @@ msgstr ""
 msgid "Install"
 msgstr "Installer"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 #, fuzzy
 msgid "Installed"
 msgstr "Installer"
@@ -171,8 +180,8 @@ msgstr "Last ned og installer pakken"
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Neste side"
 
@@ -199,7 +208,7 @@ msgstr "Totalt Tilgjengelig"
 msgid "Not installed"
 msgstr "Ikke tilkoblet"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -210,16 +219,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "<abbr title=\"Open PacKaGe Management\">OPKG</abbr>-Konfigurasjon"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Pakkenavn"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Pakkenavn eller nettadresse…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -279,7 +288,7 @@ msgstr "Lagrer oppsettsdata…"
 msgid "Size"
 msgstr "Størrelse"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Størrelse (.ipk)"
 
@@ -316,7 +325,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -332,11 +341,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Oppdater lister…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 #, fuzzy
 msgid "Updates"
 msgstr "Oppdater lister"
@@ -346,13 +355,13 @@ msgstr "Oppdater lister"
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versjon"
 
@@ -365,24 +374,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Venter på at <em>opkg %h</em>-kommando fullføres…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "ukjent"
 

--- a/applications/luci-app-opkg/po/nl/opkg.po
+++ b/applications/luci-app-opkg/po/nl/opkg.po
@@ -13,7 +13,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr ""
 
@@ -25,7 +30,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr ""
 
@@ -45,11 +50,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr ""
 
@@ -59,7 +64,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr ""
 
@@ -67,7 +72,7 @@ msgstr ""
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -75,15 +80,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -93,7 +98,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr ""
 
@@ -105,7 +110,7 @@ msgstr ""
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr ""
 
@@ -113,7 +118,7 @@ msgstr ""
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -123,13 +128,17 @@ msgstr ""
 msgid "Install"
 msgstr ""
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr ""
 
@@ -165,8 +174,8 @@ msgstr ""
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -190,7 +199,7 @@ msgstr ""
 msgid "Not installed"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr ""
 
@@ -200,16 +209,16 @@ msgstr ""
 msgid "OPKG Configuration"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -269,7 +278,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -306,7 +315,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -322,11 +331,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -335,13 +344,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr ""
 
@@ -354,24 +363,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr ""
 

--- a/applications/luci-app-opkg/po/pl/opkg.po
+++ b/applications/luci-app-opkg/po/pl/opkg.po
@@ -19,7 +19,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "Zajęte: %s (zajęte: %1024mB z %1024mB, wolne: %1024mB)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Akcje"
 
@@ -31,7 +36,7 @@ msgstr "Zezwalaj na zastępowanie plików pakietów powodujących konflikty"
 msgid "Automatically remove unused dependencies"
 msgstr "Automatycznie usuwaj nieużywane zależności"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Dostępne"
 
@@ -56,11 +61,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Wyczyść"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Skonfiguruj opkg…"
 
@@ -70,7 +75,7 @@ msgstr "Zależności"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Opis"
 
@@ -78,7 +83,7 @@ msgstr "Opis"
 msgid "Details for package <em>%h</em>"
 msgstr "Szczegóły pakietu <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Miejsce na dysku"
 
@@ -86,15 +91,15 @@ msgstr "Miejsce na dysku"
 msgid "Dismiss"
 msgstr "Zamknij"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Wyświetl pakiety tłumaczeń LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Wyświetl wszystkie dostępne pakiety tłumaczeń"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -106,7 +111,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Wyświetlanie %d-%d z %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Pobierz i zainstaluj pakiet"
 
@@ -118,7 +123,7 @@ msgstr "Błędy"
 msgid "Executing package manager"
 msgstr "Uruchamianie menedżera pakietów"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtr"
 
@@ -126,7 +131,7 @@ msgstr "Filtr"
 msgid "Grant access to opkg management"
 msgstr "Udziel dostępu do zarządzania opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Ukryj wszystkie pakiety tłumaczeń"
 
@@ -136,13 +141,17 @@ msgstr "Ukryj wszystkie pakiety tłumaczeń"
 msgid "Install"
 msgstr "Instaluj"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Zainstaluj również sugerowane pakiety tłumaczeń"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Zainstalowane"
 
@@ -180,8 +189,8 @@ msgstr "Ręczna instalacja pakietu"
 msgid "Needs upgrade"
 msgstr "Wymaga aktualizacji"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Następna strona"
 
@@ -205,7 +214,7 @@ msgstr "Niedostępne"
 msgid "Not installed"
 msgstr "Nie zainstalowano"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -215,16 +224,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Konfiguracja OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Nazwa pakietu"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Nazwa pakietu lub adres URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Poprzednia strona"
 
@@ -285,7 +294,7 @@ msgstr "Zapisywanie danych konfiguracyjnych…"
 msgid "Size"
 msgstr "Rozmiar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Rozmiar (.ipk)"
 
@@ -329,7 +338,7 @@ msgstr ""
 "Wersja pakietu w repozytorium <em>%h</em> nie jest zgodna, wymaga %s ale "
 "tylko %s jest dostępna."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Wpisz, aby przefiltrować…"
 
@@ -345,11 +354,11 @@ msgstr "Nie można odczytać %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Nie można zapisać %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Aktualizuj listy…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Aktualizacje"
 
@@ -358,13 +367,13 @@ msgstr "Aktualizacje"
 msgid "Upgrade…"
 msgstr "Zaktualizuj…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Prześlij pakiet…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Wersja"
 
@@ -377,24 +386,24 @@ msgstr "Wersja niekompatybilna"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Oczekiwanie na <em>opkg %h</em> i wykonanie polecenia…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "wszystkie"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "przefiltrowane"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "żadne"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "nieznane"
 

--- a/applications/luci-app-opkg/po/pt/opkg.po
+++ b/applications/luci-app-opkg/po/pt/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s usado (%1024mB de %1024mB usados, %1024mB livre)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Ações"
 
@@ -30,7 +35,7 @@ msgstr "Permitir sobrescrever ficheiros de pacotes em conflito"
 msgid "Automatically remove unused dependencies"
 msgstr "Remover automaticamente dependências não utilizadas"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Disponível"
 
@@ -55,11 +60,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Limpar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Configurar opkg…"
 
@@ -69,7 +74,7 @@ msgstr "Dependências"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Descrição"
 
@@ -77,7 +82,7 @@ msgstr "Descrição"
 msgid "Details for package <em>%h</em>"
 msgstr "Detalhes do pacote <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Espaço no disco"
 
@@ -85,15 +90,15 @@ msgstr "Espaço no disco"
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Mostrar pacotes de tradução do LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Mostrar todos os pacotes de tradução disponíveis"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -105,7 +110,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "A mostrar %d-%d de %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Descarregar e instalar o pacote"
 
@@ -117,7 +122,7 @@ msgstr "Erros"
 msgid "Executing package manager"
 msgstr "A executar o gestor de pacotes"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtro"
 
@@ -125,7 +130,7 @@ msgstr "Filtro"
 msgid "Grant access to opkg management"
 msgstr "Conceder acesso à gestão do opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Ocultar todos os pacotes de tradução"
 
@@ -135,13 +140,17 @@ msgstr "Ocultar todos os pacotes de tradução"
 msgid "Install"
 msgstr "Instalar"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Também instalar os pacotes de tradução sugeridos"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Instalado"
 
@@ -179,8 +188,8 @@ msgstr "Instalar pacote manualmente"
 msgid "Needs upgrade"
 msgstr "Precisa de ser atualizado"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Próxima página"
 
@@ -204,7 +213,7 @@ msgstr "Não disponível"
 msgid "Not installed"
 msgstr "Não instalado"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -214,16 +223,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Configuração do OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Nome do pacote"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Nome do pacote ou URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Página anterior"
 
@@ -285,7 +294,7 @@ msgstr "A guardar dados de configuração…"
 msgid "Size"
 msgstr "Tamanho"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Tamanho (.ipk)"
 
@@ -330,7 +339,7 @@ msgstr ""
 "A versão do pacote <em>%h</em> do repositório não é compatível, é necessária "
 "a %s mas apenas a %s está disponível."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Escreva para filtrar…"
 
@@ -346,11 +355,11 @@ msgstr "Incapaz de ler %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Incapaz de gravar %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Atualizar listas…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Atualizações"
 
@@ -359,13 +368,13 @@ msgstr "Atualizações"
 msgid "Upgrade…"
 msgstr "Atualizar…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Enviar pacote…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versão"
 
@@ -378,24 +387,24 @@ msgstr "Versão incompatível"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "A aguardar que o comando <em>opkg %h</em> termine…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "todos"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtrado"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "nenhum"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "desconhecido"
 

--- a/applications/luci-app-opkg/po/pt_BR/opkg.po
+++ b/applications/luci-app-opkg/po/pt_BR/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Ações"
 
@@ -30,7 +35,7 @@ msgstr "Permite a substituição dos arquivos dos pacotes com conflito"
 msgid "Automatically remove unused dependencies"
 msgstr "Remover automaticamente dependentes não-utilizados"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Disponível"
 
@@ -55,11 +60,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Limpar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Configurar o opkg…"
 
@@ -69,7 +74,7 @@ msgstr "Dependentes"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Descrição"
 
@@ -77,7 +82,7 @@ msgstr "Descrição"
 msgid "Details for package <em>%h</em>"
 msgstr "Detalhes para o pacote <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -85,15 +90,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Dispensar"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Exibe os pacotes de tradução do LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Exibe todos os pacotes de tradução disponíveis"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -105,7 +110,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Exibindo %d-%d de %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Baixe e instale o pacote"
 
@@ -117,7 +122,7 @@ msgstr "Erros"
 msgid "Executing package manager"
 msgstr "Executando o gerenciador de pacotes"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtro"
 
@@ -125,7 +130,7 @@ msgstr "Filtro"
 msgid "Grant access to opkg management"
 msgstr "Conceder acesso ao gerenciador opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Oculte todos os pacotes de tradução"
 
@@ -135,13 +140,17 @@ msgstr "Oculte todos os pacotes de tradução"
 msgid "Install"
 msgstr "Instalar"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Instale também os pacotes sugeridos de tradução"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Instalado"
 
@@ -179,8 +188,8 @@ msgstr "Instalar o pacote manualmente"
 msgid "Needs upgrade"
 msgstr "Precisa de atualização"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Próxima página"
 
@@ -204,7 +213,7 @@ msgstr "Não disponível"
 msgid "Not installed"
 msgstr "Não instalado"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -214,16 +223,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Configuração do OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Nome do Pacote"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Nome do pacote ou URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Página anterior"
 
@@ -286,7 +295,7 @@ msgstr "Salvando os dados de configuração…"
 msgid "Size"
 msgstr "Tamanho"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Tamanho (.ipk)"
 
@@ -329,7 +338,7 @@ msgstr ""
 "A versão do repositório do pacote <em>%h</em> não é compatível, requer o %s "
 "mas apenas o %s está disponível."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Digite para filtrar…"
 
@@ -345,11 +354,11 @@ msgstr "Impossível ler %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Impossível salvar %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Atualizar listas…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Atualizações"
 
@@ -358,13 +367,13 @@ msgstr "Atualizações"
 msgid "Upgrade…"
 msgstr "Atualizar…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Enviar Pacote…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versão"
 
@@ -377,24 +386,24 @@ msgstr "Versão incompatível"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Aguardando a conclusão do comando <em>opkg %h</em>…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "todos"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtrado"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "nenhum"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "desconhecido"
 

--- a/applications/luci-app-opkg/po/ro/opkg.po
+++ b/applications/luci-app-opkg/po/ro/opkg.po
@@ -17,7 +17,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Acțiuni"
 
@@ -29,7 +34,7 @@ msgstr "Permiteți suprascrierea fișierelor pachetelor conflictuale"
 msgid "Automatically remove unused dependencies"
 msgstr "Eliminați automat dependențele neutilizate"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Disponibile"
 
@@ -54,11 +59,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Anulare"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Curățați"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Configurați opkg…"
 
@@ -68,7 +73,7 @@ msgstr "Dependențe"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Descriere"
 
@@ -76,7 +81,7 @@ msgstr "Descriere"
 msgid "Details for package <em>%h</em>"
 msgstr "Detalii pentru pachetul <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -84,15 +89,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Închideți"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Afișați pachetele de traducere LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Afișați toate pachetele de traducere disponibile"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -104,7 +109,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Se afișează %d-%d din %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Descărcați și instalați pachetul"
 
@@ -116,7 +121,7 @@ msgstr "Erori"
 msgid "Executing package manager"
 msgstr "Executarea managerului de pachete"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtru"
 
@@ -124,7 +129,7 @@ msgstr "Filtru"
 msgid "Grant access to opkg management"
 msgstr "Acordați acces la gestionarea opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Ascundeți toate pachetele de traducere"
 
@@ -134,13 +139,17 @@ msgstr "Ascundeți toate pachetele de traducere"
 msgid "Install"
 msgstr "Instalați"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Instalați și pachetele de traducere sugerate"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Instalat"
 
@@ -178,8 +187,8 @@ msgstr "Instalați manual pachetul"
 msgid "Needs upgrade"
 msgstr "Necesită actualizare"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Pagina următoare"
 
@@ -203,7 +212,7 @@ msgstr "Nu este disponibil"
 msgid "Not installed"
 msgstr "Nu este instalat"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -213,16 +222,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Configurația OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Numele pachetului"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Numele pachetului sau URL-ul…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Pagina anterioară"
 
@@ -284,7 +293,7 @@ msgstr "Se salvează datele de configurare…"
 msgid "Size"
 msgstr "Mărime"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Dimensiune (.ipk)"
 
@@ -325,7 +334,7 @@ msgstr ""
 "Versiunea din depozit a pachetului <em>%h</em> nu este compatibilă, este "
 "necesar %s dar numai %s este disponibil."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Tastați pentru a filtra…"
 
@@ -341,11 +350,11 @@ msgstr "Nu se poate citi %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Nu se poate salva %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Actualizați listele…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Actualizări"
 
@@ -354,13 +363,13 @@ msgstr "Actualizări"
 msgid "Upgrade…"
 msgstr "Faceți upgrade…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Încărcați pachetul…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Versiune"
 
@@ -373,24 +382,24 @@ msgstr "Versiune incompatibilă"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Se așteaptă finalizarea comenzii <em>opkg %h</em>…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "toate"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "Filtrate"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "niciunul"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "necunoscut"
 

--- a/applications/luci-app-opkg/po/ru/opkg.po
+++ b/applications/luci-app-opkg/po/ru/opkg.po
@@ -20,7 +20,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s использовано (%1024mB использовано из %1024mB, %1024mB свободно)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Действия"
 
@@ -32,7 +37,7 @@ msgstr "Разрешить перезапись конфликтующих фа�
 msgid "Automatically remove unused dependencies"
 msgstr "Удалить неиспользуемые зависимости"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Доступно"
 
@@ -57,11 +62,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Отмена"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Очистить"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Настройки"
 
@@ -71,7 +76,7 @@ msgstr "Зависимости"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Описание"
 
@@ -79,7 +84,7 @@ msgstr "Описание"
 msgid "Details for package <em>%h</em>"
 msgstr "Подробная информация о пакете <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Дисковое пространство"
 
@@ -87,15 +92,15 @@ msgstr "Дисковое пространство"
 msgid "Dismiss"
 msgstr "Закрыть"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Отображение пакетов перевода LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Показывать все доступные переводы пакетов"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -107,7 +112,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Показано %d-%d из %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Загрузить и установить пакет"
 
@@ -119,7 +124,7 @@ msgstr "Ошибки"
 msgid "Executing package manager"
 msgstr "Выполнение..."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Фильтр"
 
@@ -127,7 +132,7 @@ msgstr "Фильтр"
 msgid "Grant access to opkg management"
 msgstr "Предоставить доступ к управлению opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Скрывать все пакеты переводов"
 
@@ -137,13 +142,17 @@ msgstr "Скрывать все пакеты переводов"
 msgid "Install"
 msgstr "Установить"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Также установить рекомендуемые пакеты перевода"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Установлено"
 
@@ -181,8 +190,8 @@ msgstr "Ручная установка пакета"
 msgid "Needs upgrade"
 msgstr "Требуется обновление"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Следующая страница"
 
@@ -206,7 +215,7 @@ msgstr "Не доступно"
 msgid "Not installed"
 msgstr "Не установлено"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -216,16 +225,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Настройка OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Имя пакета"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Имя пакета или URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Предыдущая страница"
 
@@ -288,7 +297,7 @@ msgstr "Сохранение данных конфигурации…"
 msgid "Size"
 msgstr "Размер"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Размер (.ipk)"
 
@@ -330,7 +339,7 @@ msgstr ""
 "Версия пакета <em>%h</em>, доступная в репозитории, несовместима. Требуется "
 "%s, но доступна только %s."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Введите для фильтрации"
 
@@ -346,11 +355,11 @@ msgstr "Не удалось прочитать %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Не удалось сохранить %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Обновить списки"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Обновления"
 
@@ -359,13 +368,13 @@ msgstr "Обновления"
 msgid "Upgrade…"
 msgstr "Обновление…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Загрузить пакет"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Версия"
 
@@ -378,24 +387,24 @@ msgstr "Версия несовместима"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Выполнение команды <em>opkg %h</em>…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "все"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "отфильтровать"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "нет"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "неизвестный"
 

--- a/applications/luci-app-opkg/po/sk/opkg.po
+++ b/applications/luci-app-opkg/po/sk/opkg.po
@@ -16,7 +16,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Akcie"
 
@@ -28,7 +33,7 @@ msgstr "Povoliť prepísanie konfliktných súborov balíkov"
 msgid "Automatically remove unused dependencies"
 msgstr "Automatické odstránenie nepoužitých závislostí"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Dostupné"
 
@@ -52,11 +57,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Vymazať"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Konfigurovať opkg…"
 
@@ -66,7 +71,7 @@ msgstr "Závislosti"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Popis"
 
@@ -74,7 +79,7 @@ msgstr "Popis"
 msgid "Details for package <em>%h</em>"
 msgstr "Podrobnosti balíka <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -82,17 +87,17 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Zahodiť"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 #, fuzzy
 msgid "Display LuCI translation packages"
 msgstr "Zobraziť balíky prekladov LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 #, fuzzy
 msgid "Display all available translation packages"
 msgstr "Zobraziť všetky dostupné balíky prekladov"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 #, fuzzy
 msgid ""
 "Display base translation packages and translation packages for already "
@@ -105,7 +110,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Zobrazených %d-%d z %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Prevziať a nainštalovať balík"
 
@@ -117,7 +122,7 @@ msgstr "Chyby"
 msgid "Executing package manager"
 msgstr "Spúšťanie správcu balíkov"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filter"
 
@@ -125,7 +130,7 @@ msgstr "Filter"
 msgid "Grant access to opkg management"
 msgstr "Poskytnite prístup k správe opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 #, fuzzy
 msgid "Hide all translation packages"
 msgstr "Skryť všetky balíky prekladov"
@@ -136,6 +141,10 @@ msgstr "Skryť všetky balíky prekladov"
 msgid "Install"
 msgstr "Inštalovať"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 #, fuzzy
 msgid "Install suggested translation packages as well"
@@ -143,7 +152,7 @@ msgstr "Inštalovať aj navrhované balíky prekladov"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Nainštalované"
 
@@ -181,8 +190,8 @@ msgstr "Manuálna inštalácia balíka"
 msgid "Needs upgrade"
 msgstr "Vyžaduje aktualizáciu"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Ďalšia strana"
 
@@ -206,7 +215,7 @@ msgstr "Nie je k dispozícií"
 msgid "Not installed"
 msgstr "Nie je nainštalovaný"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -216,16 +225,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Konfigurácia OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Názov balíka"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Názov balíka alebo URL adresa…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Predošlá strana"
 
@@ -288,7 +297,7 @@ msgstr "Ukladajú sa konfiguračné údaje …"
 msgid "Size"
 msgstr "Veľkosť"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Veľkosť (.ipk)"
 
@@ -329,7 +338,7 @@ msgstr ""
 "Verzia archívu balíka <em>%h</em> nie je kompatibilná, požaduje sa %s, ale "
 "je k dispozícii je iba %s."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Reťazec na filtrovanie…"
 
@@ -345,11 +354,11 @@ msgstr "Nedá sa prečítať %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Nedá sa uložiť %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Aktualizovať zoznamy…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Aktualizácie"
 
@@ -358,13 +367,13 @@ msgstr "Aktualizácie"
 msgid "Upgrade…"
 msgstr "Inovovať…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Odovzdať balík…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Verzia"
 
@@ -377,24 +386,24 @@ msgstr "Verzia je nekompatibilná"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Čaká sa na dokončenie príkazu <em>opkg %h</em>…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "všetko"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtrované"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "žiadne"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "neznámy"
 

--- a/applications/luci-app-opkg/po/sv/opkg.po
+++ b/applications/luci-app-opkg/po/sv/opkg.po
@@ -16,7 +16,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Åtgärder"
 
@@ -28,7 +33,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr "Ta automatiskt bort oanvända beroenden"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Tillgänglig"
 
@@ -52,11 +57,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Rensa"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Ställ in opkg…"
 
@@ -66,7 +71,7 @@ msgstr "Beroenden"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Beskrivning"
 
@@ -74,7 +79,7 @@ msgstr "Beskrivning"
 msgid "Details for package <em>%h</em>"
 msgstr "Detaljer för paketet <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -82,15 +87,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Avfärda"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -100,7 +105,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Visar %d-%d av %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Ladda ner och installera paket"
 
@@ -112,7 +117,7 @@ msgstr "Felen"
 msgid "Executing package manager"
 msgstr "Kör pakethanteraren"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filter"
 
@@ -120,7 +125,7 @@ msgstr "Filter"
 msgid "Grant access to opkg management"
 msgstr "Tillåt åtkomst till hantering av opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -130,13 +135,17 @@ msgstr ""
 msgid "Install"
 msgstr "Installera"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Installerad"
 
@@ -174,8 +183,8 @@ msgstr "Installera paket manuellt"
 msgid "Needs upgrade"
 msgstr "Behöver uppgradering"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Nästa sida"
 
@@ -199,7 +208,7 @@ msgstr "Ej tillgängligt"
 msgid "Not installed"
 msgstr "Inte installerad"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -209,16 +218,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Konfiguration av OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Paketnamn"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Paketnamn eller URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Föregående sida"
 
@@ -278,7 +287,7 @@ msgstr "Sparar konfigurationsdata…"
 msgid "Size"
 msgstr "Storlek"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Storlek (.ipk)"
 
@@ -320,7 +329,7 @@ msgstr ""
 "Filförrådets version av paketet <em>%h</em> är inte tillgängligt, kräver %s, "
 "men endast %s är tillgänglig."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Skriv för att filtrera…"
 
@@ -336,11 +345,11 @@ msgstr "Kunde inte läsa %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Kunde inte spara %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Uppdatera listor…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Uppdateringar"
 
@@ -349,13 +358,13 @@ msgstr "Uppdateringar"
 msgid "Upgrade…"
 msgstr "Uppgradera…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Ladda upp paket…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Version"
 
@@ -368,24 +377,24 @@ msgstr "Versionen passar inte"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Väntar på att <em>opkg %h</em>-kommandot ska slutföras…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "okänd"
 

--- a/applications/luci-app-opkg/po/templates/opkg.pot
+++ b/applications/luci-app-opkg/po/templates/opkg.pot
@@ -5,7 +5,12 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr ""
 
@@ -17,7 +22,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr ""
 
@@ -37,11 +42,11 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr ""
 
@@ -51,7 +56,7 @@ msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr ""
 
@@ -59,7 +64,7 @@ msgstr ""
 msgid "Details for package <em>%h</em>"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -67,15 +72,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -85,7 +90,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr ""
 
@@ -97,7 +102,7 @@ msgstr ""
 msgid "Executing package manager"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr ""
 
@@ -105,7 +110,7 @@ msgstr ""
 msgid "Grant access to opkg management"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -115,13 +120,17 @@ msgstr ""
 msgid "Install"
 msgstr ""
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr ""
 
@@ -157,8 +166,8 @@ msgstr ""
 msgid "Needs upgrade"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr ""
 
@@ -182,7 +191,7 @@ msgstr ""
 msgid "Not installed"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr ""
 
@@ -192,16 +201,16 @@ msgstr ""
 msgid "OPKG Configuration"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr ""
 
@@ -261,7 +270,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr ""
 
@@ -298,7 +307,7 @@ msgid ""
 "but only %s is available."
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr ""
 
@@ -314,11 +323,11 @@ msgstr ""
 msgid "Unable to save %s: %s"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr ""
 
@@ -327,13 +336,13 @@ msgstr ""
 msgid "Upgrade…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr ""
 
@@ -346,24 +355,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr ""
 

--- a/applications/luci-app-opkg/po/tr/opkg.po
+++ b/applications/luci-app-opkg/po/tr/opkg.po
@@ -17,7 +17,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s kullanılıyor (%1024mB / %1024mB kullanılıyor, %1024mB boş)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Eylemler"
 
@@ -29,7 +34,7 @@ msgstr "Çakışan paket dosyalarının üzerine yazılmasına izin ver"
 msgid "Automatically remove unused dependencies"
 msgstr "Kullanılmayan bağımlılıkları otomatik olarak kaldır"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Kullanılabilir"
 
@@ -54,11 +59,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "İptal"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Temizle"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "opkg'yi yapılandır…"
 
@@ -68,7 +73,7 @@ msgstr "Bağımlılıklar"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Açıklama"
 
@@ -76,7 +81,7 @@ msgstr "Açıklama"
 msgid "Details for package <em>%h</em>"
 msgstr "Paket detayları <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Disk alanı"
 
@@ -84,15 +89,15 @@ msgstr "Disk alanı"
 msgid "Dismiss"
 msgstr "Kapat"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "LuCI çeviri paketlerini görüntüle"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Mevcut tüm çeviri paketlerini göster"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -104,7 +109,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Görüntülenen %d-%d toplam %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Paket indir ve yükle"
 
@@ -116,7 +121,7 @@ msgstr "Hatalar"
 msgid "Executing package manager"
 msgstr "Paket yöneticisi çalıştırılıyor"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Filtre"
 
@@ -124,7 +129,7 @@ msgstr "Filtre"
 msgid "Grant access to opkg management"
 msgstr "Opkg yönetimine erişim izni verin"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Tüm çeviri paketlerini gizle"
 
@@ -134,13 +139,17 @@ msgstr "Tüm çeviri paketlerini gizle"
 msgid "Install"
 msgstr "Yükle"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Önerilen çeviri paketlerini de yükle"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Yüklenenler"
 
@@ -178,8 +187,8 @@ msgstr "Elle paket yükle"
 msgid "Needs upgrade"
 msgstr "Yükseltme gerekli"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Sonraki sayfa"
 
@@ -203,7 +212,7 @@ msgstr "Mevcut değil"
 msgid "Not installed"
 msgstr "Yüklenmedi"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "Tamam"
 
@@ -213,16 +222,16 @@ msgstr "Tamam"
 msgid "OPKG Configuration"
 msgstr "OPKG Yapılandırması"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Paket adı"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Paket adı veya URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Önceki sayfa"
 
@@ -283,7 +292,7 @@ msgstr "Yapılandırma verisi kaydediliyor…"
 msgid "Size"
 msgstr "Boyut"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Boyut (.ipk)"
 
@@ -324,7 +333,7 @@ msgstr ""
 "<em>%h</em> paketinin depo bulunan sürümü uyumlu değil. Gerekli olan %s iken "
 "sadece %s sürümü mevcut."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Filtrelemek için yazın…"
 
@@ -340,11 +349,11 @@ msgstr "Okunamıyor %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Kaydedilemiyor %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Listeyi güncelle…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Güncellemeler"
 
@@ -353,13 +362,13 @@ msgstr "Güncellemeler"
 msgid "Upgrade…"
 msgstr "Yükselt…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Paket Yükle…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Sürüm"
 
@@ -372,24 +381,24 @@ msgstr "Sürüm uyumsuz"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "<em>opkg %h</em> komutunun tamamlanması bekleniyor…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "tüm"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "filtrelenmiş"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "hiçbiri"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "bilinmeyen"
 

--- a/applications/luci-app-opkg/po/uk/opkg.po
+++ b/applications/luci-app-opkg/po/uk/opkg.po
@@ -17,7 +17,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s використано (%1024mB використано з %1024mB, вільно %1024mB)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "Дії"
 
@@ -29,7 +34,7 @@ msgstr "Дозволити перезапис файлів пакунків, я�
 msgid "Automatically remove unused dependencies"
 msgstr "Автоматичне видалення невикористовуваних залежностей"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Доступно"
 
@@ -54,11 +59,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Очистити"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Налаштування opkg…"
 
@@ -68,7 +73,7 @@ msgstr "Залежності"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Опис"
 
@@ -76,7 +81,7 @@ msgstr "Опис"
 msgid "Details for package <em>%h</em>"
 msgstr "Подробиці про пакет <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "Дисковий простір"
 
@@ -84,15 +89,15 @@ msgstr "Дисковий простір"
 msgid "Dismiss"
 msgstr "Закрити"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Відображати пакети перекладу LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Відображати всі доступні пакети перекладу"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -104,7 +109,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Відображається %d-%d із %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Завантажити та інсталювати пакети"
 
@@ -116,7 +121,7 @@ msgstr "Помилки"
 msgid "Executing package manager"
 msgstr "Виконання менеджера пакетів"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Фільтр"
 
@@ -124,7 +129,7 @@ msgstr "Фільтр"
 msgid "Grant access to opkg management"
 msgstr "Надати доступ до керування opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Приховати всі пакети перекладів"
 
@@ -134,13 +139,17 @@ msgstr "Приховати всі пакети перекладів"
 msgid "Install"
 msgstr "Інсталювати"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Встановлювати запропоновані пакети перекладу також"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Інстальовано"
 
@@ -178,8 +187,8 @@ msgstr "Інсталяція пакета вручну"
 msgid "Needs upgrade"
 msgstr "Потребує оновлення"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Наступна сторінка"
 
@@ -203,7 +212,7 @@ msgstr "Недоступно"
 msgid "Not installed"
 msgstr "Не інстальовано"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -213,16 +222,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Конфігурація OPKG"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Назва пакунку"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Назва пакунка чи URL-адреса…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Попередня сторінка"
 
@@ -284,7 +293,7 @@ msgstr "Збереження даних конфігурації…"
 msgid "Size"
 msgstr "Розмір"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Розмір (.ipk)"
 
@@ -327,7 +336,7 @@ msgstr ""
 "Версія пакету <em>%h</em> у репозиторії несумісна, потрібно %s, але доступна "
 "лише %s."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Введіть текст для фільтра…"
 
@@ -343,11 +352,11 @@ msgstr "Не вдалося прочитати %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Не вдалося зберегти %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Оновити списки…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Оновлення"
 
@@ -356,13 +365,13 @@ msgstr "Оновлення"
 msgid "Upgrade…"
 msgstr "Оновлення…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Відвантажити пакет…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Версія"
 
@@ -375,24 +384,24 @@ msgstr "Несумісна версія"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Очікуємо завершення виконання команди <em>opkg %h</em> …"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "усі"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "фільтрувати"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "ні"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "невідомо"
 

--- a/applications/luci-app-opkg/po/ur/opkg.po
+++ b/applications/luci-app-opkg/po/ur/opkg.po
@@ -14,7 +14,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "اعمال"
 
@@ -26,7 +31,7 @@ msgstr ""
 msgid "Automatically remove unused dependencies"
 msgstr "غیر استعمال شدہ انحصار کو خود بخود ہٹا دیں"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "موجود"
 
@@ -51,11 +56,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "کینسل"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "کلیر"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "opkg کو ترتیب دیں…"
 
@@ -65,7 +70,7 @@ msgstr "انحصار"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "تفصیل"
 
@@ -73,7 +78,7 @@ msgstr "تفصیل"
 msgid "Details for package <em>%h</em>"
 msgstr "پیکیج <em>%h</em> کی تفصیلات"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -81,15 +86,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "مسترد کریں"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -99,7 +104,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "%d میں سے %d-%d ڈسپلے ہو رہا ہے"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "پیکیج ڈاؤن لوڈ اور انسٹال کریں"
 
@@ -111,7 +116,7 @@ msgstr "غلطیاں"
 msgid "Executing package manager"
 msgstr "پیکج مینیجر پر عمل درآمد ہو رہا"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "فلٹر"
 
@@ -119,7 +124,7 @@ msgstr "فلٹر"
 msgid "Grant access to opkg management"
 msgstr "opkg مینجمنٹ تک رسائی فراہم کریں"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr ""
 
@@ -129,13 +134,17 @@ msgstr ""
 msgid "Install"
 msgstr "انسٹال کریں"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "نصب خدمات"
 
@@ -174,8 +183,8 @@ msgstr "دستی طور پر پیکیج انسٹال کریں"
 msgid "Needs upgrade"
 msgstr "اپ گریڈ کی ضرورت ہے"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "اگلا صفحہ"
 
@@ -199,7 +208,7 @@ msgstr "دستیاب نہیں ہے"
 msgid "Not installed"
 msgstr "انسٹال نہیں ہے"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "ٹھیک ہے"
 
@@ -209,16 +218,16 @@ msgstr "ٹھیک ہے"
 msgid "OPKG Configuration"
 msgstr "OPKG کنفیگریشن"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "پیکیج کا نام"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "پیکیج کا نام یا URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "پچھلا صفحہ"
 
@@ -279,7 +288,7 @@ msgstr "کنفیگریشن ڈیٹا محفوظ ہو رہا ہے…"
 msgid "Size"
 msgstr "سائز"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "سائز(.ipk)"
 
@@ -318,7 +327,7 @@ msgstr ""
 "پیکیج <em>%h</em> کا ذخیرہ ورژن مطابقت نہیں رکھتا، %s کی ضرورت ہے لیکن صرف "
 "%s دستیاب ہے۔"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "فلٹر کرنے کے لیے ٹائپ کریں…"
 
@@ -334,11 +343,11 @@ msgstr "پڑھنے سے قاصر%s: s%"
 msgid "Unable to save %s: %s"
 msgstr "%s پڑھنے سے قاصر: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "فہرستوں کو اپ ڈیٹ کریں…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "تازہ ترین"
 
@@ -347,13 +356,13 @@ msgstr "تازہ ترین"
 msgid "Upgrade…"
 msgstr "اپ گریڈ…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "پیکج اپ لوڈ کریں…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr ""
 
@@ -366,24 +375,24 @@ msgstr ""
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr ""
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr ""
 

--- a/applications/luci-app-opkg/po/vi/opkg.po
+++ b/applications/luci-app-opkg/po/vi/opkg.po
@@ -18,7 +18,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "hành động"
 
@@ -30,7 +35,7 @@ msgstr "Cho phép ghi đè các tệp gói xung đột"
 msgid "Automatically remove unused dependencies"
 msgstr "Tự động gỡ bỏ các gói phụ thuộc không được sử dụng"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "Sẵn có"
 
@@ -55,11 +60,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "Hủy lệnh"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "Xóa"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "Cấu hình opkg…"
 
@@ -69,7 +74,7 @@ msgstr "Các gói phụ thuộc"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "Mô tả"
 
@@ -77,7 +82,7 @@ msgstr "Mô tả"
 msgid "Details for package <em>%h</em>"
 msgstr "Chi tiết cho gói <em>%h</em>"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -85,15 +90,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "Bỏ qua"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "Hiển thị các gói dịch LuCI"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "Hiển thị tất cả các gói dịch có sẵn"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -104,7 +109,7 @@ msgstr ""
 msgid "Displaying %d-%d of %d"
 msgstr "Hiển thị %d-%d của %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "Tải và cài đặt gói"
 
@@ -116,7 +121,7 @@ msgstr "Lỗi"
 msgid "Executing package manager"
 msgstr "Đang thực thi quản lý gói"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "Bộ lọc"
 
@@ -124,7 +129,7 @@ msgstr "Bộ lọc"
 msgid "Grant access to opkg management"
 msgstr "Cấp quyền truy cập vào quản lý opkg"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "Ẩn tất cả các gói dịch"
 
@@ -134,13 +139,17 @@ msgstr "Ẩn tất cả các gói dịch"
 msgid "Install"
 msgstr "Cài đặt"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "Cài đặt cả các gói dịch được đề xuất"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "Đã cài đặt"
 
@@ -178,8 +187,8 @@ msgstr "Cài đặt gói thủ công"
 msgid "Needs upgrade"
 msgstr "Cần nâng cấp"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "Trang kế"
 
@@ -203,7 +212,7 @@ msgstr "Không có sẵn"
 msgid "Not installed"
 msgstr "Không được càu đặt"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "OK"
 
@@ -213,16 +222,16 @@ msgstr "OK"
 msgid "OPKG Configuration"
 msgstr "Cấu hình OPKG-"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "Tên gói"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "Tên gói hoặc URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "Trang trước"
 
@@ -283,7 +292,7 @@ msgstr "Đang lưu dữ liệu cấu hình…"
 msgid "Size"
 msgstr "Dung lượng"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "Kích cỡ (.ipk)"
 
@@ -325,7 +334,7 @@ msgstr ""
 "Phiên bản trên repository của gói <em>%h</em> không có sẵn, yêu cầu %s nhưng "
 "chỉ có %s."
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "Gõ để lọc…"
 
@@ -341,11 +350,11 @@ msgstr "Không thể đọc %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "Không thể lưu %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "Cập nhật dan sách…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "Các cập nhật"
 
@@ -354,13 +363,13 @@ msgstr "Các cập nhật"
 msgid "Upgrade…"
 msgstr "Nâng cấp…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "Tải lên gói…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "Phiên bản"
 
@@ -373,24 +382,24 @@ msgstr "Phiên bản không tương thích"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "Đợi câu lệnh <em>opkg %h</em> hoàn thành…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "Tất cả"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "Đã lọc"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "Không"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "Không xác định"
 

--- a/applications/luci-app-opkg/po/zh_Hans/opkg.po
+++ b/applications/luci-app-opkg/po/zh_Hans/opkg.po
@@ -21,7 +21,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr "%s 已使用 (%1024mB 已使用，总共 %1024mB，剩余 %1024mB)"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "操作"
 
@@ -33,7 +38,7 @@ msgstr "允许覆盖冲突的包文件"
 msgid "Automatically remove unused dependencies"
 msgstr "自动移除未使用的依赖"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "可用"
 
@@ -56,11 +61,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "清除"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "配置 opkg…"
 
@@ -70,7 +75,7 @@ msgstr "依赖"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "描述"
 
@@ -78,7 +83,7 @@ msgstr "描述"
 msgid "Details for package <em>%h</em>"
 msgstr "软件包 <em>%h</em> 详情"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr "磁盘空间"
 
@@ -86,15 +91,15 @@ msgstr "磁盘空间"
 msgid "Dismiss"
 msgstr "关闭"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "显示 LuCI 翻译包"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "显示所有可用的翻译包"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -104,7 +109,7 @@ msgstr "仅显示基础翻译包和已安装语言的翻译包"
 msgid "Displaying %d-%d of %d"
 msgstr "正在显示 %d-%d，共 %d"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "下载并安装软件包"
 
@@ -116,7 +121,7 @@ msgstr "错误"
 msgid "Executing package manager"
 msgstr "正在执行软件包管理器"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "过滤器"
 
@@ -124,7 +129,7 @@ msgstr "过滤器"
 msgid "Grant access to opkg management"
 msgstr "授予访问 opkg 管理的权限"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "隐藏所有翻译包"
 
@@ -134,13 +139,17 @@ msgstr "隐藏所有翻译包"
 msgid "Install"
 msgstr "安装"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "同样安装推荐的翻译包"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "已安装"
 
@@ -176,8 +185,8 @@ msgstr "手动安装软件包"
 msgid "Needs upgrade"
 msgstr "需要升级"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "下一页"
 
@@ -201,7 +210,7 @@ msgstr "不可用"
 msgid "Not installed"
 msgstr "未安装"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "确认"
 
@@ -211,16 +220,16 @@ msgstr "确认"
 msgid "OPKG Configuration"
 msgstr "OPKG 配置"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "软件包名称"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "软件包名称或 URL…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "上一页"
 
@@ -280,7 +289,7 @@ msgstr "正在保存配置数据…"
 msgid "Size"
 msgstr "大小"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "大小（.ipk）"
 
@@ -317,7 +326,7 @@ msgid ""
 "but only %s is available."
 msgstr "软件包 <em>%h</em> 在仓库中的版本不兼容，需要 %s 但仅可提供 %s。"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "输入以筛选…"
 
@@ -333,11 +342,11 @@ msgstr "无法读取 %s：%s"
 msgid "Unable to save %s: %s"
 msgstr "无法保存 %s：%s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "更新列表…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "更新"
 
@@ -346,13 +355,13 @@ msgstr "更新"
 msgid "Upgrade…"
 msgstr "升级…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "上传软件包…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "版本"
 
@@ -365,24 +374,24 @@ msgstr "版本不兼容"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "等待命令 <em>opkg %h</em> 执行完成…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "全部"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "已过滤"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "无"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "未知"
 

--- a/applications/luci-app-opkg/po/zh_Hant/opkg.po
+++ b/applications/luci-app-opkg/po/zh_Hant/opkg.po
@@ -16,7 +16,12 @@ msgstr ""
 msgid "%s used (%1024mB used of %1024mB, %1024mB free)"
 msgstr ""
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+msgid ""
+"<strong>Warning!</strong> Package operations can <a %s>break your system</a>."
+msgstr ""
+
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1163
 msgid "Actions"
 msgstr "動作"
 
@@ -28,7 +33,7 @@ msgstr "允許覆蓋衝突的包檔"
 msgid "Automatically remove unused dependencies"
 msgstr "自動移除不再使用的依賴項目"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1210
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1218
 msgid "Available"
 msgstr "可用的"
 
@@ -51,11 +56,11 @@ msgstr ""
 msgid "Cancel"
 msgstr "取消"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
 msgid "Clear"
 msgstr "清除"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1159
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
 msgid "Configure opkg…"
 msgstr "設定 opkg …"
 
@@ -65,7 +70,7 @@ msgstr "依賴項目"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:750
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:938
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1228
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1236
 msgid "Description"
 msgstr "描述"
 
@@ -73,7 +78,7 @@ msgstr "描述"
 msgid "Details for package <em>%h</em>"
 msgstr "套件 <em>%h</em> 的詳細資訊"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1134
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1142
 msgid "Disk space"
 msgstr ""
 
@@ -81,15 +86,15 @@ msgstr ""
 msgid "Dismiss"
 msgstr "關閉"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1164
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1172
 msgid "Display LuCI translation packages"
 msgstr "顯示 LuCI 翻譯包"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1181
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1189
 msgid "Display all available translation packages"
 msgstr "顯示所有可用的翻譯包"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1167
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1175
 msgid ""
 "Display base translation packages and translation packages for already "
 "installed languages only"
@@ -99,7 +104,7 @@ msgstr "僅顯示已安裝語言的基本翻譯包和翻譯包"
 msgid "Displaying %d-%d of %d"
 msgstr "正在顯示第 %d 到 %d 筆，共 %d 筆"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1155
 msgid "Download and install package"
 msgstr "下載並安裝套件包"
 
@@ -111,7 +116,7 @@ msgstr "錯誤"
 msgid "Executing package manager"
 msgstr "正在執行套件包管理員"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1139
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1147
 msgid "Filter"
 msgstr "過濾"
 
@@ -119,7 +124,7 @@ msgstr "過濾"
 msgid "Grant access to opkg management"
 msgstr "授予存取 opkg 管理的權限"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1194
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1202
 msgid "Hide all translation packages"
 msgstr "隱藏所有翻譯包"
 
@@ -129,13 +134,17 @@ msgstr "隱藏所有翻譯包"
 msgid "Install"
 msgstr "安裝"
 
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1133
+msgid "Install additional software and upgrade existing packages with opkg."
+msgstr ""
+
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:780
 msgid "Install suggested translation packages as well"
 msgstr "同時安裝建議的翻譯包"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:299
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:522
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
 msgid "Installed"
 msgstr "已安裝"
 
@@ -171,8 +180,8 @@ msgstr "手動安裝套件包"
 msgid "Needs upgrade"
 msgstr "需要升級"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1219
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1237
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1245
 msgid "Next page"
 msgstr "下一頁"
 
@@ -196,7 +205,7 @@ msgstr "無法使用"
 msgid "Not installed"
 msgstr "未安裝"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1150
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
 msgid "OK"
 msgstr "確定"
 
@@ -206,16 +215,16 @@ msgstr "確定"
 msgid "OPKG Configuration"
 msgstr "OPKG 設定"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1233
 msgid "Package name"
 msgstr "套件包名稱"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
 msgid "Package name or URL…"
 msgstr "套件包名稱或網址…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1217
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1225
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1243
 msgid "Previous page"
 msgstr "上一頁"
 
@@ -275,7 +284,7 @@ msgstr "正在儲存設定值…"
 msgid "Size"
 msgstr "大小"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1227
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1235
 msgid "Size (.ipk)"
 msgstr "大小 (.ipk)"
 
@@ -312,7 +321,7 @@ msgid ""
 "but only %s is available."
 msgstr "套件包 <em>%h</em> 在儲存庫中的版本不相容，要求 %s 但僅有 %s 可用。"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1141
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1149
 msgid "Type to filter…"
 msgstr "輸入以進行過濾…"
 
@@ -328,11 +337,11 @@ msgstr "無法讀取 %s: %s"
 msgid "Unable to save %s: %s"
 msgstr "無法儲存 %s: %s"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1157
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1165
 msgid "Update lists…"
 msgstr "更新清單…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1212
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1220
 msgid "Updates"
 msgstr "可升級"
 
@@ -341,13 +350,13 @@ msgstr "可升級"
 msgid "Upgrade…"
 msgstr "升級…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1158
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1166
 msgid "Upload Package…"
 msgstr "上傳套件包…"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:757
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:945
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1226
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1234
 msgid "Version"
 msgstr "版本"
 
@@ -360,24 +369,24 @@ msgstr "版本不相容"
 msgid "Waiting for the <em>opkg %h</em> command to complete…"
 msgstr "等待 <em>opkg %h</em> 指令完成…"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1190
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1198
 msgctxt "Display translation packages"
 msgid "all"
 msgstr "全部"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1177
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1185
 msgctxt "Display translation packages"
 msgid "filtered"
 msgstr "已過濾"
 
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1203
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1211
 msgctxt "Display translation packages"
 msgid "none"
 msgstr "沒有"
 
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:673
 #: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:934
-#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1135
+#: applications/luci-app-opkg/htdocs/luci-static/resources/view/opkg.js:1143
 msgid "unknown"
 msgstr "未知"
 


### PR DESCRIPTION
A proposal for a fix for #6413 

It is a well-known fact that opkg doesn't check ABI-compatibility between dependencies and upgrading packages in a stable release is therefore not recommended. In addition, installing and removing packages blindly may result in rendering the device inaccessible as well, so caution should be taken when doing this.

This commit adds a warning which should help notify especially new users about these behaviors with a link to the wiki which advises to not upgrade packages.

See https://openwrt.org/meta/infobox/upgrade_packages_warning for more info, which is the same link that is used in the second paragraph.

Tested on Chrome and Firefox, both desktop and mobile (Android). All CSS used is theme-compatible and should therefore look at least decent across different themes.

![Screenshot_44](https://github.com/openwrt/luci/assets/7290072/9b8e0e9f-e996-40f4-87e4-8ad36e7c2f0b)

![Screenshot_45](https://github.com/openwrt/luci/assets/7290072/4a66dca7-5973-4ff0-b244-e3aa58a81446)

<details>
  <summary>First iteration of design, not relevant anymore</summary>

BootstrapLight:
![Screenshot_39](https://github.com/openwrt/luci/assets/7290072/a14fe02b-1d8a-4b3f-ae17-69aa3db4ded6)

BootstrapDark:
![Screenshot_40](https://github.com/openwrt/luci/assets/7290072/710b82eb-f8eb-49c1-9b03-1a956cca65cb)

Material:
![Screenshot_41](https://github.com/openwrt/luci/assets/7290072/765de4f6-a298-4362-ac3b-ba02bb58f6be)

OpenWrt2020:
![Screenshot_42](https://github.com/openwrt/luci/assets/7290072/934cd549-bc50-4637-be8d-251ab8ca1584)
</summary>