### PR TITLE
luci-mod-dsl: improve view for the luci-theme-material

### DIFF
--- a/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js
+++ b/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/spectrum.js
@@ -20,37 +20,50 @@ return view.extend({
 	render: function(data) {
 		window.json = data[0];
 
-		var v = E([], [
+		var v = E('div', {'class': 'cbi-map'}, [
 			E('h2', {'style': "height: 40px"}, [ _('DSL line spectrum') ]),
-			E('p', {}, _('Graphs below show Signal-to-noise ratio, Bit allocation, Quiet line noise and Channel characteristics function (HLOG) per sub-carrier.')),
-			E('div', {'style': "height: 360px; width: 1024px"},
-				E('canvas', {
-					'id': 'dbChart',
-					'height': 360,
-					'width': 1024},
-					["chart"])
-			),
-			E('div', {'style': "height: 360px; width:1024px"},
-				E('canvas', {
-					'id': 'bitsChart',
-					'height': 360,
-					'width': 1024},
-					["chart2"])
-			),
-			E('div', {'style': "height: 360px; width:1024px"},
-				E('canvas', {
-					'id': 'qlnChart',
-					'height': 360,
-					'width': 1024},
-					["chart2"])
-			),
-			E('div', {'style': "height: 360px; width:1024px"},
-				E('canvas', {
-					'id': 'hlogChart',
-					'height': 360,
-					'width': 1024},
-					["chart2"])
+			E('div', {'class': 'cbi-map-descr'}, _('The following diagrams show graphically prepared DSL characteristics that are important for evaluating the DSL connection.')),
+
+			E('div', {'class': 'cbi-section'}, [
+				E('div', {'style': "height: 360px; width: 1024px"},
+					E('canvas', {
+						'id': 'dbChart',
+						'height': 360,
+						'width': 1024},
+						["chart"])
 				),
+				E('div', {'class': 'cbi-section-descr', 'style': 'text-align:center'}, _('The graph shows the signal to noise ratio (SNR) per subcarrier in the uplink and downlink direction')),
+			]),
+			E('div', {'class': 'cbi-section'}, [
+				E('div', {'style': "height: 360px; width:1024px"},
+					E('canvas', {
+						'id': 'bitsChart',
+						'height': 360,
+						'width': 1024},
+						["chart2"])
+				),
+				E('div', {'class': 'cbi-section-descr', 'style': 'text-align:center'}, _('The graph shows th amount of bits actually allocated per subcarrier in the uplink and downlink direction')),
+			]),
+			E('div', {'class': 'cbi-section'}, [
+				E('div', {'style': "height: 360px; width:1024px"},
+					E('canvas', {
+						'id': 'qlnChart',
+						'height': 360,
+						'width': 1024},
+						["chart2"])
+				),
+				E('div', {'class': 'cbi-section-descr', 'style': 'text-align:center'}, _('The diagram shows the quiet line noise (QLN) per subcarrier in uplink and downlink direction')),
+			]),
+			E('div', {'class': 'cbi-section'}, [
+				E('div', {'style': "height: 360px; width:1024px"},
+					E('canvas', {
+						'id': 'hlogChart',
+						'height': 360,
+						'width': 1024},
+						["chart2"])
+				),
+				E('div', {'class': 'cbi-section-descr', 'style': 'text-align:center'}, _('The diagram shows the Channel Characteristics Function (HLOG) per subcarrier in uplink and downlink direction')),
+			]),
 			E('script', {'src':'/luci-static/resources/view/status/dsl/graph.js'}, {})
 		]);
 

--- a/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js
+++ b/modules/luci-mod-dsl/htdocs/luci-static/resources/view/status/dsl/stats.js
@@ -59,7 +59,7 @@ return view.extend({
 			]));
 		}
 
-		return table;
+		return E('div', { 'class': 'cbi-section' }, table);
 	},
 
 	renderTable: function(data) {
@@ -80,7 +80,7 @@ return view.extend({
 			]));
 		}
 
-		return table;
+		return E('div', { 'class': 'cbi-section' }, table);
 	},
 
 	renderContent: function(data) {


### PR DESCRIPTION
Description:
@jow- This shortcomings are not noticeable when using the luci-theme-boostrap. However, I use the luci-theme-material and the luci-mod-dsl sub pages do not look clean. The pullrequest fixes this by adding missing cbi- css classes and adds also cbi-section-descr

luci-mod-dsl(spectrum) (old/new) luci-theme-material:
![old-dsl-spec](https://github.com/openwrt/luci/assets/553091/ffb65e34-0a33-4659-9a8c-ea588af99c22)
![new-dsl-spec](https://github.com/openwrt/luci/assets/553091/2e2ba363-371e-4de0-8cd0-78017c4c5ebb)


luci-mod-dsl(statistics) (old/new) luci-theme-material:
![old-dsl-stat](https://github.com/openwrt/luci/assets/553091/06cddbe1-b028-45c6-8150-bce57daea93e)
![new-dsl-stat](https://github.com/openwrt/luci/assets/553091/cc0a21e8-ae14-433e-8fff-1694faf3335c)


- [x] This PR is not from my *main* or *master* branch :poop:, but a *separate* branch :white_check_mark:
- [x]  Each commit has a valid :black_nib: `Signed-off-by: <my@email.address>` row (via `git commit --signoff`)
- [x] Each commit and PR title has a valid :memo: `<package name>: title` first line subject for packages
- [x] Tested on: (architecture, openwrt version, browser) :white_check_mark:
- [x] \( Preferred ) Mention: @ the original code author for feedback
- [x] \( Preferred ) Screenshot or mp4 of changes:

