### PR TITLE
treewide: Add missing PKG_MAINTAINER

### DIFF
--- a/applications/luci-app-acl/Makefile
+++ b/applications/luci-app-acl/Makefile
@@ -7,6 +7,8 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=LuCI account management module
 LUCI_DEPENDS:=+luci-base
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-acme/Makefile
+++ b/applications/luci-app-acme/Makefile
@@ -1,7 +1,7 @@
 #
 # Copyright (C) 2010 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
+# This is free software, licensed under the GNU General Public License v3.
 # See /LICENSE for more information.
 #
 

--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -7,6 +7,8 @@ LUCI_TITLE:=LuCI support for Adblock
 LUCI_DEPENDS:=+luci-base +adblock
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Hannu Nyman <hannu.nyman@iki.fi> \
+	Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-adblock/Makefile
+++ b/applications/luci-app-adblock/Makefile
@@ -7,7 +7,7 @@ LUCI_TITLE:=LuCI support for Adblock
 LUCI_DEPENDS:=+luci-base +adblock
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Hannu Nyman <hannu.nyman@iki.fi> \
+PKG_MAINTAINER:=Hannu Nyman <hannu.nyman@iki.fi>, \
 	Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk

--- a/applications/luci-app-ahcp/Makefile
+++ b/applications/luci-app-ahcp/Makefile
@@ -11,6 +11,8 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=LuCI Support for AHCPd
 LUCI_DEPENDS:=+luci-base +luci-compat +ahcpd
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-alist/Makefile
+++ b/applications/luci-app-alist/Makefile
@@ -9,6 +9,8 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=LuCI app for AList
 LUCI_DEPENDS:=+alist
 
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-attendedsysupgrade/Makefile
+++ b/applications/luci-app-attendedsysupgrade/Makefile
@@ -6,6 +6,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for attended sysupgrades
 LUCI_DEPENDS:=+luci-base +attendedsysupgrade-common +cgi-io
 
+PKG_MAINTAINER:=Paul Spooren <paul@spooren.de>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-attendedsysupgrade/Makefile
+++ b/applications/luci-app-attendedsysupgrade/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI support for attended sysupgrades
 LUCI_DEPENDS:=+luci-base +attendedsysupgrade-common +cgi-io
 
 PKG_MAINTAINER:=Paul Spooren <paul@spooren.de>
+PKG_LICENSE:=GPL-2.0
 
 include ../../luci.mk
 

--- a/applications/luci-app-babeld/Makefile
+++ b/applications/luci-app-babeld/Makefile
@@ -3,6 +3,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for babeld
 LUCI_DEPENDS:=+luci-base +babeld
 
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-babeld/Makefile
+++ b/applications/luci-app-babeld/Makefile
@@ -3,6 +3,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for babeld
 LUCI_DEPENDS:=+luci-base +babeld
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 
 include ../../luci.mk

--- a/applications/luci-app-banip/Makefile
+++ b/applications/luci-app-banip/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI support for banIP
 LUCI_DEPENDS:=+luci-base +banip
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-bcp38/Makefile
+++ b/applications/luci-app-bcp38/Makefile
@@ -1,9 +1,7 @@
 #
 # Copyright (C) 2010 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 

--- a/applications/luci-app-clamav/Makefile
+++ b/applications/luci-app-clamav/Makefile
@@ -1,9 +1,7 @@
 #
 # Copyright (C) 2015 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 

--- a/applications/luci-app-commands/Makefile
+++ b/applications/luci-app-commands/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=LuCI Shell Command Module
 LUCI_DEPENDS:=+luci-base
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/applications/luci-app-coovachilli/Makefile
+++ b/applications/luci-app-coovachilli/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=LuCI Support for Coova Chilli
 LUCI_DEPENDS:=+luci-base +luci-compat @BROKEN
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org>, \
 	Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-coovachilli/Makefile
+++ b/applications/luci-app-coovachilli/Makefile
@@ -9,6 +9,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Coova Chilli
 LUCI_DEPENDS:=+luci-base +luci-compat @BROKEN
 
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-coovachilli/Makefile
+++ b/applications/luci-app-coovachilli/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Coova Chilli
 LUCI_DEPENDS:=+luci-base +luci-compat @BROKEN
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
 	Jo-Philipp Wich <jo@mein.io>
 

--- a/applications/luci-app-crowdsec-firewall-bouncer/Makefile
+++ b/applications/luci-app-crowdsec-firewall-bouncer/Makefile
@@ -1,9 +1,7 @@
 #
 # Copyright (C) 2010 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 

--- a/applications/luci-app-cshark/Makefile
+++ b/applications/luci-app-cshark/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Cloudshark capture tool Web UI
 LUCI_DEPENDS:=+luci-base +luci-compat +cshark
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Luka Perkov <luka@openwrt.org>
 
 include ../../luci.mk

--- a/applications/luci-app-dawn/Makefile
+++ b/applications/luci-app-dawn/Makefile
@@ -3,6 +3,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for DAWN
 LUCI_DEPENDS:=+luci-base +dawn
 
+PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-dawn/Makefile
+++ b/applications/luci-app-dawn/Makefile
@@ -3,6 +3,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for DAWN
 LUCI_DEPENDS:=+luci-base +dawn
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Nick Hainke <vincent@systemli.org>
 
 include ../../luci.mk

--- a/applications/luci-app-dcwapd/Makefile
+++ b/applications/luci-app-dcwapd/Makefile
@@ -1,15 +1,14 @@
 #
 # Copyright (C) 2019 EWSI
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Dual Channel Wi-Fi AP Daemon configuration module
 LUCI_DEPENDS:=+luci-base +luci-compat +dcwapd
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Carey Sonsino <csonsino@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-dcwapd/Makefile
+++ b/applications/luci-app-dcwapd/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Dual Channel Wi-Fi AP Daemon configuration module
 LUCI_DEPENDS:=+luci-base +luci-compat +dcwapd
 
