### PR TITLE
rpcd-mod-luci: use standard POSIX header for basename()

### DIFF
--- a/libs/rpcd-mod-luci/Makefile
+++ b/libs/rpcd-mod-luci/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=rpcd-mod-luci
-PKG_VERSION:=20230123
+PKG_VERSION:=20240305
 PKG_RELEASE:=1
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 

--- a/libs/rpcd-mod-luci/src/luci.c
+++ b/libs/rpcd-mod-luci/src/luci.c
@@ -19,7 +19,7 @@
 #define _GNU_SOURCE
 
 #include <stdio.h>
-#include <string.h>
+#include <libgen.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdarg.h>


### PR DESCRIPTION
The musl libc only implements POSIX basename() but provided a GNU header kludge in <string.h>, which is removed in musl 1.2.5 [1]. Use the standard <libgen.h> header to avoid compilation errors like:

luci.c: In function 'rpc_luci_parse_network_device_sys': luci.c:676:53: error: implicit declaration of function 'basename' [-Werror=implicit-function-declaration]
  676 |                 blobmsg_add_string(&blob, "master", basename(link));
      |                                                     ^~~~~~~~
luci.c:676:53: error: passing argument 3 of 'blobmsg_add_string' makes pointer from integer without a cast [-Werror=int-conversion]
  676 |                 blobmsg_add_string(&blob, "master", basename(link));
      |                                                     ^~~~~~~~~~~~~~
      |                                                     |
      |                                                     int
...
cc1: all warnings being treated as errors

Link 1: https://git.musl-libc.org/cgit/musl/log/?qt=grep&q=basename

@jow- This change is needed by https://github.com/openwrt/openwrt/pull/14802 and was tested therein.


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (built and run on QEMU against master/malta/le64 and armsr/32) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [x] Description: (describe the changes proposed in this PR)
