### PR TITLE
luci-proto-nebula: prepare migration to APK

### DIFF
--- a/protocols/luci-proto-nebula/Makefile
+++ b/protocols/luci-proto-nebula/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.6.1-1
+PKG_VERSION:=1.8.2-r2
 
 LUCI_TITLE:=Support for Nebula
 LUCI_DESCRIPTION:=Provides Web UI for Nebula protocol/interface.


### PR DESCRIPTION
Maintainer: me
Compile tested: x86_64, Sophos XG-135r3, OpenWrt 23.05.2
