### PR TITLE
[23.05] luci-app-adblock-fast: prepare migration to APK

### DIFF
--- a/applications/luci-app-adblock-fast/Makefile
+++ b/applications/luci-app-adblock-fast/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=1.1.1-5
+PKG_VERSION:=1.1.1-r7
 
 LUCI_TITLE:=AdBlock-Fast Web UI
 LUCI_DESCRIPTION:=Provides Web UI for adblock-fast service.

--- a/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
+++ b/applications/luci-app-adblock-fast/root/usr/libexec/rpcd/luci.adblock-fast
@@ -120,7 +120,7 @@ get_init_status() {
 	else
 		json_add_boolean 'running' '0'
 	fi
-	json_add_string 'version' "$(get_version "$name")"
+	json_add_string 'version' "$PKG_VERSION"
 	errors="$(ubus_get_data errors)"
 	json_add_array 'errors'
 	if [ -n "$errors" ]; then


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit b6c9d5f9744e8e84829115692e7f02c165cc2a34)
