### PR TITLE
luci-mod-status: Move "Scroll to tail" button to header line on syslog and kernellog status pages

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
@@ -51,9 +51,11 @@ return view.extend({
 		});
 
 		return E([], [
-			E('h2', {}, [ _('Kernel Log') ]),
+			E('div', { 'style': 'display:flex; align-items:center; gap:5rem; padding-bottom:1rem' }, [
+				E('h2', {}, [ _('Kernel Log') ]),
+				scrollDownButton
+         ]),
 			E('div', { 'id': 'content_syslog' }, [
-				E('div', {'style': 'padding-bottom: 20px'}, [scrollDownButton]),
 				E('textarea', {
 					'id': 'syslog',
 					'style': 'font-size:12px',

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
@@ -55,9 +55,11 @@ return view.extend({
 		});
 
 		return E([], [
-			E('h2', {}, [ _('System Log') ]),
+			E('div', { 'style': 'display:flex; align-items:center; gap:5rem; padding-bottom:1rem' }, [
+				E('h2', {}, [ _('System Log') ]),
+				scrollDownButton
+         ]),
 			E('div', { 'id': 'content_syslog' }, [
-				E('div', {'style': 'padding-bottom: 20px'}, [scrollDownButton]),
 				E('textarea', {
 					'id': 'syslog',
 					'style': 'font-size:12px',


### PR DESCRIPTION
Layout after the changes.

![Button](https://github.com/openwrt/luci/assets/58993776/5258ad15-6c0e-4420-bb2c-c6b7962f3f30)