+PKG_MAINTAINER:=Carey Sonsino <csonsino@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-dnscrypt-proxy/Makefile
+++ b/applications/luci-app-dnscrypt-proxy/Makefile
@@ -7,6 +7,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for DNSCrypt-Proxy
 LUCI_DEPENDS:=+luci-base +luci-compat +uclient-fetch +dnscrypt-proxy +luci-lib-httpprotoutils
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk

--- a/applications/luci-app-dnscrypt-proxy/Makefile
+++ b/applications/luci-app-dnscrypt-proxy/Makefile
@@ -7,6 +7,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for DNSCrypt-Proxy
 LUCI_DEPENDS:=+luci-base +luci-compat +uclient-fetch +dnscrypt-proxy +luci-lib-httpprotoutils
 
+PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-dump1090/Makefile
+++ b/applications/luci-app-dump1090/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for dump1090
 LUCI_DEPENDS:=+luci-base +luci-compat +dump1090
 
+PKG_MAINTAINER:=Alvaro Fernandez Rojas <noltari@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-dump1090/Makefile
+++ b/applications/luci-app-dump1090/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for dump1090
 LUCI_DEPENDS:=+luci-base +luci-compat +dump1090
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Alvaro Fernandez Rojas <noltari@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-email/Makefile
+++ b/applications/luci-app-email/Makefile
@@ -5,6 +5,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI app for email server configuration (EmailRelay)
 LUCI_DEPENDS:=+luci-base +emailrelay
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Sergey Ponomarev <stokito@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-example/Makefile
+++ b/applications/luci-app-example/Makefile
@@ -7,6 +7,9 @@ LUCI_TITLE:=LuCI example app for js based luci
 LUCI_DEPENDS:=+luci-base
 LUCI_PKGARCH:=all
 
+PKG_MAINTAINER:=Andreas Brau <ab@andi95.de> \
+	Duncan Hill <github.com@cricalix.net>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-example/Makefile
+++ b/applications/luci-app-example/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI example app for js based luci
 LUCI_DEPENDS:=+luci-base
 LUCI_PKGARCH:=all
 
+PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Andreas Brau <ab@andi95.de> \
 	Duncan Hill <github.com@cricalix.net>
 

--- a/applications/luci-app-example/Makefile
+++ b/applications/luci-app-example/Makefile
@@ -8,7 +8,7 @@ LUCI_DEPENDS:=+luci-base
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=GPL-2.0
-PKG_MAINTAINER:=Andreas Brau <ab@andi95.de> \
+PKG_MAINTAINER:=Andreas Brau <ab@andi95.de>, \
 	Duncan Hill <github.com@cricalix.net>
 
 include ../../luci.mk

--- a/applications/luci-app-firewall/Makefile
+++ b/applications/luci-app-firewall/Makefile
@@ -6,10 +6,11 @@
 
 include $(TOPDIR)/rules.mk
 
-LUCI_TITLE:=Firewall and Portforwarding application
+LUCI_TITLE:=Firewall and port forwarding application
 LUCI_DEPENDS:=+luci-base +uci-firewall
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/applications/luci-app-fwknopd/Makefile
+++ b/applications/luci-app-fwknopd/Makefile
@@ -8,7 +8,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Fwknopd config - web config for the firewall knock daemon
 LUCI_DEPENDS:=+luci-base +fwknopd +qrencode
-PKG_LICENSE:=GPLv2
+PKG_LICENSE:=GPL-2.0
 PKG_MAINTAINER:=Jonathan Bennett <JBennett@incomsystems.biz>
 include ../../luci.mk
 

--- a/applications/luci-app-hd-idle/Makefile
+++ b/applications/luci-app-hd-idle/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Hard Disk Idle Spin-Down module
 LUCI_DEPENDS:=+luci-base +hd-idle +lsblk
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-hd-idle/Makefile
+++ b/applications/luci-app-hd-idle/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Hard Disk Idle Spin-Down module
 LUCI_DEPENDS:=+luci-base +hd-idle +lsblk
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-irqbalance/Makefile
+++ b/applications/luci-app-irqbalance/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI support for irqbalance
 LUCI_DEPENDS:=+luci-base +irqbalance
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Puran Lyu <pl2355@nyu.edu>
 
 include ../../luci.mk
 

--- a/applications/luci-app-ksmbd/Makefile
+++ b/applications/luci-app-ksmbd/Makefile
@@ -5,6 +5,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Network Shares - Ksmbd the SMB kernel fileserver
 LUCI_DEPENDS:=+luci-base +ksmbd-server
 
+PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ksmbd/Makefile
+++ b/applications/luci-app-ksmbd/Makefile
@@ -5,6 +5,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Network Shares - Ksmbd the SMB kernel fileserver
 LUCI_DEPENDS:=+luci-base +ksmbd-server
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-ledtrig-rssi/Makefile
+++ b/applications/luci-app-ledtrig-rssi/Makefile
@@ -10,6 +10,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger rssi
 LUCI_DEPENDS:=+luci-base +rssileds
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-ledtrig-rssi/Makefile
+++ b/applications/luci-app-ledtrig-rssi/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger rssi
 LUCI_DEPENDS:=+luci-base +rssileds
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-switch/Makefile
+++ b/applications/luci-app-ledtrig-switch/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger switch
 LUCI_DEPENDS:=+luci-base
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-ledtrig-switch/Makefile
+++ b/applications/luci-app-ledtrig-switch/Makefile
@@ -10,6 +10,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger switch
 LUCI_DEPENDS:=+luci-base
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-ledtrig-usbport/Makefile
+++ b/applications/luci-app-ledtrig-usbport/Makefile
@@ -10,6 +10,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger usbport
 LUCI_DEPENDS:=+luci-base +kmod-usb-ledtrig-usbport
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-ledtrig-usbport/Makefile
+++ b/applications/luci-app-ledtrig-usbport/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:= LuCI Support for ledtrigger usbport
 LUCI_DEPENDS:=+luci-base +kmod-usb-ledtrig-usbport
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-lorawan-basicstation/Makefile
+++ b/applications/luci-app-lorawan-basicstation/Makefile
@@ -11,7 +11,7 @@ LUCI_TITLE:=LuCI Support for LoRaWAN basicstation
 LUCI_DEPENDS:=+luci-base +basicstation
 
 PKG_MAINTAINER:=Marcus Schref <mschref@tdt.de>
-PKG_LICENSE:=APACHE-2.0
+PKG_LICENSE:=Apache-2.0
 
 include ../../luci.mk
 

--- a/applications/luci-app-ltqtapi/Makefile
+++ b/applications/luci-app-ltqtapi/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Lantiq Devices
 LUCI_DEPENDS:=+luci-base +luci-compat @BROKEN
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
 
 include ../../luci.mk

--- a/applications/luci-app-ltqtapi/Makefile
+++ b/applications/luci-app-ltqtapi/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Lantiq Devices
 LUCI_DEPENDS:=+luci-base +luci-compat @BROKEN
 
+PKG_MAINTAINER:=John Crispin <blogic@openwrt.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-lxc/Makefile
+++ b/applications/luci-app-lxc/Makefile
@@ -13,7 +13,8 @@ define Package/luci-app-lxc/conffiles
 /etc/config/lxc
 endef
 
-PKG_MAINTAINER:=Petar Koretic <petar.koretic@sartura.hr>
+PKG_MAINTAINER:=Petar Koretic <petar.koretic@sartura.hr> \
+	Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-lxc/Makefile
+++ b/applications/luci-app-lxc/Makefile
@@ -13,6 +13,7 @@ define Package/luci-app-lxc/conffiles
 /etc/config/lxc
 endef
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Petar Koretic <petar.koretic@sartura.hr> \
 	Dirk Brenken <dev@brenken.org>
 

--- a/applications/luci-app-lxc/Makefile
+++ b/applications/luci-app-lxc/Makefile
@@ -14,7 +14,7 @@ define Package/luci-app-lxc/conffiles
 endef
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Petar Koretic <petar.koretic@sartura.hr> \
+PKG_MAINTAINER:=Petar Koretic <petar.koretic@sartura.hr>, \
 	Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk

--- a/applications/luci-app-minidlna/Makefile
+++ b/applications/luci-app-minidlna/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for miniDLNA
 LUCI_DEPENDS:=+luci-base +minidlna
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-minidlna/Makefile
+++ b/applications/luci-app-minidlna/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for miniDLNA
 LUCI_DEPENDS:=+luci-base +minidlna
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-mjpg-streamer/Makefile
+++ b/applications/luci-app-mjpg-streamer/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=MJPG-Streamer service configuration module
 LUCI_DEPENDS:=+luci-base +mjpg-streamer
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-mjpg-streamer/Makefile
+++ b/applications/luci-app-mjpg-streamer/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=MJPG-Streamer service configuration module
 LUCI_DEPENDS:=+luci-base +mjpg-streamer
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-mwan3/Makefile
+++ b/applications/luci-app-mwan3/Makefile
@@ -1,14 +1,13 @@
 #
 # Copyright (C) 2017 Dan Luedtke <mail@danrl.com>
 #
-# This is free software, licensed under the Apache License, Version 2.0 .
-#
+# This is free software, licensed under the GNU General Public License v2.
 
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for the MWAN3 MultiWAN Manager
 LUCI_DEPENDS:=+luci-base +mwan3
-PKG_LICENSE:=GPLv2
+PKG_LICENSE:=GPL-2.0
 
 PKG_MAINTAINER:=Florian Eckert <fe@dev.tdt.de>
 

--- a/applications/luci-app-nextdns/Makefile
+++ b/applications/luci-app-nextdns/Makefile
@@ -6,6 +6,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for NextDNS
 LUCI_DEPENDS:=+luci-base +nextdns
 
+PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nextdns/Makefile
+++ b/applications/luci-app-nextdns/Makefile
@@ -6,6 +6,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for NextDNS
 LUCI_DEPENDS:=+luci-base +nextdns
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Olivier Poitrey <rs@nextdns.io>
 
 include ../../luci.mk

--- a/applications/luci-app-nft-qos/Makefile
+++ b/applications/luci-app-nft-qos/Makefile
@@ -11,6 +11,8 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=QoS over Nftables
 LUCI_DEPENDS:=+luci-base +luci-compat +nft-qos
 
+PKG_MAINTAINER:=Rosy Song <rosysong@rosinson.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nlbwmon/Makefile
+++ b/applications/luci-app-nlbwmon/Makefile
@@ -5,6 +5,7 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=Netlink based bandwidth accounting
 LUCI_DEPENDS:=+luci-base +luci-lib-chartjs +nlbwmon
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-nlbwmon/Makefile
+++ b/applications/luci-app-nlbwmon/Makefile
@@ -5,6 +5,8 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=Netlink based bandwidth accounting
 LUCI_DEPENDS:=+luci-base +luci-lib-chartjs +nlbwmon
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nut/Makefile
+++ b/applications/luci-app-nut/Makefile
@@ -1,9 +1,7 @@
 #
 # Copyright (C) 2015 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 
@@ -11,6 +9,7 @@ LUCI_TITLE:=Network UPS Tools Configuration
 LUCI_DEPENDS:=+luci-base +luci-compat
 PKG_RELEASE:=1
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 
 include ../../luci.mk

--- a/applications/luci-app-nut/Makefile
+++ b/applications/luci-app-nut/Makefile
@@ -11,6 +11,8 @@ LUCI_TITLE:=Network UPS Tools Configuration
 LUCI_DEPENDS:=+luci-base +luci-compat
 PKG_RELEASE:=1
 
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua
+++ b/applications/luci-app-nut/luasrc/model/cbi/nut_cgi.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local m, s, o

--- a/applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua
+++ b/applications/luci-app-nut/luasrc/model/cbi/nut_monitor.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local m, s, o

--- a/applications/luci-app-nut/luasrc/model/cbi/nut_server.lua
+++ b/applications/luci-app-nut/luasrc/model/cbi/nut_server.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local m, s, o

--- a/applications/luci-app-ocserv/Makefile
+++ b/applications/luci-app-ocserv/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for OpenConnect VPN
 LUCI_DEPENDS:=+luci-base +luci-compat +ocserv +certtool
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-ocserv/Makefile
+++ b/applications/luci-app-ocserv/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for OpenConnect VPN
 LUCI_DEPENDS:=+luci-base +luci-compat +ocserv +certtool
 
+PKG_MAINTAINER:=Nikos Mavrogiannopoulos <n.mavrogiannopoulos@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-olsr-services/Makefile
+++ b/applications/luci-app-olsr-services/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Show services announced with the nameservice plugin
 LUCI_DEPENDS:=+luci-base +luci-app-olsr +olsrd +olsrd-mod-nameservice
 
+PKG_MAINTAINER:=Andreas Brau <ab@andi95.de>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-olsr-services/Makefile
+++ b/applications/luci-app-olsr-services/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Show services announced with the nameservice plugin
 LUCI_DEPENDS:=+luci-base +luci-app-olsr +olsrd +olsrd-mod-nameservice
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Andreas Brau <ab@andi95.de>
 
 include ../../luci.mk

--- a/applications/luci-app-olsr-viz/Makefile
+++ b/applications/luci-app-olsr-viz/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=OLSR Visualisation
 LUCI_DEPENDS:=+luci-base +luci-app-olsr +olsrd +olsrd-mod-txtinfo
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Lorenz Schori <lo@znerol.ch>
 
 include ../../luci.mk

--- a/applications/luci-app-olsr-viz/Makefile
+++ b/applications/luci-app-olsr-viz/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=OLSR Visualisation
 LUCI_DEPENDS:=+luci-base +luci-app-olsr +olsrd +olsrd-mod-txtinfo
 
+PKG_MAINTAINER:=Lorenz Schori <lo@znerol.ch>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-olsr/Makefile
+++ b/applications/luci-app-olsr/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=OLSR configuration and status module
 LUCI_DEPENDS:=+luci-base +olsrd
 
+PKG_MAINTAINER:=Manuel Munz <munz@comuno.net>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-olsr/Makefile
+++ b/applications/luci-app-olsr/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=OLSR configuration and status module
 LUCI_DEPENDS:=+luci-base +olsrd
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Manuel Munz <munz@comuno.net>
 
 include ../../luci.mk

--- a/applications/luci-app-openvpn/Makefile
+++ b/applications/luci-app-openvpn/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=LuCI Support for OpenVPN
 LUCI_DEPENDS:=+luci-base +luci-compat
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org>, \
 	Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-openvpn/Makefile
+++ b/applications/luci-app-openvpn/Makefile
@@ -10,6 +10,8 @@ LUCI_TITLE:=LuCI Support for OpenVPN
 LUCI_DEPENDS:=+luci-base +luci-compat
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+	Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/applications/luci-app-opkg/Makefile
+++ b/applications/luci-app-opkg/Makefile
@@ -11,6 +11,8 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=OPKG package management application
 LUCI_DEPENDS:=+luci-base +opkg
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-p910nd/Makefile
+++ b/applications/luci-app-p910nd/Makefile
@@ -9,6 +9,10 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=p910nd - Printer server module
 LUCI_DEPENDS:=+luci-base +luci-compat +p910nd
 
+PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Paul Donald <newtwen@gmail.com> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-p910nd/Makefile
+++ b/applications/luci-app-p910nd/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=p910nd - Printer server module
 LUCI_DEPENDS:=+luci-base +luci-compat +p910nd
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Paul Donald <newtwen@gmail.com> \
+PKG_MAINTAINER:=Paul Donald <newtwen@gmail.com>, \
 	Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-pagekitec/Makefile
+++ b/applications/luci-app-pagekitec/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for PageKite
 LUCI_DEPENDS:=+luci-base +pagekitec
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Karl Palsson <karlp@tweak.net.au>
 
 include ../../luci.mk

--- a/applications/luci-app-polipo/Makefile
+++ b/applications/luci-app-polipo/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for the Polipo Proxy
 LUCI_DEPENDS:=+luci-base +luci-compat +polipo
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Aleksandar Krsteski <alekrsteski@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-polipo/Makefile
+++ b/applications/luci-app-polipo/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for the Polipo Proxy
 LUCI_DEPENDS:=+luci-base +luci-compat +polipo
 
+PKG_MAINTAINER:=Aleksandar Krsteski <alekrsteski@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-privoxy/Makefile
+++ b/applications/luci-app-privoxy/Makefile
@@ -8,18 +8,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-privoxy
 
