### PR TITLE
luci-app-nlbwmon: add missing PKG_LICENSE

### DIFF
--- a/applications/luci-app-nlbwmon/Makefile
+++ b/applications/luci-app-nlbwmon/Makefile
@@ -1,5 +1,7 @@
 include $(TOPDIR)/rules.mk
 
+PKG_LICENSE:=Apache-2.0
+
 LUCI_TITLE:=Netlink based bandwidth accounting
 LUCI_DEPENDS:=+luci-base +nlbwmon
 


### PR DESCRIPTION
@jow- As you may have seen, I am currently updating the license information in some makefiles. I have not found anything for the luci-app-nlbwmon. So that I do not commit something wrong!
Is `luci-app-nlbwmon` licensed  under the Apache 2.0?