### PR TITLE
luci.mk: more APK version compatibility changes

### DIFF
--- a/luci.mk
+++ b/luci.mk
@@ -85,18 +85,18 @@ define findrev
       if [ -n "$$1" ]; then
         secs="$$(($$1 % 86400))"; \
         yday="$$(date --utc --date="@$$1" "+%y.%j")"; \
-        printf 'git-%s.%05d~%s' "$$yday" "$$secs" "$$2"; \
+        printf '%s.%05d~%s' "$$yday" "$$secs" "$$2"; \
       else \
-        echo "unknown"; \
+        echo "0"; \
       fi; \
     else \
       ts=$$(find . -type f $(if $(1),-not) -path './po/*' -printf '%T@\n' 2>/dev/null | sort -rn | head -n1 | cut -d. -f1); \
       if [ -n "$$ts" ]; then \
         secs="$$(($$ts % 86400))"; \
         date="$$(date --utc --date="@$$ts" "+%y%m%d")"; \
-        printf '%s.%05d' "$$date" "$$secs"; \
+        printf '0.%s.%05d' "$$date" "$$secs"; \
       else \
-        echo "unknown"; \
+        echo "0"; \
       fi; \
     fi \
   )


### PR DESCRIPTION
The initial commit did not take care of corner cases which could happen if building under build conditions other than using Git.

There are three cases for the `findrev` function:

- git -> `24.079.58964~7943616` (remove prefixed `git-`)

APK can't handle `git-` as prefix, it could be `0_git<integer>` but this seems rather confusing.

- date -> `0.240326.34906` ( add leading 0)

Add a leading zero so the version is always lower compared to using Git. This makes it easier to distinguish from a Git based version.

- unknown -> `0` (instead of `unknown`)

APK can't handle `unknown` so set it to a simple zero instead.