### PR TITLE
luci-base: ucitrack: check config trigger for affected config absent config                   

### DIFF
--- a/modules/luci-base/root/etc/init.d/ucitrack
+++ b/modules/luci-base/root/etc/init.d/ucitrack
@@ -17,8 +17,7 @@ register_init() {
 }
 
 register_trigger() {
-	local uci="$1"
-	local file="$2"
+	local file="$1"
 
 	local config init exec affects affected
 	local prev
@@ -27,10 +26,6 @@ register_trigger() {
 	json_init
 	json_load_file "${file}" >/dev/null 2>&1
 	json_get_var config 'config'
-	[ "$config" = "$uci" ] || {
-		json_set_namespace "$prev"
-		return
-	}
 	json_get_var init 'init'
 	json_get_var exec 'exec'
 	json_get_values affects 'affects'
@@ -62,19 +57,13 @@ register_trigger() {
 	done
 }
 
-check_trigger() {
+service_triggers() {
 	local config="$1"
 
 	local file
 
 	for file in /usr/share/ucitrack/*.json; do
 		[ -f "$file" ] || continue
-		register_trigger "$config" "$file"
-	done
-}
-
-service_triggers() {
-	for config in /etc/config/*; do
-		check_trigger "${config##*/}"
+		register_trigger "$file"
 	done
 }


### PR DESCRIPTION
cc @feckert 

for case config XXX where `/etc/config/XXX` is missing but ucitrack track XXX (/etc/init.d/XXX)