### PR TITLE
luci-mod-status: unify of the appearance of the real-time graphic display.

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/bandwidth.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/bandwidth.js
@@ -247,7 +247,7 @@ return view.extend({
 		var svg = data[0],
 		    devs = data[1];
 
-		var v = E('div', {}, E('div'));
+		var v = E('div', { 'class': 'cbi-map', 'id': 'map' }, E('div'));
 
 		for (var i = 0; i < devs.length; i++) {
 			var ifname = devs[i].getName();
@@ -257,7 +257,7 @@ return view.extend({
 
 			var csvg = svg.cloneNode(true);
 
-			v.firstElementChild.appendChild(E('div', { 'data-tab': ifname, 'data-tab-title': ifname }, [
+			v.firstElementChild.appendChild(E('div', { 'class': 'cbi-section', 'data-tab': ifname, 'data-tab-title': ifname }, [
 				csvg,
 				E('div', { 'class': 'right' }, E('small', { 'id': 'scale' }, '-')),
 				E('br'),
@@ -283,7 +283,8 @@ return view.extend({
 						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
 						E('td', { 'class': 'td', 'id': 'tx_bw_peak' }, rate(0, true))
 					])
-				])
+				]),
+				E('div', {'class': 'cbi-section-create'})
 			]));
 
 			this.updateGraph(ifname, csvg, [ { line: 'rx', counter: true }, null, { line: 'tx', counter: true } ], function(svg, info) {

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/bandwidth.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/bandwidth.js
@@ -309,7 +309,11 @@ return view.extend({
 
 		this.pollData();
 
-		return v;
+		return  E([], [
+			E('h2', _('Bandwith')),
+			E('div', {'class': 'cbi-map-descr'}, _('This page displays the bandwidth used for all available physical interfaces.')),
+			v
+		]);
 	},
 
 	handleSaveApply: null,

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
@@ -318,79 +318,81 @@ return view.extend({
 	render: function(data) {
 		var svg = data[0];
 
-		var v = E([], [
+		var v = E('div', { 'class': 'cbi-map', 'id': 'map' }, [
 			E('h2', _('Connections')),
 			E('div', {'class': 'cbi-map-descr'}, _('This page displays the active connections via this device.')),
-			svg,
-			E('div', { 'class': 'right' }, E('small', { 'id': 'scale' }, '-')),
-			E('br'),
+			E('div', { 'class': 'cbi-section' }, [
+				svg,
+				E('div', { 'class': 'right' }, E('small', { 'id': 'scale' }, '-')),
+				E('br'),
 
-			E('table', { 'class': 'table', 'style': 'width:100%;table-layout:fixed' }, [
-				E('tr', { 'class': 'tr' }, [
-					E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid blue' }, [ _('UDP:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_udp_cur' }, [ '0' ]),
+				E('table', { 'class': 'table', 'style': 'width:100%;table-layout:fixed' }, [
+					E('tr', { 'class': 'tr' }, [
+						E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid blue' }, [ _('UDP:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_udp_cur' }, [ '0' ]),
 
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_udp_avg' }, [ '0' ]),
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_udp_avg' }, [ '0' ]),
 
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_udp_peak' }, [ '0' ])
-				]),
-				E('tr', { 'class': 'tr' }, [
-					E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid green' }, [ _('TCP:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_tcp_cur' }, [ '0' ]),
-
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_tcp_avg' }, [ '0' ]),
-
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_tcp_peak' }, [ '0' ])
-				]),
-				E('tr', { 'class': 'tr' }, [
-					E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid red' }, [ _('Other:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_otr_cur' }, [ '0' ]),
-
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_otr_avg' }, [ '0' ]),
-
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_otr_peak' }, [ '0' ])
-				])
-			]),
-
-			E('div', { 'class': 'right' }, [
-				E('button', {
-					'class': 'btn toggle-lookups',
-					'click': function(ev) {
-						if (!enableLookups) {
-							ev.currentTarget.classList.add('spinning');
-							ev.currentTarget.disabled = true;
-							enableLookups = true;
-						}
-						else {
-							ev.currentTarget.firstChild.data = _('Enable DNS lookups');
-							enableLookups = false;
-						}
-
-						this.blur();
-					}
-				}, [ enableLookups ? _('Disable DNS lookups') : _('Enable DNS lookups') ])
-			]),
-
-			E('br'),
-
-			E('div', { 'class': 'cbi-section-node' }, [
-				E('table', { 'class': 'table', 'id': 'connections' }, [
-					E('tr', { 'class': 'tr table-titles' }, [
-						E('th', { 'class': 'th col-2 hide-xs' }, [ _('Network') ]),
-						E('th', { 'class': 'th col-2' }, [ _('Protocol') ]),
-						E('th', { 'class': 'th col-7' }, [ _('Source') ]),
-						E('th', { 'class': 'th col-7' }, [ _('Destination') ]),
-						E('th', { 'class': 'th col-4' }, [ _('Transfer') ])
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_udp_peak' }, [ '0' ])
 					]),
-					E('tr', { 'class': 'tr placeholder' }, [
-						E('td', { 'class': 'td' }, [
-							E('em', {}, [ _('Collecting data...') ])
+					E('tr', { 'class': 'tr' }, [
+						E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid green' }, [ _('TCP:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_tcp_cur' }, [ '0' ]),
+
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_tcp_avg' }, [ '0' ]),
+
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_tcp_peak' }, [ '0' ])
+					]),
+					E('tr', { 'class': 'tr' }, [
+						E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid red' }, [ _('Other:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_otr_cur' }, [ '0' ]),
+
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_otr_avg' }, [ '0' ]),
+
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_otr_peak' }, [ '0' ])
+					])
+				]),
+
+				E('div', { 'class': 'right' }, [
+					E('button', {
+						'class': 'btn toggle-lookups',
+						'click': function(ev) {
+							if (!enableLookups) {
+								ev.currentTarget.classList.add('spinning');
+								ev.currentTarget.disabled = true;
+								enableLookups = true;
+							}
+							else {
+								ev.currentTarget.firstChild.data = _('Enable DNS lookups');
+								enableLookups = false;
+							}
+
+							this.blur();
+						}
+					}, [ enableLookups ? _('Disable DNS lookups') : _('Enable DNS lookups') ])
+				]),
+
+				E('br'),
+
+				E('div', { 'class': 'cbi-section-node' }, [
+					E('table', { 'class': 'table', 'id': 'connections' }, [
+						E('tr', { 'class': 'tr table-titles' }, [
+							E('th', { 'class': 'th col-2 hide-xs' }, [ _('Network') ]),
+							E('th', { 'class': 'th col-2' }, [ _('Protocol') ]),
+							E('th', { 'class': 'th col-7' }, [ _('Source') ]),
+							E('th', { 'class': 'th col-7' }, [ _('Destination') ]),
+							E('th', { 'class': 'th col-4' }, [ _('Transfer') ])
+						]),
+						E('tr', { 'class': 'tr placeholder' }, [
+							E('td', { 'class': 'td' }, [
+								E('em', {}, [ _('Collecting data...') ])
+							])
 						])
 					])
 				])

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
@@ -361,7 +361,7 @@ return view.extend({
 
 				E('div', { 'class': 'right' }, [
 					E('button', {
-						'class': 'btn toggle-lookups',
+						'class': 'btn cbi-button cbi-button-apply toggle-lookups',
 						'click': function(ev) {
 							if (!enableLookups) {
 								ev.currentTarget.classList.add('spinning');

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/connections.js
@@ -319,6 +319,8 @@ return view.extend({
 		var svg = data[0];
 
 		var v = E([], [
+			E('h2', _('Connections')),
+			E('div', {'class': 'cbi-map-descr'}, _('This page displays the active connections via this device.')),
 			svg,
 			E('div', { 'class': 'right' }, E('small', { 'id': 'scale' }, '-')),
 			E('br'),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/load.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/load.js
@@ -224,6 +224,8 @@ return view.extend({
 		var svg = data[0];
 
 		var v = E([], [
+			E('h2', _('System load')),
+			E('div', {'class': 'cbi-map-descr'}, _('Load Average is a metric that is used by Linux to keep track of system resources.')),
 			svg,
 			E('div', { 'class': 'right' }, E('small', { 'id': 'scale' }, '-')),
 			E('br'),

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/load.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/load.js
@@ -223,43 +223,45 @@ return view.extend({
 	render: function(data) {
 		var svg = data[0];
 
-		var v = E([], [
+		var v = E('div', { 'class': 'cbi-map', 'id': 'map' }, [
 			E('h2', _('System load')),
 			E('div', {'class': 'cbi-map-descr'}, _('Load Average is a metric that is used by Linux to keep track of system resources.')),
-			svg,
-			E('div', { 'class': 'right' }, E('small', { 'id': 'scale' }, '-')),
-			E('br'),
+			E('div', { 'class': 'cbi-section' }, [
+				svg,
+				E('div', { 'class': 'right' }, E('small', { 'id': 'scale' }, '-')),
+				E('br'),
 
-			E('table', { 'class': 'table', 'style': 'width:100%;table-layout:fixed' }, [
-				E('tr', { 'class': 'tr' }, [
-					E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid #f00' }, [ _('1 Minute Load:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load01_cur' }, [ '0.00' ]),
+				E('table', { 'class': 'table', 'style': 'width:100%;table-layout:fixed' }, [
+					E('tr', { 'class': 'tr' }, [
+						E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid #f00' }, [ _('1 Minute Load:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load01_cur' }, [ '0.00' ]),
 
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load01_avg' }, [ '0.00' ]),
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load01_avg' }, [ '0.00' ]),
 
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load01_peak' }, [ '0.00' ])
-				]),
-				E('tr', { 'class': 'tr' }, [
-					E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid #f60' }, [ _('5 Minute Load:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load05_cur' }, [ '0.00' ]),
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load01_peak' }, [ '0.00' ])
+					]),
+					E('tr', { 'class': 'tr' }, [
+						E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid #f60' }, [ _('5 Minute Load:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load05_cur' }, [ '0.00' ]),
 
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load05_avg' }, [ '0.00' ]),
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load05_avg' }, [ '0.00' ]),
 
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load05_peak' }, [ '0.00' ])
-				]),
-				E('tr', { 'class': 'tr' }, [
-					E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid #fa0' }, [ _('15 Minute Load:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load15_cur' }, [ '0.00' ]),
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load05_peak' }, [ '0.00' ])
+					]),
+					E('tr', { 'class': 'tr' }, [
+						E('td', { 'class': 'td right top' }, E('strong', { 'style': 'border-bottom:2px solid #fa0' }, [ _('15 Minute Load:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load15_cur' }, [ '0.00' ]),
 
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load15_avg' }, [ '0.00' ]),
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Average:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load15_avg' }, [ '0.00' ]),
 
-					E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
-					E('td', { 'class': 'td', 'id': 'lb_load15_peak' }, [ '0.00' ])
+						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
+						E('td', { 'class': 'td', 'id': 'lb_load15_peak' }, [ '0.00' ])
+					])
 				])
 			])
 		]);

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js
@@ -336,7 +336,11 @@ return view.extend({
 
 		this.pollData();
 
-		return v;
+		return E([], [
+			E('h2', _('Wireless')),
+			E('div', {'class': 'cbi-map-descr'}, _('This page displays the wireless metrics, for each available radio interfaces.')),
+			v
+		]);
 	},
 
 	handleSaveApply: null,

--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/wireless.js
@@ -241,7 +241,7 @@ return view.extend({
 		    svg2 = data[1],
 		    wifidevs = data[2];
 
-		var v = E('div', {}, E('div'));
+		var v = E('div', { 'class': 'cbi-map', 'id': 'map' }, E('div'));
 
 		for (var i = 0; i < wifidevs.length; i++) {
 			var ifname = wifidevs[i].getIfname();
@@ -252,7 +252,7 @@ return view.extend({
 			var csvg1 = svg1.cloneNode(true),
 			    csvg2 = svg2.cloneNode(true);
 
-			v.firstElementChild.appendChild(E('div', { 'data-tab': ifname, 'data-tab-title': ifname }, [
+			v.firstElementChild.appendChild(E('div', { 'class': 'cbi-section', 'data-tab': ifname, 'data-tab-title': ifname }, [
 				csvg1,
 				E('div', { 'class': 'right' }, E('small', { 'id': 'scale' }, '-')),
 				E('br'),
@@ -296,7 +296,8 @@ return view.extend({
 						E('td', { 'class': 'td right top' }, E('strong', {}, [ _('Peak:') ])),
 						E('td', { 'class': 'td', 'id': 'rate_bw_peak' }, [ '0 Mbit/s' ])
 					])
-				])
+				]),
+				E('div', {'class': 'cbi-section-create'})
 			]));
 
 			this.updateGraph(ifname, csvg1, [ null, { line: 'rssi', offset: 155 }, { line: 'noise', offset: 155 } ], function(svg, info) {

--- a/modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json
+++ b/modules/luci-mod-status/root/usr/share/luci/menu.d/luci-mod-status.json
@@ -136,7 +136,7 @@
 	},
 
 	"admin/status/realtime/bandwidth": {
-		"title": "Traffic",
+		"title": "Bandwith",
 		"order": 2,
 		"action": {
 			"type": "view",


### PR DESCRIPTION
desciption:
@jow- This shortcomings are not noticeable when using the `luci-theme-boostrap`. However, I use the `luci-theme-material `and the realtime graph pages do not look clean. The pullrequest fixes this by adding missing `cbi- `css classes

bandwith (old/new) luci-theme-material:
![old-bandwith](https://github.com/openwrt/luci/assets/553091/c93a4f38-fd60-48ec-8d22-b799976e5739)
![new-bandwith](https://github.com/openwrt/luci/assets/553091/d8420f03-0e26-4163-86ec-1b35806e48c0)

connections (old/new) luci-theme-material:
![old-connections](https://github.com/openwrt/luci/assets/553091/1a6b7f2e-4d66-4acc-9385-d86a644be0ef)
![new-connections](https://github.com/openwrt/luci/assets/553091/e2d66b7f-0331-467e-8cfd-1f56688759f6)

load (old/new) luci-theme-material:
![old-load](https://github.com/openwrt/luci/assets/553091/c96cd4f1-de4e-4ce4-9975-53ad2bf25c18)
![new-load](https://github.com/openwrt/luci/assets/553091/f30ab1bf-8eca-4a47-807b-7be2bae7ab11)

wlan (old/new) luci-theme-material:
![old-wlan](https://github.com/openwrt/luci/assets/553091/fb655543-e793-4e8a-8ffb-be9583962821)
![new-wlan](https://github.com/openwrt/luci/assets/553091/e929a6e8-23ff-452b-9b17-c13e3fd8c983)

- [x] Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:
