### PR TITLE
luci-base: use correct regex for time validation

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/validation.js
+++ b/modules/luci-base/htdocs/luci-static/resources/validation.js
@@ -563,7 +563,7 @@ var ValidatorFactory = baseclass.extend({
 		},
 
 		timehhmmss: function() {
-			return this.assert(this.value.match(/^[0-6][0-9]:[0-6][0-9]:[0-6][0-9]$/),
+			return this.assert(this.value.match(/^(?:[01]\d|2[0-3]):[0-5]\d:(?:[0-5]\d|60)$/),
 				_('valid time (HH:MM:SS)'));
 		},
 


### PR DESCRIPTION
Before this change, values further in time than 23:59:59 was allowed, such as 24:00:00 and 23:60:00. Leap seconds is accounted for so 60 is allowed in the seconds parameter.

First reported in https://github.com/openwrt/luci/issues/6965 and https://forum.openwrt.org/t/openwrt-23-05-2-service-release/177709/303

![Screenshot_29](https://github.com/openwrt/luci/assets/7290072/500f775f-8344-470e-938f-891b08f9ea9e)
![Screenshot_28](https://github.com/openwrt/luci/assets/7290072/f97038b4-4f7c-4377-aa4f-cdef2c25bcb4)
![Screenshot_21](https://github.com/openwrt/luci/assets/7290072/d62c7535-8967-4d17-8ca5-385edd160d08)
![Screenshot_22](https://github.com/openwrt/luci/assets/7290072/81ebacd1-999b-42bf-8536-c2cf92876cc7)

After fix:
![Screenshot_30](https://github.com/openwrt/luci/assets/7290072/5a56c58e-07ab-42fb-9db6-2480a4b29a60)

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile (package doesn't have one, not applicable)
- [X] Tested on: (x86/generic, OpenWrt 23.05.2, Chrome and Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @jow- 
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