-# Version == major.minor.patch
-# increase "minor" on new functionality and "patch" on patches/optimization
 PKG_VERSION:=1.0.6
 
-# Release == build
-# increase on changes of translation files
 PKG_RELEASE:=2
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=
+PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
-# LuCI specific settings
 LUCI_TITLE:=LuCI Support for Privoxy WEB proxy
 LUCI_DEPENDS:=+luci-compat +luci-lib-ipkg +luci-base +privoxy
 

--- a/applications/luci-app-qos/Makefile
+++ b/applications/luci-app-qos/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Quality of Service configuration module
 LUCI_DEPENDS:=+luci-base +luci-compat +qos-scripts
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-radicale/Makefile
+++ b/applications/luci-app-radicale/Makefile
@@ -8,18 +8,13 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-radicale
 
-# Version == major.minor.patch
-# increase "minor" on new functionality and "patch" on patches/optimization
 PKG_VERSION:=1.1.0
 
-# Release == build
-# increase on changes of translation files
 PKG_RELEASE:=2
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=
+PKG_MAINTAINER:=Christian Schoenebeck <christian.schoenebeck@gmail.com>
 
-# LuCI specific settings
 LUCI_TITLE:=LuCI Support for Radicale CardDAV/CalDAV
 LUCI_DEPENDS:=+luci-compat +luci-lib-ipkg +luci-base
 

--- a/applications/luci-app-radicale2/Makefile
+++ b/applications/luci-app-radicale2/Makefile
@@ -4,6 +4,7 @@ LUCI_TITLE:=Radicale v2.x CalDAV/CardDAV Server
 LUCI_DEPENDS:=+luci-base +luci-compat +radicale2 +rpcd-mod-rad2-enc
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 
 LUA_TARGET:=source
 

--- a/applications/luci-app-rp-pppoe-server/Makefile
+++ b/applications/luci-app-rp-pppoe-server/Makefile
@@ -1,15 +1,14 @@
 #
 # Copyright (C) 2015 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Roaring Penguin PPPoE Server
 LUCI_DEPENDS:=+luci-base +luci-compat +rp-pppoe-server
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 
 include ../../luci.mk

--- a/applications/luci-app-rp-pppoe-server/Makefile
+++ b/applications/luci-app-rp-pppoe-server/Makefile
@@ -10,6 +10,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Roaring Penguin PPPoE Server
 LUCI_DEPENDS:=+luci-base +luci-compat +rp-pppoe-server
 
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
+++ b/applications/luci-app-rp-pppoe-server/luasrc/model/cbi/rp-pppoe-server.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local m, s, o

--- a/applications/luci-app-samba4/Makefile
+++ b/applications/luci-app-samba4/Makefile
@@ -5,6 +5,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Network Shares - Samba 4 SMB/CIFS fileserver
 LUCI_DEPENDS:=+luci-base +samba4-server
 
+PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-samba4/Makefile
+++ b/applications/luci-app-samba4/Makefile
@@ -5,6 +5,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Network Shares - Samba 4 SMB/CIFS fileserver
 LUCI_DEPENDS:=+luci-base +samba4-server
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Andy Walsh <andy.walsh44+github@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-ser2net/Makefile
+++ b/applications/luci-app-ser2net/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=LuCI Support for ser2net
 LUCI_DEPENDS:=+luci-base +ser2net
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Michele Primavera <primavera@elmod.it>
 
 include ../../luci.mk
 

--- a/applications/luci-app-shadowsocks-libev/Makefile
+++ b/applications/luci-app-shadowsocks-libev/Makefile
@@ -10,6 +10,8 @@ LUCI_TITLE:=LuCI Support for shadowsocks-libev
 LUCI_DEPENDS:=+luci-base
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com> \
+	Jian Chang <aa65535@live.com>
 
 include ../../luci.mk
 

--- a/applications/luci-app-shadowsocks-libev/Makefile
+++ b/applications/luci-app-shadowsocks-libev/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=LuCI Support for shadowsocks-libev
 LUCI_DEPENDS:=+luci-base
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com> \
+PKG_MAINTAINER:=Yousong Zhou <yszhou4tech@gmail.com>, \
 	Jian Chang <aa65535@live.com>
 
 include ../../luci.mk

--- a/applications/luci-app-siitwizard/Makefile
+++ b/applications/luci-app-siitwizard/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=SIIT IPv4-over-IPv6 configuration wizard
 LUCI_DEPENDS:=+luci-base +luci-compat +kmod-siit
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org>, \
 	Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-siitwizard/Makefile
+++ b/applications/luci-app-siitwizard/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=SIIT IPv4-over-IPv6 configuration wizard
 LUCI_DEPENDS:=+luci-base +luci-compat +kmod-siit
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
 	Jo-Philipp Wich <jo@mein.io>
 

--- a/applications/luci-app-siitwizard/Makefile
+++ b/applications/luci-app-siitwizard/Makefile
@@ -9,6 +9,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=SIIT IPv4-over-IPv6 configuration wizard
 LUCI_DEPENDS:=+luci-base +luci-compat +kmod-siit
 
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-softether/Makefile
+++ b/applications/luci-app-softether/Makefile
@@ -7,6 +7,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Softether management application
 LUCI_DEPENDS:=+luci-base +softethervpn5-client
 
+PKG_MAINTAINER:=BERENYI Balazs <balazs@wee.hu> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-softether/Makefile
+++ b/applications/luci-app-softether/Makefile
@@ -8,7 +8,7 @@ LUCI_TITLE:=Softether management application
 LUCI_DEPENDS:=+luci-base +softethervpn5-client
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=BERENYI Balazs <balazs@wee.hu> \
+PKG_MAINTAINER:=BERENYI Balazs <balazs@wee.hu>, \
 	Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-softether/Makefile
