### PR TITLE
luci-app-dockerman: Add dockerd and docker-compose as dependency

### DIFF
--- a/applications/luci-app-dockerman/Makefile
+++ b/applications/luci-app-dockerman/Makefile
@@ -6,7 +6,9 @@ LUCI_DEPENDS:=@(aarch64||arm||x86_64) \
 	+luci-compat \
 	+luci-lib-docker \
 	+docker \
-	+ttyd
+	+ttyd \
+	+dockerd \
+	+docker-compose
 
 PKG_LICENSE:=AGPL-3.0
 PKG_MAINTAINER:=lisaac <lisaac.cn@gmail.com> \


### PR DESCRIPTION
When installing luci-app-dockerman the webui appears empty and unusable if these dependencies are not installed (see https://forum.openwrt.org/t/luci-app-dockerman-missing-configuration-on-23-05-02/184043). Fix it by declaring them.

CC @lisaac 