### PR TITLE
luci-theme-bootstrap: darkmode graphs fine-tuning

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -2567,17 +2567,18 @@ div.cbi-value var.cbi-tooltip-container,
 	max-width: none;
 }
 
+[data-darkmode="true"] [data-page="admin-status-channel_analysis"] #view> div > div > div > div > div[style],
 [data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div[style],
 [data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div > div[style],
-[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div[style],
-[data-darkmode="true"] [data-page="admin-status-channel_analysis"] #view> div >div > div > div > div[style],
-[data-darkmode="true"] [data-page="admin-status-realtime-wireless"] #view > div > div > div > div[style] {
+[data-darkmode="true"] [data-page="admin-status-realtime-wireless"] #view > div > div > div > div[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div[style] {
 	background-color: var(--background-color-high)!important;
 }
 
+[data-darkmode="true"] [data-page="admin-status-channel_analysis"] #view> div > div > div > div > div > svg > line[style],
 [data-darkmode="true"] [data-page="admin-status-realtime-load"] #view > div > svg > line[style],
 [data-darkmode="true"] [data-page="admin-status-realtime-bandwidth"] #view > div > div > div > div > svg > line[style],
-[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div > svg > line[style],
-[data-darkmode="true"] [data-page="admin-status-realtime-wireless"] #view > div > svg > line[style] {
+[data-darkmode="true"] [data-page="admin-status-realtime-wireless"] #view > div > div > div > div > svg > line[style],
+[data-darkmode="true"] [data-page="admin-status-realtime-connections"] #view > div > svg > line[style] {
 	stroke: #fff!important;
 }


### PR DESCRIPTION
Fine tuning #6991

Bugfix for the wireless graphs, reorder everything to the same level as displayed in the menu and make the spaces even.

At the realtime graph pages, the brighter lines for Wi-Fi where missing, as well for the channel analysis page:
![grafik](https://github.com/thomasschroeder/luci/assets/9166348/cbf44ecd-2899-427e-b548-16f828bf8e11)

@JimMatthew: As you are unable to test this changes with your wired build, here are some bugfixes for it.