### PR TITLE
luci-theme-bootstrap: Change textarea font-family to monospace

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -259,6 +259,7 @@ input[type="search"]::-webkit-search-decoration {
 textarea {
 	overflow: auto;
 	vertical-align: top;
+	font-family: monospace;
 }
 
 .control-group {
@@ -535,8 +536,7 @@ fieldset legend {
 label,
 input,
 button,
-select,
-textarea {
+select {
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 13px;
 	font-weight: normal;


### PR DESCRIPTION
Better readability for pages that use textarea, similar to `admin/status/logs`.

The pages below use textarea today:
- Startup -> Local Startup
- Flash Firmware -> Configuration
- Diagnostics

Signed-off-by: Kristian Skramstad <kristian+github@83.no>