+++ b/applications/luci-app-softether/Makefile
@@ -7,6 +7,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Softether management application
 LUCI_DEPENDS:=+luci-base +softethervpn5-client
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=BERENYI Balazs <balazs@wee.hu> \
 	Jo-Philipp Wich <jo@mein.io>
 

--- a/applications/luci-app-splash/Makefile
+++ b/applications/luci-app-splash/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Freifunk DHCP-Splash application
 LUCI_DEPENDS:=+luci-base +luci-compat +luci-lib-nixio +luci-lib-iptparser +luci-lua-runtime +tc +kmod-sched +iptables-mod-nat-extra +iptables-mod-ipopt
 
+PKG_MAINTAINER:=Manuel Munz <munz@comuno.net>
+
 define Package/luci-app-splash/conffiles
 /etc/config/luci_splash
 /usr/lib/luci-splash/splashtext.html

--- a/applications/luci-app-splash/Makefile
+++ b/applications/luci-app-splash/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Freifunk DHCP-Splash application
 LUCI_DEPENDS:=+luci-base +luci-compat +luci-lib-nixio +luci-lib-iptparser +luci-lua-runtime +tc +kmod-sched +iptables-mod-nat-extra +iptables-mod-ipopt
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Manuel Munz <munz@comuno.net>
 
 define Package/luci-app-splash/conffiles

--- a/applications/luci-app-squid/Makefile
+++ b/applications/luci-app-squid/Makefile
@@ -1,9 +1,7 @@
 #
 # Copyright (C) 2015 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 

--- a/applications/luci-app-sshtunnel/Makefile
+++ b/applications/luci-app-sshtunnel/Makefile
@@ -5,6 +5,7 @@ include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI support for SSH Tunnels (sshtunnel package)
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Sergey Ponomarev <stokito@gmail.com>
 LUCI_DEPENDS:=+luci-base +sshtunnel
 PKG_VERSION:=1.1.0

--- a/applications/luci-app-statistics/Makefile
+++ b/applications/luci-app-statistics/Makefile
@@ -21,6 +21,8 @@ LUCI_DEPENDS:= \
 	+collectd-mod-load \
 	+collectd-mod-network
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 define Package/luci-app-statistics/conffiles
 /etc/config/luci_statistics
 endef

--- a/applications/luci-app-tinyproxy/Makefile
+++ b/applications/luci-app-tinyproxy/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Tinyproxy - HTTP(S)-Proxy configuration
 LUCI_DEPENDS:=+luci-base +luci-compat +tinyproxy
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
 	Jo-Philipp Wich <jo@mein.io>
 

--- a/applications/luci-app-tinyproxy/Makefile
+++ b/applications/luci-app-tinyproxy/Makefile
@@ -9,6 +9,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Tinyproxy - HTTP(S)-Proxy configuration
 LUCI_DEPENDS:=+luci-base +luci-compat +tinyproxy
 
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+	Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-tinyproxy/Makefile
+++ b/applications/luci-app-tinyproxy/Makefile
@@ -10,7 +10,7 @@ LUCI_TITLE:=Tinyproxy - HTTP(S)-Proxy configuration
 LUCI_DEPENDS:=+luci-base +luci-compat +tinyproxy
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Steven Barth <steven@midlink.org> \
+PKG_MAINTAINER:=Steven Barth <steven@midlink.org>, \
 	Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-tor/Makefile
+++ b/applications/luci-app-tor/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI app to configure Tor
 LUCI_DEPENDS:=+luci-base +tor +tor-hs
 PKG_VERSION:=1.1.0
 PKG_RELEASE:=1
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Sergey Ponomarev <stokito@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-transmission/Makefile
+++ b/applications/luci-app-transmission/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Transmission
 LUCI_DEPENDS:=+luci-base +transmission-daemon
 
+PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-transmission/Makefile
+++ b/applications/luci-app-transmission/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Transmission
 LUCI_DEPENDS:=+luci-base +transmission-daemon
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-travelmate/Makefile
+++ b/applications/luci-app-travelmate/Makefile
@@ -7,6 +7,7 @@ LUCI_TITLE:=LuCI support for Travelmate
 LUCI_DEPENDS:=+luci-base +travelmate
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Dirk Brenken <dev@brenken.org>
 
 include ../../luci.mk
 

--- a/applications/luci-app-ttyd/Makefile
+++ b/applications/luci-app-ttyd/Makefile
@@ -5,6 +5,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=ttyd - Command-line tool for sharing terminal over the web
 LUCI_DEPENDS:=+luci-base +ttyd
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-ttyd/Makefile
+++ b/applications/luci-app-ttyd/Makefile
@@ -5,6 +5,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=ttyd - Command-line tool for sharing terminal over the web
 LUCI_DEPENDS:=+luci-base +ttyd
 
+PKG_MAINTAINER:=Richard Yu <yurichard3839@gmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-udpxy/Makefile
+++ b/applications/luci-app-udpxy/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for udpxy
 LUCI_DEPENDS:=+luci-base +udpxy
 
+PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-udpxy/Makefile
+++ b/applications/luci-app-udpxy/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for udpxy
 LUCI_DEPENDS:=+luci-base +udpxy
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 
 include ../../luci.mk

--- a/applications/luci-app-uhttpd/Makefile
+++ b/applications/luci-app-uhttpd/Makefile
@@ -1,9 +1,7 @@
 #
 # Copyright (C) 2015 OpenWrt.org
 #
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 

