### PR TITLE
[23.05] luci-proto-qmi: allow v6apn and (v6)profile configuration

### DIFF
--- a/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
+++ b/protocols/luci-proto-qmi/htdocs/luci-static/resources/protocol/qmi.js
@@ -65,8 +65,7 @@ return network.registerProtocol('qmi', {
 			}, this));
 		};
 
-		o = s.taboption('general', form.Value, 'apn', _('APN'));
-		o.validate = function(section_id, value) {
+		var validate_apn = function(section_id, value) {
 			if (value == null || value == '')
 				return true;
 
@@ -74,6 +73,14 @@ return network.registerProtocol('qmi', {
 				return _('Invalid APN provided');
 
 			return true;
+		};
+		o = s.taboption('general', form.Value, 'apn', _('APN'));
+		o.validate = validate_apn;
+
+		if (L.hasSystemFeature('ipv6')) {
+			o = s.taboption('general', form.Value, 'v6apn', _('IPv6 APN'));
+			o.validate = validate_apn;
+			o.depends('pdptype', 'ipv4v6')
 		};
 
 		o = s.taboption('general', form.Value, 'pincode', _('PIN'));
@@ -133,5 +140,17 @@ return network.registerProtocol('qmi', {
 			_('If unchecked, the advertised DNS server addresses are ignored'));
 		o.default = o.enabled;
 
+		o = s.taboption('advanced', form.Value, 'profile',
+			_('APN profile index'));
+		o.placeholder = '1';
+		o.datatype = 'uinteger';
+
+		if (L.hasSystemFeature('ipv6')) {
+			o = s.taboption('advanced', form.Value, 'v6profile',
+				_('IPv6 APN profile index'));
+			o.placeholder = '1';
+			o.datatype = 'uinteger';
+			o.depends('pdptype', 'ipv4v6');
+		};
 	}
 });


### PR DESCRIPTION
[Backport to openwrt-23.05 branch - I forgot to open this after core changes were merged into 23.05-rc3]

To support split-APN dual-stack connections over QMI, add new parameters supported in UCI to LuCI as well. Previously, connection profile wasn't configurable from LuCI at all, so add options to set which APN profile to match for each protocol.

(cherry picked from commit c682e530e2b95af7768b6a0c74c942222e0cd78d)
Original PR #6426 
<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (ath79, OpenWrt 23.05.2, Firefox 115) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
