### PR TITLE
luci-app-speedtest: add new packages

### DIFF
--- a/applications/luci-app-speedtest/Makefile
+++ b/applications/luci-app-speedtest/Makefile
@@ -4,12 +4,11 @@
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=LuCI for speedtest
+LUCI_TITLE:=LuCI for speedtestcpp
 LUCI_DEPENDS:=+speedtestcpp
-LUCI_DESCRIPTION:=LuCI support for Speedtestcpp
 
 PKG_MAINTAINER:=Hilman Maulana <hilman0.0maulana@gmail.com>
-PKG_VERSION:=1.1
+PKG_VERSION:=1.0
 PKG_LICENSE:=Apache-2.0
 
 include ../../luci.mk

--- a/applications/luci-app-speedtest/Makefile
+++ b/applications/luci-app-speedtest/Makefile
@@ -1,0 +1,17 @@
+# This is free software, licensed under the Apache License, Version 2.0
+#
+# Copyright (C) 2024 Hilman Maulana <hilman0.0maulana@gmail.com>
+
+include $(TOPDIR)/rules.mk
+
+LUCI_TITLE:=LuCI for speedtest
+LUCI_DEPENDS:=+speedtestcpp
+LUCI_DESCRIPTION:=LuCI support for Speedtestcpp
+
+PKG_MAINTAINER:=Hilman Maulana <hilman0.0maulana@gmail.com>
+PKG_VERSION:=1.1
+PKG_LICENSE:=Apache-2.0
+
+include ../../luci.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js
+++ b/applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js
@@ -12,6 +12,10 @@ return view.extend({
 	handleSave: null,
 	handleReset: null,
 	render: function() {
+		var header = [
+			E('h2', {'class': 'section-title'}, _('Speedtest')),
+			E('div', {'class': 'cbi-map-descr'}, _('Here you can perform a speed test to measure the basic aspects of your network connection.'))
+		];
 		var select = [
 			E('label', { 'class': 'cbi-input-label', 'for': 'speedtest-type', 'style': 'margin-right: 8px;'}, _('Test')),
 			E('select', { 'id': 'speedtest-type', 'style': 'width:80%;'}, [
@@ -24,47 +28,6 @@ return view.extend({
 		var status = [
 			E('label', { 'class': 'cbi-input-label', 'style': 'margin-right: 8px;'}, _('Status')),
 			E('em', { 'id': 'speedtest-status'}, _('Available'))
-		];
-		var running = false;
-		var button = [
-			E('button', {
-				'class': 'btn cbi-button cbi-button-action',
-				'click': function() {
-					if (!running) {
-						running = true;
-						var dropdown = document.getElementById('speedtest-type');
-						var value = dropdown.options[dropdown.selectedIndex].value;
-						var command = ['--output', 'json'];
-						if (value !== 'all') {
-							command.push('--' + value);
-						}
-
-						var status = document.getElementById('speedtest-status');
-						status.textContent = _('Running');
-
-						fs.exec_direct('speedtest', command)
-						.then(function(response) {
-							var result = JSON.parse(response);
-							document.getElementById('client-ip').textContent = result.client.ip;
-							document.getElementById('client-isp').textContent = result.client.isp + ' [' + result.client.lat + ', ' + result.client.lon + ']';
-							document.getElementById('server-name').textContent = result.server.sponsor;
-							document.getElementById('server-id').textContent = result.server.id;
-							document.getElementById('server-location').textContent = result.server.name + ' (' + result.server.distance + ' km)';
-							document.getElementById('server-host').textContent = result.server.host;
-							document.getElementById('ping').textContent = result.ping + ' ms';
-							document.getElementById('jitter').textContent = result.jitter + ' ms';
-							document.getElementById('download').textContent = result.download_mbit ? result.download_mbit + ' Mbit/s' : '-';
-							document.getElementById('upload').textContent = result.upload_mbit ? result.upload_mbit + ' Mbit/s' : '-';
-							status.textContent = _('Finished');
-							running = false;
-						})
-						.catch(function(err) {
-							status.textContent = err;
-							running = false;
-						});
-					}
-				}
-			}, _('Run Speedtest'))
 		];
 		var table = [
 			E('h3', {'class': 'section-title'}, _('Results')),
@@ -114,9 +77,55 @@ return view.extend({
 				])
 			])
 		];
-		var body = E('div', {'class': 'cbi-map'}, [
-			E('h2', {'class': 'section-title'}, _('Speedtest')),
-			E('div', {'class': 'cbi-map-descr'}, _('Here you can perform a speedtest to measure the basic aspects of your network connection.')),
+		var running = false;
+		var button = [
+			E('button', {
+				'class': 'btn cbi-button cbi-button-action',
+				'click': function() {
+					if (!running) {
+						running = true;
+						var dropdown = document.getElementById('speedtest-type');
+						var value = dropdown.options[dropdown.selectedIndex].value;
+						var command = ['--output', 'json'];
+						if (value !== 'all') {
+							command.push('--' + value);
+						}
+
+						var status = document.getElementById('speedtest-status');
+						status.textContent = _('Running');
+
+						fs.exec_direct('speedtest', command)
+						.then(function(response) {
+							var result = JSON.parse(response);
+							document.getElementById('client-ip').textContent = result.client.ip;
+							document.getElementById('client-isp').textContent = result.client.isp + ' [' + result.client.lat + ', ' + result.client.lon + ']';
+							document.getElementById('server-name').textContent = result.server.sponsor;
+							document.getElementById('server-id').textContent = result.server.id;
+							document.getElementById('server-location').textContent = result.server.name + ' (' + result.server.distance + ' km)';
+							document.getElementById('server-host').textContent = result.server.host;
+							document.getElementById('ping').textContent = result.ping + ' ms';
+							document.getElementById('jitter').textContent = result.jitter + ' ms';
+							document.getElementById('download').textContent = result.download_mbit ? result.download_mbit + ' Mbit/s' : '-';
+							document.getElementById('upload').textContent = result.upload_mbit ? result.upload_mbit + ' Mbit/s' : '-';
+							status.textContent = _('Finished');
+							running = false;
+						})
+						.catch(function(err) {
+							if (!err.response) {
+								status.textContent = _('No response received from speedtest. Please check your internet connection or try again later.');
+							} else if (err.response.data && err.response.data.error === 'unable to retrieve your ip info') {
+								status.textContent = _('Unable to retrieve IP information. Please check your internet connection.');
+							} else {
+								status.textContent = err;
+							}
+							running = false;
+						});
+					}
+				}
+			}, _('Start'))
+		];
+		return E('div', {'class': 'cbi-map'}, [
+			E(header),
 			E('table', {'class': 'table'}, [
 				E('tr', {'class': 'tr'}, [
 					E('td', {'class': 'td', 'style': 'overflow:initial;'}, select),
@@ -127,7 +136,6 @@ return view.extend({
 			E('div', {'class': 'cbi-section'}, [
 				E('div', {'class': 'speedtest-info'}, table)
 			])
-		]);
-		return body
+		])
 	}
 })

--- a/applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js
+++ b/applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js
@@ -1,0 +1,133 @@
+/* This is free software, licensed under the Apache License, Version 2.0
+ *
+ * Copyright (C) 2024 Hilman Maulana <hilman0.0maulana@gmail.com>
+ */
+
+'use strict';
+'require view';
+'require fs';
+
+return view.extend({
+	handleSaveApply: null,
+	handleSave: null,
+	handleReset: null,
+	render: function() {
+		var select = [
+			E('label', { 'class': 'cbi-input-label', 'for': 'speedtest-type', 'style': 'margin-right: 8px;'}, _('Test')),
+			E('select', { 'id': 'speedtest-type', 'style': 'width:80%;'}, [
+				E('option', { 'value': 'all', 'selected': 'selected'}, _('All')),
+				E('option', { 'value': 'latency' }, _('Latency')),
+				E('option', { 'value': 'download' }, _('Download')),
+				E('option', { 'value': 'upload' }, _('Upload'))
+			])
+		];
+		var status = [
+			E('label', { 'class': 'cbi-input-label', 'style': 'margin-right: 8px;'}, _('Status')),
+			E('em', { 'id': 'speedtest-status'}, _('Available'))
+		];
+		var running = false;
+		var button = [
+			E('button', {
+				'class': 'btn cbi-button cbi-button-action',
+				'click': function() {
+					if (!running) {
+						running = true;
+						var dropdown = document.getElementById('speedtest-type');
+						var value = dropdown.options[dropdown.selectedIndex].value;
+						var command = ['--output', 'json'];
+						if (value !== 'all') {
+							command.push('--' + value);
+						}
+
+						var status = document.getElementById('speedtest-status');
+						status.textContent = _('Running');
+
+						fs.exec_direct('speedtest', command)
+						.then(function(response) {
+							var result = JSON.parse(response);
+							document.getElementById('client-ip').textContent = result.client.ip;
+							document.getElementById('client-isp').textContent = result.client.isp + ' [' + result.client.lat + ', ' + result.client.lon + ']';
+							document.getElementById('server-name').textContent = result.server.sponsor;
+							document.getElementById('server-id').textContent = result.server.id;
+							document.getElementById('server-location').textContent = result.server.name + ' (' + result.server.distance + ' km)';
+							document.getElementById('server-host').textContent = result.server.host;
+							document.getElementById('ping').textContent = result.ping + ' ms';
+							document.getElementById('jitter').textContent = result.jitter + ' ms';
+							document.getElementById('download').textContent = result.download_mbit ? result.download_mbit + ' Mbit/s' : '-';
+							document.getElementById('upload').textContent = result.upload_mbit ? result.upload_mbit + ' Mbit/s' : '-';
+							status.textContent = _('Finished');
+							running = false;
+						})
+						.catch(function(err) {
+							status.textContent = err;
+							running = false;
+						});
+					}
+				}
+			}, _('Run Speedtest'))
+		];
+		var table = [
+			E('h3', {'class': 'section-title'}, _('Results')),
+			E('table', {'class': 'table cbi-section-table'}, [
+				E('tr', {'class': 'tr table-title'}, [
+					E('th', {'class': 'th ', 'style': 'display: none;'})
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-1'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('IP Address')),
+					E('td', {'class': 'td', 'id': 'client-ip'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-2'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('Provider')),
+					E('td', {'class': 'td', 'id': 'client-isp'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-1'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('Server')),
+					E('td', {'class': 'td', 'id': 'server-name'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-2'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('ID')),
+					E('td', {'class': 'td', 'id': 'server-id'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-1'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('Location')),
+					E('td', {'class': 'td', 'id': 'server-location'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-2'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('Server Host')),
+					E('td', {'class': 'td', 'id': 'server-host'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-1'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('Ping')),
+					E('td', {'class': 'td', 'id': 'ping'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-2'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('Jitter')),
+					E('td', {'class': 'td', 'id': 'jitter'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-1'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('Download Speed')),
+					E('td', {'class': 'td', 'id': 'download'}, '-')
+				]),
+				E('tr', {'class': 'tr cbi-rowstyle-2'},[
+					E('td', {'class': 'td left', 'width': '50%'}, _('Upload Speed')),
+					E('td', {'class': 'td', 'id': 'upload'}, '-')
+				])
+			])
+		];
+		var body = E('div', {'class': 'cbi-map'}, [
+			E('h2', {'class': 'section-title'}, _('Speedtest')),
+			E('div', {'class': 'cbi-map-descr'}, _('Here you can perform a speedtest to measure the basic aspects of your network connection.')),
+			E('table', {'class': 'table'}, [
+				E('tr', {'class': 'tr'}, [
+					E('td', {'class': 'td', 'style': 'overflow:initial;'}, select),
+					E('td', {'class': 'td', 'style': 'overflow:initial;'}, button),
+					E('td', {'class': 'td'}, status)
+				])
+			]),
+			E('div', {'class': 'cbi-section'}, [
+				E('div', {'class': 'speedtest-info'}, table)
+			])
+		]);
+		return body
+	}
+})

--- a/applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js
+++ b/applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js
@@ -112,9 +112,9 @@ return view.extend({
 						})
 						.catch(function(err) {
 							if (!err.response) {
-								status.textContent = _('No response received from speedtest. Please check your internet connection or try again later.');
+								status.textContent = _('No response received, please check your internet connection or try again later.');
 							} else if (err.response.data && err.response.data.error === 'unable to retrieve your ip info') {
-								status.textContent = _('Unable to retrieve IP information. Please check your internet connection.');
+								status.textContent = _('Unable to retrieve IP information, please check your internet connection.');
 							} else {
 								status.textContent = err;
 							}

--- a/applications/luci-app-speedtest/po/templates/speedtest.pot
+++ b/applications/luci-app-speedtest/po/templates/speedtest.pot
@@ -1,99 +1,107 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
-#: applications/luci-app-speedtest/root/usr/share/luci/menu.d/luci-app-speedtest.json:3
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:118
-msgid "Speedtest"
-msgstr ""
-
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:119
-msgid "Here you can perform a speedtest to measure the basic aspects of your network connection."
-msgstr ""
-
 #: applications/luci-app-speedtest/root/usr/share/rpcd/acl.d/luci-app-speedtest.json:3
 msgid "Grant access to speedtest"
 msgstr ""
 
+#: applications/luci-app-speedtest/root/usr/share/luci/menu.d/luci-app-speedtest.json:3
 #: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:16
-msgid "Test"
+msgid "Speedtest"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:18
-msgid "All"
-msgstr ""
-
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:19
-msgid "Latency"
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:17
+msgid "Here you can perform a speed test to measure the basic aspects of your network connection."
 msgstr ""
 
 #: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:20
+msgid "Test"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:22
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:23
+msgid "Latency"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:24
 msgid "Download"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:21
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:25
 msgid "Upload"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:25
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:29
 msgid "Status"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:26
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:30
 msgid "Available"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:43
-msgid "Running"
-msgstr ""
-
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:58
-msgid "Finished"
-msgstr ""
-
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:67
-msgid "Run Speedtest"
-msgstr ""
-
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:70
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:33
 msgid "Results"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:76
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:39
 msgid "IP Address"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:80
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:43
 msgid "Provider"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:84
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:47
 msgid "Server"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:88
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:51
 msgid "ID"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:92
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:55
 msgid "Location"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:96
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:59
 msgid "Server Host"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:100
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:63
 msgid "Ping"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:104
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:67
 msgid "Jitter"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:100
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:71
 msgid "Download Speed"
 msgstr ""
 
-#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:112
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:75
 msgid "Upload Speed"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:95
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:110
+msgid "Finished"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:115
+msgid "No response received from speedtest. Please check your internet connection or try again later."
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:117
+msgid "Unable to retrieve IP information. Please check your internet connection."
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:125
+msgid "Start"
 msgstr ""

--- a/applications/luci-app-speedtest/po/templates/speedtest.pot
+++ b/applications/luci-app-speedtest/po/templates/speedtest.pot
@@ -1,0 +1,99 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+#: applications/luci-app-speedtest/root/usr/share/luci/menu.d/luci-app-speedtest.json:3
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:118
+msgid "Speedtest"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:119
+msgid "Here you can perform a speedtest to measure the basic aspects of your network connection."
+msgstr ""
+
+#: applications/luci-app-speedtest/root/usr/share/rpcd/acl.d/luci-app-speedtest.json:3
+msgid "Grant access to speedtest"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:16
+msgid "Test"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:18
+msgid "All"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:19
+msgid "Latency"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:20
+msgid "Download"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:21
+msgid "Upload"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:25
+msgid "Status"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:26
+msgid "Available"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:43
+msgid "Running"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:58
+msgid "Finished"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:67
+msgid "Run Speedtest"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:70
+msgid "Results"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:76
+msgid "IP Address"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:80
+msgid "Provider"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:84
+msgid "Server"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:88
+msgid "ID"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:92
+msgid "Location"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:96
+msgid "Server Host"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:100
+msgid "Ping"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:104
+msgid "Jitter"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:100
+msgid "Download Speed"
+msgstr ""
+
+#: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:112
+msgid "Upload Speed"
+msgstr ""

--- a/applications/luci-app-speedtest/po/templates/speedtest.pot
+++ b/applications/luci-app-speedtest/po/templates/speedtest.pot
@@ -95,11 +95,11 @@ msgid "Finished"
 msgstr ""
 
 #: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:115
-msgid "No response received from speedtest. Please check your internet connection or try again later."
+msgid "No response received, please check your internet connection or try again later."
 msgstr ""
 
 #: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:117
-msgid "Unable to retrieve IP information. Please check your internet connection."
+msgid "Unable to retrieve IP information, please check your internet connection."
 msgstr ""
 
 #: applications/luci-app-speedtest/htdocs/luci-static/resources/view/speedtest.js:125

--- a/applications/luci-app-speedtest/root/usr/share/luci/menu.d/luci-app-speedtest.json
+++ b/applications/luci-app-speedtest/root/usr/share/luci/menu.d/luci-app-speedtest.json
@@ -1,0 +1,13 @@
+{
+	"admin/network/speedtest": {
+		"title": "Speedtest",
+		"order": 50,
+		"action": {
+			"type": "view",
+			"path": "speedtest"
+		},
+		"depends": {
+			"acl": [ "luci-app-speedtest" ]
+		}
+	}
+}

--- a/applications/luci-app-speedtest/root/usr/share/rpcd/acl.d/luci-app-speedtest.json
+++ b/applications/luci-app-speedtest/root/usr/share/rpcd/acl.d/luci-app-speedtest.json
@@ -1,0 +1,10 @@
+{
+	"luci-app-speedtest": {
+		"description": "Grant access to speedtest",
+		"write": {
+			"file": {
+				"/usr/bin/speedtest": [ "exec"]
+			}
+		}
+	}
+}

--- a/applications/luci-app-speedtest/root/usr/share/rpcd/acl.d/luci-app-speedtest.json
+++ b/applications/luci-app-speedtest/root/usr/share/rpcd/acl.d/luci-app-speedtest.json
@@ -3,7 +3,7 @@
 		"description": "Grant access to speedtest",
 		"write": {
 			"file": {
-				"/usr/bin/speedtest": [ "exec"]
+				"/usr/bin/speedtest": [ "exec" ]
 			}
 		}
 	}


### PR DESCRIPTION
# LuCI for Speedtest

![image](https://github.com/openwrt/luci/assets/14136053/fe0f3d97-0aad-4288-8e01-1889954fa7ec)

I feel this is very helpful for those of us who don't want the hassle of going to the terminal just to check the internet speed of OpenWrt devices. Especially for those who are remote accessing from outside the network.