### PR TITLE
luci-theme-bootstrap: darkmode graphs

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2567,14 +2567,17 @@ div.cbi-value var.cbi-tooltip-container,
 	max-width: none;
 }
 
-[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div[style] {
+[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div > div[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div[style],
+[data-darkmode="true"] [data-page="admin-status-channel_analysis"] #view> div >div > div > div > div[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-wireless"] #view > div > div > div > div[style] {
 	background-color: var(--background-color-high)!important;
 }
 
-[data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div > div[style] {
-	background-color: var(--background-color-high)!important;
-}
-
-[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div[style] {
-	background-color: var(--background-color-high)!important;
+[data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div > svg > line[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div > div > svg > line[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div > svg > line[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-wireless"] #view > div > svg > line[style] {
+	stroke: #fff!important;
 }


### PR DESCRIPTION
This is a continuation of https://github.com/openwrt/luci/pull/6982 
This adds the wireless and channel analysis graphs to be dark in bootstrap dark theme,  and makes the gridlines white so they are visible against the dark background. 

See the below image for an example. 
Note, I was not able to test the wireless and channel analysis graphs because I don't have wireless in my build so if someone could test and confirm that would be helpful. 

<img width="739" alt="darkmodeGraph2" src="https://github.com/openwrt/luci/assets/28635265/f95dcab2-1611-4ce5-b151-1909c37784d3">
