### PR TITLE
luci-base: force menu to regenerate after uci change

### DIFF
--- a/modules/luci-base/htdocs/luci-static/resources/uci.js
+++ b/modules/luci-base/htdocs/luci-static/resources/uci.js
@@ -919,6 +919,8 @@ return baseclass.extend(/** @lends LuCI.uci.prototype */ {
 							window.setTimeout(try_confirm, 250);
 						else
 							return Promise.reject(rv);
+					} else {
+						document.dispatchEvent(new CustomEvent('uci-applied'));
 					}
 
 					return rv;

--- a/modules/luci-base/htdocs/luci-static/resources/ui.js
+++ b/modules/luci-base/htdocs/luci-static/resources/ui.js
@@ -3516,6 +3516,10 @@ var UITable = baseclass.extend(/** @lends LuCI.ui.table.prototype */ {
 	}
 });
 
+// Because the menu can depend on uci values, we need to flush the cache
+// after uci mutations.
+document.addEventListener('uci-applied', () => UIMenu.flushCache());
+
 /**
  * @class ui
  * @memberof LuCI

--- a/modules/luci-base/ucode/dispatcher.uc
+++ b/modules/luci-base/ucode/dispatcher.uc
@@ -358,7 +358,7 @@ function build_pagetree() {
 		firstchild_ineligible: 'bool'
 	};
 
-	let files = glob('/usr/share/luci/menu.d/*.json', '/usr/lib/lua/luci/controller/*.lua', '/usr/lib/lua/luci/controller/*/*.lua');
+	let files = glob('/usr/share/luci/menu.d/*.json', '/etc/config/*', '/usr/lib/lua/luci/controller/*.lua', '/usr/lib/lua/luci/controller/*/*.lua');
 	let cachefile;
 
 	if (indexcache) {
@@ -375,13 +375,15 @@ function build_pagetree() {
 
 	for (let file in files) {
 		let data;
-
 		if (substr(file, -5) == '.json')
 			data = read_jsonfile(file);
-		else if (load_luabridge(true))
-			data = runtime.call('luci.dispatcher', 'process_lua_controller', file);
+		else if (substr(file, -4) == '.lua')
+			if (load_luabridge(true))
+				data = runtime.call('luci.dispatcher', 'process_lua_controller', file);
+			else
+				warn(`Lua controller ${file} present but no Lua runtime installed.\n`);
 		else
-			warn(`Lua controller ${file} present but no Lua runtime installed.\n`);
+			continue;
 
 		if (type(data) == 'object') {
 			for (let path, spec in data) {


### PR DESCRIPTION
Because the menu JSON can have 'depends' in them, uci changes should force the menu to regenerate.

Checklist suggested incrementing PKG_VERSION, but AFAIK for luci this is automatic.

Closes openwrt/luci#6422

<!-- 

Thank you for your contribution to the luci repository.

Please read this before creating your PR.

Review https://github.com/openwrt/luci/blob/master/CONTRIBUTING.md
especially if this is your first time to contribute to this repo.

MUST NOT:
- add a PR from your *main* branch - put it on a separate branch
- add merge commits to your PR: rebase locally and force-push

MUST:
- increment any PKG_VERSION in the affected Makefile
- set to draft if this PR depends on other PRs to e.g. openwrt/openwrt
- each commit subject line starts with '<package name>: title' 
- each commit has a valid `Signed-off-by: ` (S.O.B.) with a reachable email
	* Forgot? `git commit --amend ; git push -f`
	* Tip: use `git commit --signoff`

MAY:
- your S.O.B. *may* be a nickname
- delete the below *optional* entries that do not apply
- skip a `<package name>: title` first line subject if the commit is house-keeping or chore

-->

- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [ ] Incremented :up: any `PKG_VERSION` in the Makefile
- [x] Tested on: (arm64, 23.05, Firefox + Chrome) :white_check_mark:
- [ ] \( Preferred ) Mention: @ the original code author for feedback
- [ ] \( Preferred ) Screenshot or mp4 of changes:
- [x] \( Optional ) Closes: e.g. openwrt/luci#issue-number
- [ ] \( Optional ) Depends on: e.g. openwrt/packages#pr-number in sister repo
- [x] Description: (describe the changes proposed in this PR)
