### PR TITLE
luci-app-statistics: Add UI to configure Mqtt

### DIFF
--- a/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/mqtt.js
+++ b/applications/luci-app-statistics/htdocs/luci-static/resources/view/statistics/plugins/mqtt.js
@@ -1,0 +1,88 @@
+'use strict';
+'require baseclass';
+'require form';
+
+return baseclass.extend({
+    title: _('Mqtt Plugin Configuration'),
+
+    addFormOptions: function(s) {
+        let o, ss;
+
+        o = s.option(form.Flag, 'enable', _('Sends or receives data via mqtt'));
+
+        o = s.option(form.SectionValue, '__blocks', form.GridSection, 'collectd_mqtt_block');
+        o.depends('enable', '1');
+
+        ss = o.subsection;
+        ss.anonymous = true;
+        ss.addremove = true;
+
+        o = ss.option(form.ListValue, 'blocktype', _('Type'));
+        o.value('Publish', _('Publish'));
+        o.value('Subscribe', _('Subscribe'));
+        o.default = 'Publish';
+
+        o = ss.option(form.Value, 'name', _('Name'));
+        o.optional = false;
+        o.rmempty = false;
+
+        o = ss.option(form.Value, 'Host', _('Host'));
+        o.datatype = 'host';
+        o.optional = false;
+        o.rmempty = false;
+
+        o = ss.option(form.Value, 'Port', _('Port'));
+        o.datatype = 'port';
+        o.optional = true;
+
+        o = ss.option(form.Value, 'User', _('User'));
+        o.optional = true;
+
+        o = ss.option(form.Value, 'Password', _('Password'));
+        o.password = true;
+        o.optional = true;
+        o.modalonly = true;
+
+        o = ss.option(form.ListValue, 'Qos', _('QoS'));
+        o.value('0', _('0 - At most once'));
+        o.value('1', _('1 - At least once'));
+        o.value('2', _('2 - Exactly once'));
+        o.modalonly = true;
+        o.optional = true;
+
+        o = ss.option(form.Value, 'Prefix', _('Prefix'));
+        o.depends('blocktype', 'Publish');
+        o.optional = true;
+        o.modalonly = true;
+
+        o = ss.option(form.ListValue, 'Retain', _('Retain'));
+        o.depends('blocktype', 'Publish');
+        o.value('true', _('True'));
+        o.value('false', _('False'));
+        o.optional = true;
+        o.modalonly = true;
+
+        o = ss.option(form.ListValue, 'StoreRates', _('StoreRates'));
+        o.depends('blocktype', 'Publish');
+        o.value('true', _('True'));
+        o.value('false', _('False'));
+        o.modalonly = true;
+        o.optional = true;
+
+        o = ss.option(form.ListValue, 'CleanSession', _('CleanSession'));
+        o.depends('blocktype', 'Subscribe');
+        o.value('true', _('True'));
+        o.value('false', _('False'));
+        o.optional = true;
+        o.modalonly = true;
+
+        o = ss.option(form.Value, 'Topic', _('Topic'));
+        o.depends('blocktype', 'Subscribe');
+        o.optional = true;
+        o.modalonly = true;
+    },
+
+    configSummary: function(section) {
+        return _('Mqtt plugin enabled');
+    }
+});

--- a/applications/luci-app-statistics/root/usr/libexec/stat-genconfig
+++ b/applications/luci-app-statistics/root/usr/libexec/stat-genconfig
@@ -241,6 +241,33 @@ function config_network(c) {
 	;
 }
 
+function config_mqtt(c) {
+	let str = "";
+
+	for (let k, s in sections) {
+			if (s['.type'] === 'collectd_mqtt_block') {
+					const isPublish = s['blocktype'] === 'Publish';
+
+					str += isPublish ? `\t<Publish "${s.name}">\n` : `\t<Subscribe "${s.name}">\n`;
+
+					str += `\t\tHost "${s.Host}"\n`;
+					str += s['Port'] ? `\t\tPort ${s.Port}\n` : '';
+					str += s['User'] ? `\t\tUser "${s.User}"\n` : '';
+					str += s['Password'] ? `\t\tPassword "${s.Password}"\n` : '';
+					str += s['Qos'] ? `\t\tQos ${s.Qos}\n` : '';
+					str += s['Prefix'] ? `\t\tPrefix ${s.Prefix}\n` : '';
+					str += s['Retain'] ? `\t\tRetain ${s.Retain}\n` : '';
+					str += s['StoreRates'] ? `\t\tRetain ${s.StoreRates}\n` : '';
+					str += s['CleanSession'] ? `\t\tRetain ${s.CleanSession}\n` : '';
+					str += s['Topic'] ? `\t\tTopic "${s.Topic}"\n` : '';
+
+					str += isPublish ? `\t</Publish>\n` : `\t</Subscribe>\n`;
+			}
+	}
+
+	return str;
+}
+
 function section(plugin) {
 	let config = sections[`collectd_${plugin}`] ?? sections.collectd;
 
@@ -270,6 +297,7 @@ for (let filename in lsdir(plugin_dir)) {
 	case 'iptables': plugins[name] = config_iptables; break;
 	case 'curl':     plugins[name] = config_curl;     break;
 	case 'network':  plugins[name] = config_network;  break;
+	case 'mqtt':     plugins[name] = config_mqtt;     break;
 	default:
 		plugins[name] = json(open(`${plugin_dir}/${filename}`))?.legend;
 	}

--- a/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/mqtt.json
+++ b/applications/luci-app-statistics/root/usr/share/luci/statistics/plugins/mqtt.json
@@ -1,0 +1,4 @@
+{
+	"title": "Mqtt",
+	"category": "output"
+}


### PR DESCRIPTION
This commit adds UI to configure the Mqtt plugin of the luci-app-statistics.

This PR https://github.com/openwrt/packages/pull/20662 added the possibility of use UCI commands some time ago, now this PR adds the LuCi way. Some screen captures:

![image](https://github.com/openwrt/luci/assets/2673520/fe606dd7-12e9-4384-aa8a-41db9b4606cc)

![image](https://github.com/openwrt/luci/assets/2673520/ae0d0027-3f0e-46d5-96a9-80e02f0e8147)

![image](https://github.com/openwrt/luci/assets/2673520/48d3e53a-7ae0-4247-8a5a-e7e6de74661b)

The UCI part was based on the cURL plugin, so I did the same in the UI part.

~~I've tested it and one thing is not working: the mandatory fields (not optional) are not being validated, so the user can left this fields empty. I don't know why it not works, maybe someone can point me to the bug.~~ I've fixed it but I'm not too sure if it's the correct way: to be mandatory it needs to have `optional = false` AND `rmempty = false`. 