### PR TITLE
[23.05] luci-app-https-dns-proxy: prepare migration to APK

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -5,7 +5,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2023-11-19-1
+PKG_VERSION:=2023.11.19-r1
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy

--- a/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
+++ b/applications/luci-app-https-dns-proxy/root/usr/libexec/rpcd/luci.https-dns-proxy
@@ -19,7 +19,7 @@ readonly providersDir="/usr/share/${packageName}/providers"
 
 is_enabled() { "/etc/init.d/${1}" enabled; }
 is_running() { [ "$(ubus call service list "{ 'name': '$1' }" | jsonfilter -q -e "@['$1'].instances[*].running" | uniq)" = 'true' ]; }
-get_version() { grep -m1 -A2 -w "^Package: $1$" /usr/lib/opkg/status | sed -n 's/Version: //p'; }
+get_version() { /usr/sbin/https-dns-proxy -V; }
 check_http2() { curl --version | grep -q 'nghttp2'; }
 check_http3() { curl --version | grep -q 'nghttp3'; }
 ubus_get_ports() { ubus call service list "{ 'name': '$packageName' }" | jsonfilter -e "@['${packageName}'].instances[*].data.firewall.*.dest_port"; }


### PR DESCRIPTION
Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit 1efb3cd5f898e41148b298ae6ecdec4a7ae558f8)