--- a/applications/luci-app-uhttpd/Makefile
+++ b/applications/luci-app-uhttpd/Makefile
@@ -11,7 +11,7 @@ LUCI_TITLE:=uHTTPd Webserver Configuration
 LUCI_DEPENDS:=+luci-base +uhttpd
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 
 include ../../luci.mk
 

--- a/applications/luci-app-unbound/Makefile
+++ b/applications/luci-app-unbound/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Unbound Recursive DNS Resolver Configuration
 LUCI_DEPENDS:=+luci-base +luci-compat +unbound-daemon
 
+PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@hotmail.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-unbound/Makefile
+++ b/applications/luci-app-unbound/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Unbound Recursive DNS Resolver Configuration
 LUCI_DEPENDS:=+luci-base +luci-compat +unbound-daemon
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Eric Luehrsen <ericluehrsen@hotmail.com>
 
 include ../../luci.mk

--- a/applications/luci-app-upnp/Makefile
+++ b/applications/luci-app-upnp/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Universal Plug and Play (UPnP IGD) & PCP/NAT-PMP configuration module
 LUCI_DEPENDS:=+luci-base +miniupnpd +rpcd-mod-ucode
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-upnp/Makefile
+++ b/applications/luci-app-upnp/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Universal Plug and Play (UPnP IGD) & PCP/NAT-PMP configuration module
 LUCI_DEPENDS:=+luci-base +miniupnpd +rpcd-mod-ucode
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-usteer/Makefile
+++ b/applications/luci-app-usteer/Makefile
@@ -6,7 +6,7 @@ LUCI_TITLE:=LuCI usteer app for js based luci
 LUCI_DEPENDS:=+luci-base +usteer
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Ramon Van Gorkom <github@flightfoil.com>
+PKG_MAINTAINER:=Ramon Van Gorkom <Ramon00c00@gmail.com>
 
 include ../../luci.mk
 

--- a/applications/luci-app-usteer/Makefile
+++ b/applications/luci-app-usteer/Makefile
@@ -6,6 +6,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI usteer app for js based luci
 LUCI_DEPENDS:=+luci-base +usteer
 
+PKG_MAINTAINER:=Ramon Van Gorkom <github@flightfoil.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-usteer/Makefile
+++ b/applications/luci-app-usteer/Makefile
@@ -1,11 +1,11 @@
-# See /LICENSE for more information.
-# This is free software, licensed under the GNU General Public License v2.
+# This is free software, licensed under the Apache License, Version 2.0 .
 
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI usteer app for js based luci
 LUCI_DEPENDS:=+luci-base +usteer
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Ramon Van Gorkom <github@flightfoil.com>
 
 include ../../luci.mk

--- a/applications/luci-app-v2raya/Makefile
+++ b/applications/luci-app-v2raya/Makefile
@@ -7,6 +7,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI support for v2rayA
 LUCI_DEPENDS:=+v2raya
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Tianling Shen <cnsztl@immortalwrt.org>
 
 include ../../luci.mk

--- a/applications/luci-app-vnstat/Makefile
+++ b/applications/luci-app-vnstat/Makefile
@@ -9,6 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for VnStat
 LUCI_DEPENDS:=+luci-base +luci-compat +vnstat +vnstati
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/applications/luci-app-vnstat/Makefile
+++ b/applications/luci-app-vnstat/Makefile
@@ -9,6 +9,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for VnStat
 LUCI_DEPENDS:=+luci-base +luci-compat +vnstat +vnstati
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-watchcat/Makefile
+++ b/applications/luci-app-watchcat/Makefile
@@ -6,7 +6,7 @@ LUCI_TITLE:=LuCI Support for Watchcat
 LUCI_DEPENDS:=+luci-base +watchcat
 
 PKG_LICENSE:=Apache-2.0
-PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io> \
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>, \
 	Nicholas Smith <nicholas@nbembedded.com>
 
 include ../../luci.mk

--- a/applications/luci-app-watchcat/Makefile
+++ b/applications/luci-app-watchcat/Makefile
@@ -5,6 +5,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Watchcat
 LUCI_DEPENDS:=+luci-base +watchcat
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io> \
 	Nicholas Smith <nicholas@nbembedded.com>
 

--- a/applications/luci-app-watchcat/Makefile
+++ b/applications/luci-app-watchcat/Makefile
@@ -5,6 +5,9 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=LuCI Support for Watchcat
 LUCI_DEPENDS:=+luci-base +watchcat
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io> \
+	Nicholas Smith <nicholas@nbembedded.com>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-wifischedule/Makefile
+++ b/applications/luci-app-wifischedule/Makefile
@@ -17,6 +17,8 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Turns WiFi on and off according to a schedule
 LUCI_DEPENDS:=+luci-base +luci-compat +wifischedule
 
+PKG_MAINTAINER:=Nils Koenig <openwrt@newk.it>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-wifischedule/Makefile
+++ b/applications/luci-app-wifischedule/Makefile
@@ -17,6 +17,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Turns WiFi on and off according to a schedule
 LUCI_DEPENDS:=+luci-base +luci-compat +wifischedule
 
+PKG_LICENSE:=ISC
 PKG_MAINTAINER:=Nils Koenig <openwrt@newk.it>
 
 include ../../luci.mk

--- a/applications/luci-app-wol/Makefile
+++ b/applications/luci-app-wol/Makefile
@@ -11,6 +11,8 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=LuCI Support for Wake-on-LAN
 LUCI_DEPENDS:=+luci-base +etherwake
 
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
+
 include ../../luci.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/applications/luci-app-wol/Makefile
+++ b/applications/luci-app-wol/Makefile
@@ -11,6 +11,7 @@ PKG_LICENSE:=Apache-2.0
 LUCI_TITLE:=LuCI Support for Wake-on-LAN
 LUCI_DEPENDS:=+luci-base +etherwake
 
