### PR TITLE
luci-mod-status: Lease Time Retrieval for IPv6 Interfaces

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/30_network.js
@@ -21,7 +21,7 @@ function renderbox(ifc, ipv6) {
 	    active = (dev && ifc.getProtocol() != 'none'),
 	    addrs = (ipv6 ? ifc.getIP6Addrs() : ifc.getIPAddrs()) || [],
 	    dnssrv = (ipv6 ? ifc.getDNS6Addrs() : ifc.getDNSAddrs()) || [],
-	    expires = (ipv6 ? null : ifc.getExpiry()),
+	    expires = ifc.getExpiry(),
 	    uptime = ifc.getUptime();
 
 	return E('div', { class: 'ifacebox' }, [


### PR DESCRIPTION
This pull request introduces a streamlined method for retrieving lease time information on IPv6 interfaces. While IPv4 interfaces typically have a single lease time (available in the interface `data`), IPv6 interfaces commonly feature multiple lease times due to factors like multiple delegated prefixes or multiple standard /64 subnet.

Users typically receive only one prefix delegation from their ISP, leading this PR to the retrieval of lease time from the first available prefix or IPv6 address.

To enhance usability and provide users with a more comprehensive view of lease time information, however, alternative approaches should be discussed.

Suggestions include returning an array of lease times or aggregating the various possible values using methods like finding the minimum or maximum.

These enhancements aim to improve the clarity the lease time management on IPv6 interfaces.

![immagine](https://github.com/openwrt/luci/assets/1431337/b2b32890-358b-4107-aeca-02b5ff145724)
