### PR TITLE
luci-mod-dashboard: Fill gateway info with the connection with lowest metric

### DIFF
--- a/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js
+++ b/modules/luci-mod-dashboard/htdocs/luci-static/resources/view/dashboard/include/10_router.js
@@ -142,27 +142,35 @@ return baseclass.extend({
 
 	renderUpdateWanData: function(data, v6) {
 
+		var min_metric = 2000000000;
+		var min_metric_i = 0;
 		for (var i = 0; i < data.length; i++) {
-			 var ifc = data[i];
+			var metric = data[i].getMetric();
+			if (metric < min_metric) {
+				min_metric = metric;
+				min_metric_i = i;
+			}
+		 }
 
-			 if (v6) {
-				var uptime = ifc.getUptime();
-				this.params.internet.v6.uptime.value = (uptime > 0) ? '%t'.format(uptime) : '-';
-				this.params.internet.v6.ipprefixv6.value =  ifc.getIP6Prefix() || '-';
-				this.params.internet.v6.gatewayv6.value =  ifc.getGateway6Addr() || '-';
-				this.params.internet.v6.protocol.value=  ifc.getI18n() || E('em', _('Not connected'));
-				this.params.internet.v6.addrsv6.value = ifc.getIP6Addrs() || [ '-' ];
-				this.params.internet.v6.dnsv6.value = ifc.getDNS6Addrs() || [ '-' ];
-				this.params.internet.v6.connected.value = ifc.isUp();
-			 } else {
-				var uptime = ifc.getUptime();
-				this.params.internet.v4.uptime.value = (uptime > 0) ? '%t'.format(uptime) : '-';
-				this.params.internet.v4.protocol.value=  ifc.getI18n() || E('em', _('Not connected'));
-				this.params.internet.v4.gatewayv4.value =  ifc.getGatewayAddr() || '0.0.0.0';
-				this.params.internet.v4.connected.value = ifc.isUp();
-				this.params.internet.v4.addrsv4.value = ifc.getIPAddrs() || [ '-'];
-				this.params.internet.v4.dnsv4.value = ifc.getDNSAddrs() || [ '-' ];
-			 }
+		var ifc = data[min_metric_i];
+
+		if (v6) {
+		var uptime = ifc.getUptime();
+			this.params.internet.v6.uptime.value = (uptime > 0) ? '%t'.format(uptime) : '-';
+			this.params.internet.v6.ipprefixv6.value =  ifc.getIP6Prefix() || '-';
+			this.params.internet.v6.gatewayv6.value =  ifc.getGateway6Addr() || '-';
+			this.params.internet.v6.protocol.value=  ifc.getI18n() || E('em', _('Not connected'));
+			this.params.internet.v6.addrsv6.value = ifc.getIP6Addrs() || [ '-' ];
+			this.params.internet.v6.dnsv6.value = ifc.getDNS6Addrs() || [ '-' ];
+			this.params.internet.v6.connected.value = ifc.isUp();
+		} else {
+			var uptime = ifc.getUptime();
+			this.params.internet.v4.uptime.value = (uptime > 0) ? '%t'.format(uptime) : '-';
+			this.params.internet.v4.protocol.value=  ifc.getI18n() || E('em', _('Not connected'));
+			this.params.internet.v4.gatewayv4.value =  ifc.getGatewayAddr() || '0.0.0.0';
+			this.params.internet.v4.connected.value = ifc.isUp();
+			this.params.internet.v4.addrsv4.value = ifc.getIPAddrs() || [ '-'];
+			this.params.internet.v4.dnsv4.value = ifc.getDNSAddrs() || [ '-' ];
 		}
 	},
 


### PR DESCRIPTION
The Internet section in Dashboard shows a gateway and WAN IP, but it doesn't care whether it actually displays the WAN that is used according to metric or a different WAN interface.

This PR changes the behavior so that it always shows the properties of the WAN interface with the lowest metric.

Actually, the for loop in the source code this PR replaces was a bit weird. It was looping through all WAN interfaces, but overwriting the values by the contents from the last loop iteration. Not sure what was meant by that.

![Screenshot 2024-04-10 at 14-27-15 orangebox-1 - Dashboard - LuCI](https://github.com/openwrt/luci/assets/182533/421e82a6-4f8e-4f28-8ee9-4db2017c8406)

@ZoZhang could you please review?

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: OpenWRT 22.03, Turris Omnia, Firefox :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [ ] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
