### PR TITLE
luci-base: fix license

### DIFF
--- a/modules/luci-base/Makefile
+++ b/modules/luci-base/Makefile
@@ -27,7 +27,7 @@ LUCI_DEPENDS:=\
 	+ucode-mod-html \
 	+liblucihttp-ucode
 
-PKG_LICENSE:=MIT
+PKG_LICENSE:=Apache-2.0
 
 HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)
 


### PR DESCRIPTION
Mention: @jow- @Ansuel 

Description:
During the update of luasrcdiet with commit b5d5e5bf13e572af7f1589a01bfd338691d5f063 the license was incorrectly changed from 'Apache-2.0' to 'MIT'.

As the name implies, this is the basic package that must be installed on the target for the LuCI to work at all. So changing the license from 'Apache-2.0' to 'MIT' should not have happend, because this information belongs to the package 'luci-base' and to the 'luasrcdiet'.

Therefore, with commit b0d8fff3e40568af633032aacb0624da16f4266c the 'luasrcdiet' was moved to its own package. However, it was forgotten to adapt the licence to 'Apache-2.0' again.

While we are at it, also set the 'PKG_LICENSE_FILES' to 'LICENSE' and 'NOTICE'.
