### PR TITLE
luci-theme-material: make luci-app-commands command box align with Bootstrap theme

### DIFF
--- a/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
+++ b/themes/luci-theme-material/htdocs/luci-static/material/cascade.css
@@ -2474,19 +2474,8 @@ input[name="nslookup"] {
 }
 
 .commandbox code {
-	position: absolute;
-	overflow: hidden;
-	max-width: 60%;
 	margin-left: 4px;
 	padding: 2px 3px;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-}
-
-.commandbox code:hover {
-	overflow-y: auto;
-	max-height: 50px;
-	white-space: normal;
 }
 
 .commandbox p:first-of-type {


### PR DESCRIPTION
The current implementation made the commands from the app luci-app-commands absolutely positioned which resulted in hiding elements which was underneath it, ie. the buttons. This implementation removes the absolutely positioned behavior making the buttons visible again and as an upside aligns it with how the Bootstrap theme handles commands.

Spawned from https://github.com/openwrt/luci/pull/6936#issuecomment-2006720954. Ping @DittelHome

Before: 
![before](https://github.com/openwrt/luci/assets/7290072/166b0549-a77c-4e79-b9a1-2c820ba67d0f)

After:
![after](https://github.com/openwrt/luci/assets/7290072/1cda5849-02b6-4b87-bf1d-558a3afc21cf)


<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [X] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [X] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [X] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [X] Incremented :up: any `PKG_VERSION` in the Makefile
- [X] Tested on: (x86/64, 23.05.2, Firefox and Chrome) :white_check_mark:
- [X] \( Preferred ) Mention: @ the original code author for feedback @LuttyYang 
- [X] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [X] Description: (describe the changes proposed in this PR)
