### PR TITLE
luci-app-https-dns-proxy: bugfix: AdGuard servers URLs

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -3,14 +3,23 @@
 
 include $(TOPDIR)/rules.mk
 
+PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
-PKG_VERSION:=2023.11.19-r1
+PKG_VERSION:=2023.11.19
+PKG_RELEASE:=r2
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy
 LUCI_DEPENDS:=+luci-base +https-dns-proxy
-LUCI_PKGARCH:=all
+
+define Package/$(PKG_NAME)/config
+# shown in make menuconfig <Help>
+help
+	$(LUCI_TITLE)
+	.
+	Version: $(PKG_VERSION)-$(PKG_RELEASE)
+endef
 
 include ../../luci.mk
 

--- a/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json
+++ b/applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json
@@ -1,24 +1,28 @@
 {
 	"title": "AdGuard",
-	"template": "https://dns{option}.adguard.com/dns-query",
-	"bootstrap_dns": "176.103.130.130,176.103.130.131",
-	"help_link": "https://adguard.com/en/adguard-dns/overview.html",
+	"template": "https://{option}.adguard-dns.com/dns-query",
+	"bootstrap_dns": "94.140.14.140,94.140.14.141",
+	"help_link": "https://adguard-dns.io/en/public-dns.html",
 	"params": {
 		"option": {
 			"description": "Variant",
 			"type": "select",
-			"regex": "(-family|)",
+			"regex": "(dns|unfiltered|family)",
 			"options": [
 				{
-					"value": "-family",
-					"description": "Family Filter"
+					"value": "dns",
+					"description": "Default (Blocks ads and trackers)"
 				},
 				{
-					"value": "",
-					"description": "Standard"
+					"value": "unfiltered",
+					"description": "Unfiltered"
+				},
+				{
+					"value": "family",
+					"description": "Family Filter"
 				}
 			],
-			"default": ""
+			"default": "dns"
 		}
 	}
 }


### PR DESCRIPTION
AdGuard seems to have drastically changed their DoH servers URLs, so this change updates the root/usr/share/https-dns-proxy/providers/com.adguard.dns.json file. Fixes https://github.com/openwrt/luci/issues/7038

Also include minor Makefile changes for better menuconfig presence.