+PKG_LICENSE:=Apache-2.0
 PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk

--- a/modules/luci-compat/luasrc/model/network/proto_vpnc.lua
+++ b/modules/luci-compat/luasrc/model/network/proto_vpnc.lua
@@ -1,4 +1,4 @@
--- Copyright 2015 Daniel Dickinson <openwrt@daniel.thecshore.com>
+-- Copyright 2015 Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 -- Licensed to the public under the Apache License 2.0.
 
 local netmod = luci.model.network

--- a/protocols/luci-proto-3g/Makefile
+++ b/protocols/luci-proto-3g/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for 3G
 LUCI_DEPENDS:=+comgt
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-autoip/Makefile
+++ b/protocols/luci-proto-autoip/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for Avahi IPv4LL configuration
 LUCI_DEPENDS:=+avahi-autoipd
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-batman-adv/Makefile
+++ b/protocols/luci-proto-batman-adv/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for the batman-adv protocol
 LUCI_DEPENDS:=+kmod-batman-adv
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Marc Ahlgrim <marc@onemarcfifty.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-external/Makefile
+++ b/protocols/luci-proto-external/Makefile
@@ -4,6 +4,7 @@ LUCI_TITLE:=Support for externally managed protocol
 LUCI_DEPENDS:=+external-protocol
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Oskari Rauta <oskari.rauta@gmail.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-ipv6/Makefile
+++ b/protocols/luci-proto-ipv6/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for DHCPv6/6in4/6to4/6rd/DS-Lite/IPIP6
 LUCI_DEPENDS:=@IPV6
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-mbim/Makefile
+++ b/protocols/luci-proto-mbim/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for MBIM
 LUCI_DEPENDS:=+umbim
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Howard Chu <hyc@symas.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-modemmanager/Makefile
+++ b/protocols/luci-proto-modemmanager/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for ModemManager
 LUCI_DEPENDS:=+modemmanager
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Nicholas Smith <nicholas@nbembedded.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-ncm/Makefile
+++ b/protocols/luci-proto-ncm/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for NCM
 LUCI_DEPENDS:=+comgt-ncm
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Lucian Cristian <lucian.cristian@gmail.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-openconnect/Makefile
+++ b/protocols/luci-proto-openconnect/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for OpenConnect VPN
 LUCI_DEPENDS:=+openconnect +luci-lua-runtime
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-openfortivpn/Makefile
+++ b/protocols/luci-proto-openfortivpn/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for OpenFortivpn
 LUCI_DEPENDS:=+openfortivpn +luci-lua-runtime
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Aaron Goodman <aaronjg@stanford.edu>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-ppp/Makefile
+++ b/protocols/luci-proto-ppp/Makefile
@@ -7,9 +7,9 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Support for PPP/PPPoE/PPPoA/PPtP
-LUCI_DEPENDS:=
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-qmi/Makefile
+++ b/protocols/luci-proto-qmi/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for QMI
 LUCI_DEPENDS:=+uqmi
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=David Thornley <david.thornley@touchstargroup.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-relay/Makefile
+++ b/protocols/luci-proto-relay/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for relayd pseudo bridges
 LUCI_DEPENDS:=+relayd
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Jo-Philipp Wich <jo@mein.io>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-sstp/Makefile
+++ b/protocols/luci-proto-sstp/Makefile
@@ -11,6 +11,7 @@ LUCI_DEPENDS:=+sstp-client
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Robert Koszewski <rkkoszewski@gmail.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-unet/Makefile
+++ b/protocols/luci-proto-unet/Makefile
@@ -11,6 +11,7 @@ LUCI_DEPENDS:=+unetd +unet-cli
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Hannu Nyman <hannu.nyman@iki.fi>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-vpnc/Makefile
+++ b/protocols/luci-proto-vpnc/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Support for VPNC VPN
 LUCI_DEPENDS:=+vpnc
 
-PKG_MAINTAINER:=Daniel Dickinson <openwrt@daniel.thecshore.com>
+PKG_MAINTAINER:=Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>
 PKG_LICENSE:=Apache-2.0
 
 include ../../luci.mk

--- a/protocols/luci-proto-wireguard/Makefile
+++ b/protocols/luci-proto-wireguard/Makefile
@@ -11,6 +11,7 @@ LUCI_DEPENDS:=+wireguard-tools +ucode
 LUCI_PKGARCH:=all
 
 PKG_LICENSE:=Apache-2.0
+PKG_MAINTAINER:=Dan Luedtke <mail@danrl.com>
 
 include ../../luci.mk
 

--- a/protocols/luci-proto-yggdrasil/Makefile
+++ b/protocols/luci-proto-yggdrasil/Makefile
@@ -10,6 +10,7 @@ LUCI_TITLE:=Support for Yggdrasil Network
 LUCI_DEPENDS:=+yggdrasil
 LUCI_PKGARCH:=all
 PKG_VERSION:=1.1.0
+PKG_MAINTAINER:=William Fleurant <meshnet@protonmail.com>
 
 include ../../luci.mk
 


### PR DESCRIPTION
The luci-app-bcp38 had a maintainer from luci-app-acme and that looks like a copy-paste error. So it's maintainer was changed to an author @danrl

Daniel F. Dickinson changed email address to <dfdpublic@wildtechgarden.ca>

luci-all-lxl has a maintainer Petar Koretic <petar.koretic@sartura.hr> but there is no corresponding GitHub account. So Dirk Brenken was added as a second maintainer: he answered on an issue of the app.

When maintainer wasn't set the initial author was used, or most contributor or Jo-Philipp Wich as a default.
