### PR TITLE
luci-mod-status: Move "Scroll to tail" button to header line on syslog and kernellog status pages

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
@@ -35,9 +35,11 @@ return view.extend({
 		});
 
 		return E([], [
-			E('h2', {}, [ _('Kernel Log') ]),
+			E('div', { 'style': 'display:flex; align-items: center; gap: 1rem; padding-bottom: 0.5rem' }, [
+				E('h2', { 'style': 'flex: 1 1 auto' }, [ _('Kernel Log') ]),
+				scrollDownButton
+         ]),
 			E('div', { 'id': 'content_syslog' }, [
-				E('div', {'style': 'padding-bottom: 20px'}, [scrollDownButton]),
 				E('textarea', {
 					'id': 'syslog',
 					'style': 'font-size:12px',
@@ -45,7 +47,7 @@ return view.extend({
 					'wrap': 'off',
 					'rows': loglines.length + 1
 				}, [ loglines.join('\n') ]),
-				E('div', {'style': 'padding-bottom: 20px'}, [scrollUpButton])
+				E('div', {'style': 'padding-bottom: 20px; text-align: right !important'}, [scrollUpButton])
 			])
 		]);
 	},

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
@@ -41,9 +41,11 @@ return view.extend({
 		});
 
 		return E([], [
-			E('h2', {}, [ _('System Log') ]),
+			E('div', { 'style': 'display:flex; align-items: center; gap: 1rem; padding-bottom: 0.5rem;' }, [
+				E('h2', { 'style': 'flex: 1 1 auto' }, [ _('System Log') ]),
+				scrollDownButton
+         ]),
 			E('div', { 'id': 'content_syslog' }, [
-				E('div', {'style': 'padding-bottom: 20px'}, [scrollDownButton]),
 				E('textarea', {
 					'id': 'syslog',
 					'style': 'font-size:12px',
@@ -51,7 +53,7 @@ return view.extend({
 					'wrap': 'off',
 					'rows': loglines.length + 1
 				}, [ loglines.join('\n') ]),
-				E('div', {'style': 'padding-bottom: 20px'}, [scrollUpButton])
+				E('div', {'style': 'padding-bottom: 20px; text-align: right !important'}, [scrollUpButton])
 			])
 		]);
 	},


### PR DESCRIPTION
Page header and footer after moved buttons

![Capture](https://github.com/openwrt/luci/assets/58993776/d83efd49-4cf2-4811-ad38-0a67cf52a459)


![Capture2](https://github.com/openwrt/luci/assets/58993776/7f56b35e-bd08-42dc-970d-02e31a77f8fc)
