### PR TITLE
[23.05] luci-app-https-dns-proxy: bugfix: status/overview page include

### DIFF
--- a/applications/luci-app-https-dns-proxy/Makefile
+++ b/applications/luci-app-https-dns-proxy/Makefile
@@ -7,7 +7,7 @@ PKG_NAME:=luci-app-https-dns-proxy
 PKG_LICENSE:=GPL-3.0-or-later
 PKG_MAINTAINER:=Stan Grishin <stangri@melmac.ca>
 PKG_VERSION:=2023.11.19
-PKG_RELEASE:=r2
+PKG_RELEASE:=r3
 
 LUCI_TITLE:=DNS Over HTTPS Proxy Web UI
 LUCI_DESCRIPTION:=Provides Web UI for DNS Over HTTPS Proxy

--- a/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js
+++ b/applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js
@@ -105,46 +105,47 @@ return baseclass.extend({
 		);
 
 		var rows = [];
-		Object.values(reply.runtime.instances).forEach((element) => {
-			var resolver;
-			var address;
-			var port;
-			var name;
-			var option;
-			var found;
-			element.command.forEach((param, index, arr) => {
-				if (param === "-r") resolver = arr[index + 1];
-				if (param === "-a") address = arr[index + 1];
-				if (param === "-p") port = arr[index + 1];
-			});
-			resolver = resolver || "Unknown";
-			address = address || "127.0.0.1";
-			port = port || "Unknown";
-			reply.providers.forEach((prov) => {
-				let regexp = pkg.templateToRegexp(prov.template);
-				if (!found && regexp.test(resolver)) {
-					found = true;
-					name = _(prov.title);
-					let match = resolver.match(regexp);
-					if (match[1] != null) {
-						if (
-							prov.params &&
-							prov.params.option &&
-							prov.params.option.options
-						) {
-							prov.params.option.options.forEach((opt) => {
-								if (opt.value === match[1]) option = _(opt.description);
-							});
-							name += " (" + option + ")";
-						} else {
-							if (match[1] !== "") name += " (" + match[1] + ")";
+		if (reply.runtime.instances) {
+			Object.values(reply.runtime.instances).forEach((element) => {
+				var resolver;
+				var address;
+				var port;
+				var name;
+				var option;
+				var found;
+				element.command.forEach((param, index, arr) => {
+					if (param === "-r") resolver = arr[index + 1];
+					if (param === "-a") address = arr[index + 1];
+					if (param === "-p") port = arr[index + 1];
+				});
+				resolver = resolver || "Unknown";
+				address = address || "127.0.0.1";
+				port = port || "Unknown";
+				reply.providers.forEach((prov) => {
+					let regexp = pkg.templateToRegexp(prov.template);
+					if (!found && regexp.test(resolver)) {
+						found = true;
+						name = _(prov.title);
+						let match = resolver.match(regexp);
+						if (match[1] != null) {
+							if (
+								prov.params &&
+								prov.params.option &&
+								prov.params.option.options
+							) {
+								prov.params.option.options.forEach((opt) => {
+									if (opt.value === match[1]) option = _(opt.description);
+								});
+								name += " (" + option + ")";
+							} else {
+								if (match[1] !== "") name += " (" + match[1] + ")";
+							}
 						}
 					}
-				}
+				});
+				rows.push([name, address, port, forceDnsText]);
 			});
-			rows.push([name, address, port, forceDnsText]);
-		});
-
+		}
 		cbi_update_table(table, rows, E("em", _("There are no active instances.")));
 
 		return table;

--- a/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
+++ b/applications/luci-app-https-dns-proxy/po/templates/https-dns-proxy.pot
@@ -37,6 +37,18 @@ msgstr ""
 msgid "DSCP Codepoint"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.decloudus.dns.json:2
+msgid "DeCloudUs DNS"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ch.digitale-gesellschaft.dns.json:2
+msgid "Digitale Gesellschaft (CH)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/app.tiarap.doh.json:14
+msgid "Direct"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:376
 msgid "Disable"
 msgstr ""
@@ -55,6 +67,32 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:351
 msgid "Enabling %s service"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ffmuc.doh.json:2
+msgid "FFMUC DNS (DE)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/ca.cira.canadianshield.json:14
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json:14
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.cloudflare-dns.json:14
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:14
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json:14
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json:18
+msgid "Family Filter"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.cleanbrowsing.doh.json:8
+msgid "Filter"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.ahadns.blitz.json:8
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.rethinkdns.sky.json:8
+msgid "Filters"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:22
+msgid "Finland"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:102
@@ -215,6 +253,33 @@ msgstr ""
 msgid "Service Status"
 msgstr ""
 
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/one.comss.dns.json:13
+msgid "Siberia"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.blahdns.doh.json:30
+msgid "Singapore"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/org.snopyta.dns.doh.fi.json:2
+msgid "Snopyta DNS (FI)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:22
+msgid "Spain"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/co.oszx.dns.json:18
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.adguard.dns.json:18
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.cloudflare-dns.json:18
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.controld.freedns.json:18
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/com.opendns.doh.json:18
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/gr.libredns.doh.json:18
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.mullvad.doh.json:19
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.quad9.json:14
+msgid "Standard"
+msgstr ""
+
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/https-dns-proxy/status.js:300
 msgid "Start"
 msgstr ""
@@ -233,6 +298,22 @@ msgstr ""
 
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/status/include/71_https-dns-proxy.js:148
 msgid "There are no active instances."
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/app.tiarap.doh.json:2
+msgid "Tiarap Public DNS (JP)"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:18
+msgid "US/Chicago"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:34
+msgid "US/Los Angeles"
+msgstr ""
+
+#: applications/luci-app-https-dns-proxy/root/usr/share/https-dns-proxy/providers/net.ahadns.doh.json:46
+msgid "US/New York"
 msgstr ""
 
 #: applications/luci-app-https-dns-proxy/htdocs/luci-static/resources/view/https-dns-proxy/overview.js:245


### PR DESCRIPTION
This fix prevents iteration over empty/null array of instances (and the type error) if there are no instances found.

Fixes https://github.com/openwrt/packages/issues/23868

Signed-off-by: Stan Grishin <stangri@melmac.ca>
(cherry picked from commit f19647536440f93a16612d4746508f9ff7d49161)
