### PR TITLE
Make Realtime Graphs Respect Bootstrap Dark Mode

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2570,7 +2570,7 @@ div.cbi-value var.cbi-tooltip-container,
 	background-color: var(--background-color-high)!important;
 }
 
-[data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div div > div > div[style]{
+[data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div[style]{
 	background-color: var(--background-color-high)!important;
 }
 

--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2565,3 +2565,15 @@ div.cbi-value var.cbi-tooltip-container,
 [data-page="admin-system-admin-sshkeys"] .cbi-dynlist {
 	max-width: none;
 }
+
+[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div[style]{
+	background-color: var(--background-color-high)!important;
+}
+
+[data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div div > div > div[style]{
+	background-color: var(--background-color-high)!important;
+}
+
+[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div[style]{
+	background-color: var(--background-color-high)!important;
+}


### PR DESCRIPTION
Currently, the realtime graphs, under Status > Realtime Graphs are always white, even in Bootstrap Dark theme. 

This change will make the graphs dark in darkmode. Note, it may not work for all graphs yet, I wanted to get some guidance on whether this is the right direction before making sure all the realtime graphs work. 

This is my first PR so please be patient if I have done anything incorrectly. 

Example of dark graph. 
Currently the graph lines do not show up well, I can work on that if requested. 

<img width="721" alt="darkmodeGraph" src="https://github.com/openwrt/luci/assets/28635265/05b7558c-fa99-4097-a495-d76b2adae8f5">
