### PR TITLE
luci-mod-status: fix syslog scroll for some themes

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/dmesg.js
@@ -22,7 +22,7 @@ return view.extend({
 			}, _('Scroll to tail', 'scroll to bottom (the tail) of the log file')
 		);
 		scrollDownButton.addEventListener('click', function() {
-			window.scrollTo(0, document.body.scrollHeight);
+			scrollUpButton.focus();
 		});
 
 		var scrollUpButton = E('button', { 
@@ -31,7 +31,7 @@ return view.extend({
 			}, _('Scroll to head', 'scroll to top (the head) of the log file')
 		);
 		scrollUpButton.addEventListener('click', function() {
-			window.scrollTo(0, 0);
+			scrollDownButton.focus();
 		});
 
 		return E([], [

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/syslog.js
@@ -28,7 +28,7 @@ return view.extend({
 			}, _('Scroll to tail', 'scroll to bottom (the tail) of the log file')
 		);
 		scrollDownButton.addEventListener('click', function() {
-			window.scrollTo(0, document.body.scrollHeight);
+			scrollUpButton.focus();
 		});
 
 		var scrollUpButton = E('button', { 
@@ -37,7 +37,7 @@ return view.extend({
 			}, _('Scroll to head', 'scroll to top (the head) of the log file')
 		);
 		scrollUpButton.addEventListener('click', function() {
-			window.scrollTo(0, 0);
+			scrollDownButton.focus();
 		});
 
 		return E([], [


### PR DESCRIPTION
The actual code moves the scroll in the window. This works for the bootstrap theme, because the scroll is at window level. But this does not work for other themes, like material.

This commit changes the move of the scroll by "focusing" the window in the opposite button element in the syslog page. In this way the move is automatically done by the browser.

Another solution is to "search" in the parent until we find the scroll and move it, but seems less solid.

This fixes https://github.com/openwrt/luci/issues/7027

This has been tested on Chrome and Edge, any other test will be appreciated. I've tested too the solution "searching" for the scroll in the parent, and it works, but I'm not too sure where to stop the search if the scroll does not exist or if it can find a different scroll at other place, so I used this other solution.