### PR TITLE
luci-app-advanced-reboot: prepare migration to APK

### DIFF
--- a/applications/luci-app-advanced-reboot/Makefile
+++ b/applications/luci-app-advanced-reboot/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.net>
-PKG_VERSION:=1.0.1-9
+PKG_VERSION:=1.0.1-r10
 
 LUCI_TITLE:=Advanced Linksys Reboot Web UI
 LUCI_URL:=https://docs.openwrt.melmac.net/luci-app-advanced-reboot/

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/dlink-fgs1210-28.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/dlink-fgs1210-28.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "D-Link",
+	"deviceName": "DGS-1210-28",
+	"boardNames": [ "d-link,dgs-1210-28" ],
+	"partition1MTD": "mtd5",
+	"partition2MTD": "mtd9",
+	"labelOffset": null,
+	"bootEnv1": "bootcmd",
+	"bootEnv1Partition1Value": null,
+	"bootEnv1Partition2Value": "run addargs\\; bootm 0xb4e80000",
+	"bootEnv2": "image",
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": "/dev/mtdblock7"
+}

--- a/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea8100v1.json
+++ b/applications/luci-app-advanced-reboot/root/usr/share/advanced-reboot/devices/linksys-ea8100v1.json
@@ -1,0 +1,14 @@
+{
+	"vendorName": "Linksys",
+	"deviceName": "EA8100v1",
+	"boardNames": [ "linksys,ea8100-v1" ],
+	"partition1MTD": "mtd5",
+	"partition2MTD": "mtd7",
+	"labelOffset": 32,
+	"bootEnv1": "boot_part",
+	"bootEnv1Partition1Value": 1,
+	"bootEnv1Partition2Value": 2,
+	"bootEnv2": null,
+	"bootEnv2Partition1Value": null,
+	"bootEnv2Partition2Value": null
+}


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
