### PR TITLE
luci-app-dockerman: check for existing IPAM config

### DIFF
--- a/applications/luci-app-dockerman/Makefile
+++ b/applications/luci-app-dockerman/Makefile
@@ -12,7 +12,7 @@ PKG_LICENSE:=AGPL-3.0
 PKG_MAINTAINER:=lisaac <lisaac.cn@gmail.com> \
 		Florian Eckert <fe@dev.tdt.de>
 
-PKG_VERSION:=v0.5.13-20230114
+PKG_VERSION:=v0.5.13-20240317
 
 include ../../luci.mk
 

--- a/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/networks.lua
+++ b/applications/luci-app-dockerman/luasrc/model/cbi/dockerman/networks.lua
@@ -38,8 +38,8 @@ local get_networks = function ()
 			data[index]["_interface"] = v.Options.parent
 		end
 
-		data[index]["_subnet"] = v.IPAM and v.IPAM.Config[1] and v.IPAM.Config[1].Subnet or nil
-		data[index]["_gateway"] = v.IPAM and v.IPAM.Config[1] and v.IPAM.Config[1].Gateway or nil
+		data[index]["_subnet"] = v.IPAM and v.IPAM.Config and v.IPAM.Config[1] and v.IPAM.Config[1].Subnet or nil
+		data[index]["_gateway"] = v.IPAM and v.IPAM.Config and v.IPAM.Config[1] and v.IPAM.Config[1].Gateway or nil
 	end
 
 	return data


### PR DESCRIPTION
Fixes #6973 

This was added in upstream with https://github.com/lisaac/luci-app-dockerman/commit/7292955a1b415bb60fa2e403bb3a437b4b7f7846 so should be fine for us to add it.

Networks tab works again after fix. I'm not entirely sure how to test this properly as I don't use Docker via LuCI myself so any test would be appreciated.

![Screenshot_48](https://github.com/openwrt/luci/assets/7290072/263ca42f-a019-4153-a29b-2555f4b45003)


Ping @leobsky @Joee-D

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (x86/generic, 23.05.2, Firefox) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @feckert (and @lisaac maybe?)
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [X] \( Optional ) Closes: e.g. openwrt/luci#6973
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
