### PR TITLE
Make Realtime Graphs Respect Bootstrap Dark Mode

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2565,3 +2565,15 @@ div.cbi-value var.cbi-tooltip-container,
 [data-page="admin-system-admin-sshkeys"] .cbi-dynlist {
 	max-width: none;
 }
+
+[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div[style] {
+	background-color: var(--background-color-high)!important;
+}
+
+[data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div > div[style] {
+	background-color: var(--background-color-high)!important;
+}
+
+[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div[style] {
+	background-color: var(--background-color-high)!important;
+}


### PR DESCRIPTION
Currently, the realtime graphs, under Status > Realtime Graphs are always white, even in Bootstrap Dark theme.

This change will make the graphs dark in darkmode.  I wanted to get some guidance on whether this is the right direction.
I used !important to set the color because I needed to override the JS which is setting the background white directly. I looked at fixing this in the javascript but there doesn't seem to be common variables among the different themes, so this way seemed the simplest. 

This is my first PR so please be patient if I have done anything incorrectly.

Example of dark graph.
Currently the graph lines do not show up well, I can work on that if requested.


<img width="721" alt="darkmodeGraph" src="https://github.com/openwrt/luci/assets/28635265/d26248d0-6e04-4b9c-91d5-4979ddeb17bc">
